### PR TITLE
feat(api): implement solve and fluids API endpoints

### DIFF
--- a/apps/api/src/opensolve_pipe/main.py
+++ b/apps/api/src/opensolve_pipe/main.py
@@ -6,6 +6,8 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from .routers import fluids_router, solve_router
+
 
 @asynccontextmanager
 async def lifespan(app: FastAPI) -> AsyncGenerator[None, None]:
@@ -33,6 +35,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Include API routers
+API_V1_PREFIX = "/api/v1"
+app.include_router(fluids_router, prefix=API_V1_PREFIX)
+app.include_router(solve_router, prefix=API_V1_PREFIX)
 
 
 @app.get("/")

--- a/apps/api/src/opensolve_pipe/routers/__init__.py
+++ b/apps/api/src/opensolve_pipe/routers/__init__.py
@@ -1,1 +1,6 @@
 """API routers."""
+
+from .fluids import router as fluids_router
+from .solve import router as solve_router
+
+__all__ = ["fluids_router", "solve_router"]

--- a/apps/api/src/opensolve_pipe/routers/fluids.py
+++ b/apps/api/src/opensolve_pipe/routers/fluids.py
@@ -1,0 +1,218 @@
+"""Fluids API router for querying fluid properties."""
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, HTTPException, Query
+
+from ..models.fluids import FluidDefinition, FluidProperties, FluidType
+from ..services.data import (
+    FluidNotFoundError,
+    TemperatureOutOfRangeError,
+    list_available_fluids,
+)
+from ..services.fluids import get_fluid_properties_with_units
+
+router = APIRouter(prefix="/fluids", tags=["fluids"])
+
+
+# =============================================================================
+# Endpoints
+# =============================================================================
+
+
+@router.get(
+    "",
+    summary="List available fluids",
+    description="Get a list of all available fluid types with their properties.",
+)
+async def list_fluids() -> list[dict[str, Any]]:
+    """
+    List all available fluids.
+
+    Returns basic information about each fluid type including:
+    - id: Fluid identifier (e.g., "water", "diesel")
+    - name: Human-readable name
+    - type: "temperature_dependent" or "fixed"
+    - temperature_range_C: Valid temperature range (for temp-dependent fluids)
+    - notes: Additional information
+    """
+    return list_available_fluids()
+
+
+@router.get(
+    "/types",
+    summary="List fluid type enum values",
+    description="Get all valid fluid type enum values for use in API requests.",
+)
+async def list_fluid_types() -> list[dict[str, str]]:
+    """
+    List all fluid type enum values.
+
+    Returns the enum values that can be used in the FluidDefinition model.
+    """
+    return [{"value": ft.value, "name": ft.name} for ft in FluidType]
+
+
+@router.get(
+    "/{fluid_id}/properties",
+    summary="Get fluid properties",
+    description=(
+        "Get calculated fluid properties at a specific temperature. "
+        "Properties are returned in SI units."
+    ),
+)
+async def get_fluid_properties(
+    fluid_id: str,
+    temperature: Annotated[
+        float,
+        Query(
+            description="Operating temperature",
+            examples=[68.0, 20.0],
+        ),
+    ] = 68.0,
+    temperature_unit: Annotated[
+        str,
+        Query(
+            description="Temperature unit (F, C, or K)",
+            pattern="^[FCK]$",
+        ),
+    ] = "F",
+    concentration: Annotated[
+        float | None,
+        Query(
+            description="Glycol concentration (0-100) for glycol fluids",
+            ge=0,
+            le=100,
+        ),
+    ] = None,
+) -> FluidProperties:
+    """
+    Get fluid properties at specified temperature.
+
+    Args:
+        fluid_id: Fluid type identifier (e.g., "water", "diesel")
+        temperature: Operating temperature value
+        temperature_unit: Temperature unit - F (Fahrenheit), C (Celsius), or K (Kelvin)
+        concentration: Glycol concentration percentage (required for glycol fluids)
+
+    Returns:
+        FluidProperties with density, viscosity, vapor_pressure in SI units:
+        - density: kg/m³
+        - kinematic_viscosity: m²/s
+        - dynamic_viscosity: Pa·s
+        - vapor_pressure: Pa
+        - specific_gravity: dimensionless (relative to water at 4°C)
+
+    Raises:
+        404: Fluid type not found
+        400: Temperature out of valid range
+        501: Glycol fluids not yet implemented
+    """
+    try:
+        # Validate fluid_id is a valid enum value
+        try:
+            fluid_type = FluidType(fluid_id)
+        except ValueError:
+            valid_types = [ft.value for ft in FluidType]
+            raise HTTPException(
+                status_code=404,
+                detail={
+                    "error": "fluid_not_found",
+                    "message": f"Fluid '{fluid_id}' not found",
+                    "valid_types": valid_types,
+                },
+            ) from None
+
+        # Create fluid definition
+        fluid_def = FluidDefinition(
+            type=fluid_type,
+            temperature=temperature,
+            concentration=concentration,
+        )
+
+        # Get properties
+        return get_fluid_properties_with_units(fluid_def, temperature_unit)
+
+    except FluidNotFoundError as e:
+        raise HTTPException(
+            status_code=404,
+            detail={"error": "fluid_not_found", "message": str(e)},
+        ) from None
+    except TemperatureOutOfRangeError as e:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "temperature_out_of_range", "message": str(e)},
+        ) from None
+    except NotImplementedError as e:
+        raise HTTPException(
+            status_code=501,
+            detail={"error": "not_implemented", "message": str(e)},
+        ) from None
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "validation_error", "message": str(e)},
+        ) from None
+
+
+@router.post(
+    "/properties",
+    summary="Calculate fluid properties from definition",
+    description=(
+        "Calculate fluid properties from a complete FluidDefinition model. "
+        "Use this endpoint when you have a full fluid definition including "
+        "custom fluid properties."
+    ),
+)
+async def calculate_fluid_properties(
+    fluid_definition: FluidDefinition,
+    temperature_unit: Annotated[
+        str,
+        Query(
+            description="Temperature unit (F, C, or K)",
+            pattern="^[FCK]$",
+        ),
+    ] = "F",
+) -> FluidProperties:
+    """
+    Calculate fluid properties from a FluidDefinition model.
+
+    This endpoint is useful for:
+    - Custom fluids with user-specified properties
+    - Glycol mixtures with concentration
+    - Complex fluid definitions
+
+    Args:
+        fluid_definition: Complete fluid definition including type, temperature,
+                         and optional custom properties
+        temperature_unit: Unit of temperature in fluid_definition
+
+    Returns:
+        FluidProperties in SI units
+
+    Raises:
+        400: Invalid fluid definition or temperature out of range
+        501: Glycol fluids not yet implemented
+    """
+    try:
+        return get_fluid_properties_with_units(fluid_definition, temperature_unit)
+    except FluidNotFoundError as e:
+        raise HTTPException(
+            status_code=404,
+            detail={"error": "fluid_not_found", "message": str(e)},
+        ) from None
+    except TemperatureOutOfRangeError as e:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "temperature_out_of_range", "message": str(e)},
+        ) from None
+    except NotImplementedError as e:
+        raise HTTPException(
+            status_code=501,
+            detail={"error": "not_implemented", "message": str(e)},
+        ) from None
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "validation_error", "message": str(e)},
+        ) from None

