### PR TITLE
chore: make devcontainer services optional and add session hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,8 +8,19 @@
     "typescript-lsp@claude-plugins-official": true,
     "compound-engineering@every-marketplace": true
   },
-  "plugins": [
-    "compound-engineering"
-  ],
-  "mcpServers": {}
+  "plugins": ["compound-engineering"],
+  "mcpServers": {},
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bun x gh-setup-hooks",
+            "timeout": 120
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Make PostgreSQL and Redis availability checks optional in post-create script (warn instead of fail)
- Add SessionStart hook for gh-setup-hooks integration in Claude settings
- Conditionally display service info in welcome message based on availability

## Test plan
- [ ] Verify devcontainer builds successfully without PostgreSQL/Redis
- [ ] Verify devcontainer works normally when services are available
- [ ] Confirm session hook runs on Claude Code startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)