--- a/apps/api/src/opensolve_pipe/routers/solve.py
+++ b/apps/api/src/opensolve_pipe/routers/solve.py
@@ -1,0 +1,282 @@
+"""Solve API router for hydraulic network analysis."""
+
+from datetime import datetime
+from time import perf_counter
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from ..models.fluids import FluidDefinition
+from ..models.project import Project
+from ..models.pump import FlowHeadPoint
+from ..models.results import (
+    SolvedState,
+    Warning,
+    WarningCategory,
+    WarningSeverity,
+)
+from ..services.data import FluidNotFoundError, TemperatureOutOfRangeError
+from ..services.fluids import get_fluid_properties_with_units
+from ..services.solver.simple import SimpleSolverOptions, solve_pump_pipe_system
+
+router = APIRouter(prefix="/solve", tags=["solve"])
+
+
+# =============================================================================
+# Request/Response Models
+# =============================================================================
+
+
+class SimpleSolveRequest(BaseModel):
+    """Request model for simple pump-pipe system solve."""
+
+    pump_curve: list[FlowHeadPoint] = Field(
+        ...,
+        min_length=2,
+        description="Pump performance curve points (flow in GPM, head in ft)",
+    )
+    static_head_ft: float = Field(
+        ...,
+        description="Total static head (discharge elev - suction elev) in feet",
+    )
+    pipe_length_ft: float = Field(
+        ...,
+        gt=0,
+        description="Total pipe length in feet",
+    )
+    pipe_diameter_in: float = Field(
+        ...,
+        gt=0,
+        description="Pipe inner diameter in inches",
+    )
+    pipe_roughness_in: float = Field(
+        ...,
+        gt=0,
+        description="Pipe absolute roughness in inches (e.g., 0.0018 for steel)",
+    )
+    fluid: FluidDefinition = Field(
+        default_factory=FluidDefinition,
+        description="Fluid definition (defaults to water at 68°F)",
+    )
+    total_k_factor: float = Field(
+        default=0.0,
+        ge=0,
+        description="Sum of K-factors for all fittings",
+    )
+    suction_head_ft: float = Field(
+        default=0.0,
+        description="Static suction head (positive = flooded suction)",
+    )
+    suction_losses_ft: float = Field(
+        default=0.0,
+        ge=0,
+        description="Friction losses in suction piping in feet",
+    )
+    temperature_unit: str = Field(
+        default="F",
+        pattern="^[FCK]$",
+        description="Temperature unit for fluid definition (F, C, or K)",
+    )
+
+
+class SimpleSolveResponse(BaseModel):
+    """Response model for simple pump-pipe system solve."""
+
+    converged: bool = Field(description="Whether the solver converged")
+    error: str | None = Field(
+        default=None, description="Error message if not converged"
+    )
+
+    operating_flow_gpm: float | None = Field(
+        default=None, description="Operating flow rate in GPM"
+    )
+    operating_head_ft: float | None = Field(
+        default=None, description="Operating head in feet"
+    )
+
+    velocity_fps: float | None = Field(
+        default=None, description="Flow velocity in ft/s"
+    )
+    reynolds_number: float | None = Field(default=None, description="Reynolds number")
+    friction_factor: float | None = Field(
+        default=None, description="Darcy friction factor"
+    )
+    total_head_loss_ft: float | None = Field(
+        default=None, description="Total head loss in feet"
+    )
+    static_head_ft: float | None = Field(
+        default=None, description="Static head in feet"
+    )
+    npsh_available_ft: float | None = Field(
+        default=None, description="NPSH available in feet"
+    )
+
+    system_curve: list[tuple[float, float]] = Field(
+        default_factory=list, description="System curve points (flow_gpm, head_ft)"
+    )
+    pump_curve: list[tuple[float, float]] = Field(
+        default_factory=list, description="Pump curve points (flow_gpm, head_ft)"
+    )
+
+
+# =============================================================================
+# Endpoints
+# =============================================================================
+
+
+@router.post(
+    "",
+    summary="Solve a project",
+    description=(
+        "Solve a complete hydraulic network project and return the solved state. "
+        "This endpoint currently supports simple single-path networks."
+    ),
+)
+async def solve_project(project: Project) -> SolvedState:
+    """
+    Solve a complete project.
+
+    Takes a Project model with components, fluid definition, and settings,
+    then performs hydraulic analysis to find the operating point.
+
+    Currently supports:
+    - Simple single-path networks (reservoir → pump → pipe → destination)
+    - Water and other temperature-dependent fluids
+    - Fixed-property fluids (diesel, gasoline, etc.)
+
+    Returns a SolvedState with:
+    - node_results: Pressure and energy at each node
+    - link_results: Flow, velocity, and losses in each link
+    - pump_results: Operating point and system curve data
+    - warnings: Design check results and solver messages
+
+    Note: Full network solving is not yet implemented. This endpoint
+    will return a placeholder response for complex networks.
+    """
+    start_time = perf_counter()
+
+    # For now, return a placeholder solved state
+    # Full project solving will be implemented in a future issue
+    warnings = [
+        Warning(
+            category=WarningCategory.DATA,
+            severity=WarningSeverity.INFO,
+            message=(
+                "Full project solving not yet implemented. "
+                "Use POST /api/v1/solve/simple for pump-pipe systems."
+            ),
+        )
+    ]
+
+    solve_time = perf_counter() - start_time
+
+    return SolvedState(
+        converged=False,
+        iterations=0,
+        timestamp=datetime.utcnow(),
+        solve_time_seconds=solve_time,
+        error="Full project solving not yet implemented",
+        node_results={},
+        link_results={},
+        pump_results={},
+        warnings=warnings,
+    )
+
+
+@router.post(
+    "/simple",
+    summary="Solve a simple pump-pipe system",
+    description=(
+        "Solve a simple single-path pump-pipe system to find the operating point. "
+        "This endpoint is useful for quick calculations without creating a full project."
+    ),
+    response_model=SimpleSolveResponse,
+)
+async def solve_simple(request: SimpleSolveRequest) -> SimpleSolveResponse:
+    """
+    Solve a simple pump-pipe system.
+
+    This endpoint provides a simplified interface for solving basic pump
+    selection problems without the overhead of creating a full project model.
+
+    The solver:
+    1. Generates a system curve based on static head and pipe friction
+    2. Interpolates the pump curve
+    3. Finds the intersection (operating point) using Brent's method
+    4. Calculates NPSH available
+
+    Returns:
+        SimpleSolveResponse with operating point, curves, and hydraulic details
+
+    Raises:
+        400: Invalid fluid definition or calculation error
+        501: Glycol fluids not yet implemented
+    """
+    try:
+        # Get fluid properties
+        fluid_props = get_fluid_properties_with_units(
+            request.fluid, request.temperature_unit
+        )
+
+        # Configure solver
+        options = SimpleSolverOptions(
+            max_iterations=100,
+            tolerance=0.001,
+            flow_min_gpm=0.1,
+            flow_max_gpm=max(p.flow for p in request.pump_curve) * 1.2,
+        )
+
+        # Solve
+        result = solve_pump_pipe_system(
+            pump_curve_points=request.pump_curve,
+            static_head_ft=request.static_head_ft,
+            pipe_length_ft=request.pipe_length_ft,
+            pipe_diameter_in=request.pipe_diameter_in,
+            pipe_roughness_in=request.pipe_roughness_in,
+            fluid_properties=fluid_props,
+            total_k_factor=request.total_k_factor,
+            suction_head_ft=request.suction_head_ft,
+            suction_losses_ft=request.suction_losses_ft,
+            options=options,
+        )
+
+        return SimpleSolveResponse(
+            converged=result.converged,
+            error=result.error_message,
+            operating_flow_gpm=result.operating_flow_gpm,
+            operating_head_ft=result.operating_head_ft,
+            velocity_fps=result.velocity_fps,
+            reynolds_number=result.reynolds_number,
+            friction_factor=result.friction_factor,
+            total_head_loss_ft=result.total_head_loss_ft,
+            static_head_ft=result.static_head_ft,
+            npsh_available_ft=result.npsh_available_ft,
+            system_curve=result.system_curve,
+            pump_curve=result.pump_curve,
+        )
+
+    except FluidNotFoundError as e:
+        raise HTTPException(
+            status_code=404,
+            detail={"error": "fluid_not_found", "message": str(e)},
+        ) from None
+    except TemperatureOutOfRangeError as e:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "temperature_out_of_range", "message": str(e)},
+        ) from None
+    except NotImplementedError as e:
+        raise HTTPException(
+            status_code=501,
+            detail={"error": "not_implemented", "message": str(e)},
+        ) from None
+    except ValueError as e:
+        raise HTTPException(
+            status_code=400,
+            detail={"error": "validation_error", "message": str(e)},
+        ) from None
+    except Exception as e:
+        raise HTTPException(
+            status_code=500,
+            detail={"error": "solver_error", "message": str(e)},
+        ) from None

--- a/apps/api/tests/test_routers/__init__.py
+++ b/apps/api/tests/test_routers/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for API routers."""

--- a/apps/api/tests/test_routers/test_fluids.py
+++ b/apps/api/tests/test_routers/test_fluids.py
@@ -1,0 +1,216 @@
+"""Tests for fluids API router."""
+
+import pytest
+from httpx import AsyncClient
+
+
+class TestListFluids:
+    """Tests for GET /api/v1/fluids endpoint."""
+
+    @pytest.mark.anyio
+    async def test_list_fluids_returns_list(self, client: AsyncClient) -> None:
+        """Should return a list of available fluids."""
+        response = await client.get("/api/v1/fluids")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+        assert len(data) > 0
+
+    @pytest.mark.anyio
+    async def test_list_fluids_contains_water(self, client: AsyncClient) -> None:
+        """Should include water in the list."""
+        response = await client.get("/api/v1/fluids")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        water = next((f for f in data if f["id"] == "water"), None)
+        assert water is not None
+        assert water["name"] == "Water"
+        assert water["type"] == "temperature_dependent"
+
+    @pytest.mark.anyio
+    async def test_list_fluids_structure(self, client: AsyncClient) -> None:
+        """Each fluid should have required fields."""
+        response = await client.get("/api/v1/fluids")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        for fluid in data:
+            assert "id" in fluid
+            assert "name" in fluid
+            assert "type" in fluid
+
+
+class TestListFluidTypes:
+    """Tests for GET /api/v1/fluids/types endpoint."""
+
+    @pytest.mark.anyio
+    async def test_list_fluid_types(self, client: AsyncClient) -> None:
+        """Should return all fluid type enum values."""
+        response = await client.get("/api/v1/fluids/types")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert isinstance(data, list)
+
+        # Check for expected types
+        values = [t["value"] for t in data]
+        assert "water" in values
+        assert "diesel" in values
+        assert "custom" in values
+
+    @pytest.mark.anyio
+    async def test_fluid_types_structure(self, client: AsyncClient) -> None:
+        """Each type should have value and name."""
+        response = await client.get("/api/v1/fluids/types")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        for fluid_type in data:
+            assert "value" in fluid_type
+            assert "name" in fluid_type
+
+
+class TestGetFluidProperties:
+    """Tests for GET /api/v1/fluids/{fluid_id}/properties endpoint."""
+
+    @pytest.mark.anyio
+    async def test_water_properties_fahrenheit(self, client: AsyncClient) -> None:
+        """Should return water properties at 68°F."""
+        response = await client.get(
+            "/api/v1/fluids/water/properties",
+            params={"temperature": 68.0, "temperature_unit": "F"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Verify structure
+        assert "density" in data
+        assert "kinematic_viscosity" in data
+        assert "dynamic_viscosity" in data
+        assert "vapor_pressure" in data
+        assert "specific_gravity" in data
+
+        # Water at 68°F (20°C) should have density ~998 kg/m³
+        assert 995 < data["density"] < 1000
+
+    @pytest.mark.anyio
+    async def test_water_properties_celsius(self, client: AsyncClient) -> None:
+        """Should return water properties at 20°C."""
+        response = await client.get(
+            "/api/v1/fluids/water/properties",
+            params={"temperature": 20.0, "temperature_unit": "C"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Same as 68°F
+        assert 995 < data["density"] < 1000
+
+    @pytest.mark.anyio
+    async def test_diesel_properties(self, client: AsyncClient) -> None:
+        """Should return diesel fuel properties."""
+        response = await client.get("/api/v1/fluids/diesel/properties")
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Diesel has fixed properties
+        assert 800 < data["density"] < 900  # ~850 kg/m³
+
+    @pytest.mark.anyio
+    async def test_invalid_fluid_returns_404(self, client: AsyncClient) -> None:
+        """Should return 404 for unknown fluid type."""
+        response = await client.get("/api/v1/fluids/invalid_fluid/properties")
+
+        assert response.status_code == 404
+        data = response.json()
+        assert data["detail"]["error"] == "fluid_not_found"
+
+    @pytest.mark.anyio
+    async def test_temperature_out_of_range(self, client: AsyncClient) -> None:
+        """Should return 400 for temperature outside valid range."""
+        # Water properties are only valid 0-100°C
+        response = await client.get(
+            "/api/v1/fluids/water/properties",
+            params={"temperature": 500.0, "temperature_unit": "F"},
+        )
+
+        assert response.status_code == 400
+        data = response.json()
+        assert data["detail"]["error"] == "temperature_out_of_range"
+
+    @pytest.mark.anyio
+    async def test_glycol_not_implemented(self, client: AsyncClient) -> None:
+        """Should return 501 for glycol fluids (not yet implemented)."""
+        response = await client.get(
+            "/api/v1/fluids/ethylene_glycol/properties",
+            params={"concentration": 30},
+        )
+
+        assert response.status_code == 501
+        data = response.json()
+        assert data["detail"]["error"] == "not_implemented"
+
+    @pytest.mark.anyio
+    async def test_invalid_temperature_unit(self, client: AsyncClient) -> None:
+        """Should return 422 for invalid temperature unit."""
+        response = await client.get(
+            "/api/v1/fluids/water/properties",
+            params={"temperature_unit": "X"},
+        )
+
+        assert response.status_code == 422  # Validation error
+
+
+class TestCalculateFluidProperties:
+    """Tests for POST /api/v1/fluids/properties endpoint."""
+
+    @pytest.mark.anyio
+    async def test_calculate_water_properties(self, client: AsyncClient) -> None:
+        """Should calculate water properties from definition."""
+        response = await client.post(
+            "/api/v1/fluids/properties",
+            json={"type": "water", "temperature": 68.0},
+            params={"temperature_unit": "F"},
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert 995 < data["density"] < 1000
+
+    @pytest.mark.anyio
+    async def test_calculate_custom_fluid_properties(self, client: AsyncClient) -> None:
+        """Should return custom fluid properties as-is."""
+        response = await client.post(
+            "/api/v1/fluids/properties",
+            json={
+                "type": "custom",
+                "temperature": 68.0,
+                "custom_density": 850.0,
+                "custom_kinematic_viscosity": 3e-6,
+                "custom_vapor_pressure": 1000.0,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["density"] == 850.0
+        assert data["kinematic_viscosity"] == 3e-6
+        assert data["vapor_pressure"] == 1000.0
+
+    @pytest.mark.anyio
+    async def test_custom_fluid_missing_properties(self, client: AsyncClient) -> None:
+        """Should return 422 for custom fluid without required properties."""
+        response = await client.post(
+            "/api/v1/fluids/properties",
+            json={"type": "custom", "temperature": 68.0},
+        )
+
+        assert response.status_code == 422  # Validation error

--- a/apps/api/tests/test_routers/test_solve.py
+++ b/apps/api/tests/test_routers/test_solve.py
@@ -1,0 +1,259 @@
+"""Tests for solve API router."""
+
+import pytest
+from httpx import AsyncClient
+
+
+class TestSolveProject:
+    """Tests for POST /api/v1/solve endpoint."""
+
+    @pytest.mark.anyio
+    async def test_solve_empty_project(self, client: AsyncClient) -> None:
+        """Should return placeholder response for empty project."""
+        response = await client.post(
+            "/api/v1/solve",
+            json={
+                "metadata": {"name": "Test Project"},
+                "settings": {},
+                "fluid": {"type": "water", "temperature": 68.0},
+                "components": [],
+                "pump_library": [],
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Full solving not implemented yet
+        assert data["converged"] is False
+        assert "not yet implemented" in data["error"]
+        assert len(data["warnings"]) > 0
+
+
+class TestSolveSimple:
+    """Tests for POST /api/v1/solve/simple endpoint."""
+
+    @pytest.fixture
+    def simple_pump_system(self) -> dict:
+        """Basic pump-pipe system for testing."""
+        return {
+            "pump_curve": [
+                {"flow": 0, "head": 100},
+                {"flow": 50, "head": 95},
+                {"flow": 100, "head": 85},
+                {"flow": 150, "head": 70},
+                {"flow": 200, "head": 50},
+            ],
+            "static_head_ft": 30.0,
+            "pipe_length_ft": 500.0,
+            "pipe_diameter_in": 4.0,
+            "pipe_roughness_in": 0.0018,
+            "fluid": {"type": "water", "temperature": 68.0},
+            "total_k_factor": 10.0,
+        }
+
+    @pytest.mark.anyio
+    async def test_solve_simple_converges(
+        self, client: AsyncClient, simple_pump_system: dict
+    ) -> None:
+        """Should solve a basic pump-pipe system."""
+        response = await client.post("/api/v1/solve/simple", json=simple_pump_system)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["converged"] is True
+        assert data["error"] is None
+        assert data["operating_flow_gpm"] is not None
+        assert data["operating_head_ft"] is not None
+
+    @pytest.mark.anyio
+    async def test_solve_simple_returns_curves(
+        self, client: AsyncClient, simple_pump_system: dict
+    ) -> None:
+        """Should return system and pump curves for visualization."""
+        response = await client.post("/api/v1/solve/simple", json=simple_pump_system)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert len(data["system_curve"]) > 0
+        assert len(data["pump_curve"]) > 0
+
+        # Check curve point structure
+        for point in data["system_curve"]:
+            assert len(point) == 2  # (flow, head)
+            assert isinstance(point[0], int | float)
+            assert isinstance(point[1], int | float)
+
+    @pytest.mark.anyio
+    async def test_solve_simple_returns_hydraulics(
+        self, client: AsyncClient, simple_pump_system: dict
+    ) -> None:
+        """Should return detailed hydraulic parameters."""
+        response = await client.post("/api/v1/solve/simple", json=simple_pump_system)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["velocity_fps"] is not None
+        assert data["reynolds_number"] is not None
+        assert data["friction_factor"] is not None
+        assert data["total_head_loss_ft"] is not None
+        assert data["npsh_available_ft"] is not None
+
+    @pytest.mark.anyio
+    async def test_solve_simple_reasonable_operating_point(
+        self, client: AsyncClient, simple_pump_system: dict
+    ) -> None:
+        """Operating point should be within reasonable bounds."""
+        response = await client.post("/api/v1/solve/simple", json=simple_pump_system)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Flow should be positive and in a reasonable range
+        assert 0 < data["operating_flow_gpm"] < 500
+
+        # Head should be above static head
+        assert data["operating_head_ft"] > simple_pump_system["static_head_ft"]
+
+    @pytest.mark.anyio
+    async def test_solve_simple_pump_cannot_overcome_head(
+        self, client: AsyncClient
+    ) -> None:
+        """Should fail when pump can't overcome static head."""
+        response = await client.post(
+            "/api/v1/solve/simple",
+            json={
+                "pump_curve": [
+                    {"flow": 0, "head": 50},
+                    {"flow": 100, "head": 30},
+                ],
+                "static_head_ft": 100.0,  # Higher than pump shutoff
+                "pipe_length_ft": 100.0,
+                "pipe_diameter_in": 4.0,
+                "pipe_roughness_in": 0.0018,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["converged"] is False
+        assert "cannot overcome" in data["error"].lower()
+
+    @pytest.mark.anyio
+    async def test_solve_simple_insufficient_pump_curve_points(
+        self, client: AsyncClient
+    ) -> None:
+        """Should return 422 for pump curve with < 2 points."""
+        response = await client.post(
+            "/api/v1/solve/simple",
+            json={
+                "pump_curve": [{"flow": 0, "head": 100}],  # Only 1 point
+                "static_head_ft": 30.0,
+                "pipe_length_ft": 500.0,
+                "pipe_diameter_in": 4.0,
+                "pipe_roughness_in": 0.0018,
+            },
+        )
+
+        assert response.status_code == 422
+
+    @pytest.mark.anyio
+    async def test_solve_simple_with_different_temperature(
+        self, client: AsyncClient, simple_pump_system: dict
+    ) -> None:
+        """Should solve with water at different temperature."""
+        simple_pump_system["fluid"]["temperature"] = 140.0  # Hot water
+        response = await client.post("/api/v1/solve/simple", json=simple_pump_system)
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["converged"] is True
+        # Higher temperature = lower viscosity = slightly higher flow
+        assert data["operating_flow_gpm"] is not None
+
+    @pytest.mark.anyio
+    async def test_solve_simple_with_celsius(
+        self, client: AsyncClient, simple_pump_system: dict
+    ) -> None:
+        """Should accept temperature in Celsius."""
+        simple_pump_system["fluid"]["temperature"] = 20.0
+        simple_pump_system["temperature_unit"] = "C"
+
+        response = await client.post("/api/v1/solve/simple", json=simple_pump_system)
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["converged"] is True
+
+    @pytest.mark.anyio
+    async def test_solve_simple_with_diesel(self, client: AsyncClient) -> None:
+        """Should solve with diesel fuel."""
+        response = await client.post(
+            "/api/v1/solve/simple",
+            json={
+                "pump_curve": [
+                    {"flow": 0, "head": 100},
+                    {"flow": 100, "head": 70},
+                ],
+                "static_head_ft": 20.0,
+                "pipe_length_ft": 200.0,
+                "pipe_diameter_in": 3.0,
+                "pipe_roughness_in": 0.0018,
+                "fluid": {"type": "diesel", "temperature": 68.0},
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["converged"] is True
+
+    @pytest.mark.anyio
+    async def test_solve_simple_invalid_diameter(self, client: AsyncClient) -> None:
+        """Should return 422 for invalid pipe diameter."""
+        response = await client.post(
+            "/api/v1/solve/simple",
+            json={
+                "pump_curve": [
+                    {"flow": 0, "head": 100},
+                    {"flow": 100, "head": 70},
+                ],
+                "static_head_ft": 20.0,
+                "pipe_length_ft": 200.0,
+                "pipe_diameter_in": -1.0,  # Invalid
+                "pipe_roughness_in": 0.0018,
+            },
+        )
+
+        assert response.status_code == 422
+
+
+class TestHealthCheck:
+    """Tests for health check endpoint."""
+
+    @pytest.mark.anyio
+    async def test_health_check(self, client: AsyncClient) -> None:
+        """Health endpoint should return healthy."""
+        response = await client.get("/health")
+
+        assert response.status_code == 200
+        assert response.json()["status"] == "healthy"
+
+
+class TestRootEndpoint:
+    """Tests for root endpoint."""
+
+    @pytest.mark.anyio
+    async def test_root_endpoint(self, client: AsyncClient) -> None:
+        """Root endpoint should return API info."""
+        response = await client.get("/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["name"] == "OpenSolve Pipe API"
+        assert "version" in data
+        assert "docs" in data


### PR DESCRIPTION
## Summary

- Implement FastAPI routers for hydraulic network solving and fluid property queries
- Add comprehensive API tests with 28 test cases using httpx

## Endpoints Added

### Fluids Router (`/api/v1/fluids`)
- `GET /fluids` - List all available fluids with properties
- `GET /fluids/types` - List fluid type enum values
- `GET /fluids/{fluid_id}/properties` - Get fluid properties at temperature
- `POST /fluids/properties` - Calculate properties from FluidDefinition model

### Solve Router (`/api/v1/solve`)
- `POST /solve` - Solve complete project (placeholder for full network solving)
- `POST /solve/simple` - Solve simple pump-pipe systems with operating point

## Features

- Full request validation with Pydantic models
- Proper error handling (400, 404, 501, 500) with structured error responses
- OpenAPI documentation with descriptions and examples
- System and pump curve data for visualization
- NPSH available calculation
- Support for multiple temperature units (F, C, K)

## Test plan

- [x] All 28 API tests pass
- [x] Ruff linting passes
- [x] MyPy type checking passes
- [x] Pre-commit hooks pass

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)