### PR TITLE
feat(web): implement frontend skeleton with routing and components

### DIFF
--- a/apps/web/src/lib/components/Header.svelte
+++ b/apps/web/src/lib/components/Header.svelte
@@ -1,0 +1,77 @@
+<script lang="ts">
+	type ViewMode = 'panel' | 'results';
+
+	interface Props {
+		projectName?: string;
+		viewMode?: ViewMode;
+		onViewModeChange?: (mode: ViewMode) => void;
+		showViewSwitcher?: boolean;
+	}
+
+	let {
+		projectName = 'OpenSolve Pipe',
+		viewMode = 'panel',
+		onViewModeChange,
+		showViewSwitcher = false
+	}: Props = $props();
+
+	function handleViewModeChange(mode: ViewMode) {
+		if (onViewModeChange) {
+			onViewModeChange(mode);
+		}
+	}
+</script>
+
+<header class="sticky top-0 z-50 border-b border-gray-200 bg-white shadow-sm">
+	<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+		<div class="flex h-14 items-center justify-between">
+			<!-- Left: Logo and Project Name -->
+			<div class="flex items-center gap-3">
+				<a href="/" class="flex items-center gap-2 text-gray-900 hover:text-gray-700">
+					<svg
+						class="h-6 w-6 text-blue-600"
+						fill="none"
+						stroke="currentColor"
+						viewBox="0 0 24 24"
+					>
+						<path
+							stroke-linecap="round"
+							stroke-linejoin="round"
+							stroke-width="2"
+							d="M19.428 15.428a2 2 0 00-1.022-.547l-2.387-.477a6 6 0 00-3.86.517l-.318.158a6 6 0 01-3.86.517L6.05 15.21a2 2 0 00-1.806.547M8 4h8l-1 1v5.172a2 2 0 00.586 1.414l5 5c1.26 1.26.367 3.414-1.415 3.414H4.828c-1.782 0-2.674-2.154-1.414-3.414l5-5A2 2 0 009 10.172V5L8 4z"
+						/>
+					</svg>
+					<span class="text-lg font-semibold">{projectName}</span>
+				</a>
+			</div>
+
+			<!-- Right: View Mode Switcher (if enabled) -->
+			{#if showViewSwitcher}
+				<div class="flex items-center">
+					<div class="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+						<button
+							type="button"
+							class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors {viewMode ===
+							'panel'
+								? 'bg-white text-gray-900 shadow'
+								: 'text-gray-600 hover:text-gray-900'}"
+							onclick={() => handleViewModeChange('panel')}
+						>
+							Panel
+						</button>
+						<button
+							type="button"
+							class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors {viewMode ===
+							'results'
+								? 'bg-white text-gray-900 shadow'
+								: 'text-gray-600 hover:text-gray-900'}"
+							onclick={() => handleViewModeChange('results')}
+						>
+							Results
+						</button>
+					</div>
+				</div>
+			{/if}
+		</div>
+	</div>
+</header>

--- a/apps/web/src/lib/index.ts
+++ b/apps/web/src/lib/index.ts
@@ -1,0 +1,5 @@
+// Components
+export { default as Header } from './components/Header.svelte';
+
+// Types
+export type ViewMode = 'panel' | 'results';

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -1,21 +1,190 @@
 <script lang="ts">
-  let title = 'OpenSolve Pipe';
+	import Header from '$lib/components/Header.svelte';
 </script>
 
-<main class="min-h-screen bg-gray-50">
-  <header class="border-b border-gray-200 bg-white px-4 py-3">
-    <h1 class="text-xl font-semibold text-gray-900">{title}</h1>
-  </header>
+<svelte:head>
+	<title>OpenSolve Pipe - Free Hydraulic Network Analysis</title>
+	<meta
+		name="description"
+		content="Free, browser-based hydraulic network design tool for steady-state pipe flow analysis. No installation required."
+	/>
+</svelte:head>
 
-  <div class="mx-auto max-w-4xl p-4">
-    <div class="rounded-lg bg-white p-6 shadow">
-      <h2 class="mb-4 text-lg font-medium text-gray-800">Welcome to OpenSolve Pipe</h2>
-      <p class="text-gray-600">
-        A free, browser-based hydraulic network design tool for steady-state pipe flow analysis.
-      </p>
-      <p class="mt-4 text-sm text-gray-500">
-        Project setup complete. Ready for Phase 1 development.
-      </p>
-    </div>
-  </div>
-</main>
+<div class="flex min-h-screen flex-col bg-gray-50">
+	<Header />
+
+	<main class="flex-1">
+		<!-- Hero Section -->
+		<div class="bg-gradient-to-br from-blue-600 to-blue-800 py-16 text-white">
+			<div class="mx-auto max-w-4xl px-4 text-center">
+				<h1 class="mb-4 text-4xl font-bold sm:text-5xl">Hydraulic Network Analysis</h1>
+				<p class="mb-8 text-lg text-blue-100 sm:text-xl">
+					Free, browser-based tool for steady-state pipe flow calculations. No installation, no
+					account required.
+				</p>
+				<div class="flex flex-col justify-center gap-4 sm:flex-row">
+					<a
+						href="/p/"
+						class="inline-flex items-center justify-center rounded-lg bg-white px-6 py-3 font-semibold text-blue-700 shadow-lg transition hover:bg-gray-100"
+					>
+						<svg class="mr-2 h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+							/>
+						</svg>
+						New Project
+					</a>
+					<button
+						type="button"
+						class="inline-flex items-center justify-center rounded-lg border-2 border-white/30 px-6 py-3 font-semibold text-white transition hover:bg-white/10"
+					>
+						<svg class="mr-2 h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+							/>
+						</svg>
+						Open Example
+					</button>
+				</div>
+			</div>
+		</div>
+
+		<!-- Features Section -->
+		<div class="mx-auto max-w-4xl px-4 py-12">
+			<h2 class="mb-8 text-center text-2xl font-bold text-gray-900">Key Features</h2>
+
+			<div class="grid gap-6 md:grid-cols-3">
+				<!-- Feature 1 -->
+				<div class="rounded-lg bg-white p-6 shadow">
+					<div class="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-blue-100">
+						<svg class="h-6 w-6 text-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M13 10V3L4 14h7v7l9-11h-7z"
+							/>
+						</svg>
+					</div>
+					<h3 class="mb-2 text-lg font-semibold text-gray-900">Instant Results</h3>
+					<p class="text-gray-600">
+						Solve pump-pipe systems in seconds. Find operating points, velocities, and head losses.
+					</p>
+				</div>
+
+				<!-- Feature 2 -->
+				<div class="rounded-lg bg-white p-6 shadow">
+					<div class="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+						<svg
+							class="h-6 w-6 text-green-600"
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.368 2.684 3 3 0 00-5.368-2.684z"
+							/>
+						</svg>
+					</div>
+					<h3 class="mb-2 text-lg font-semibold text-gray-900">Shareable via URL</h3>
+					<p class="text-gray-600">
+						Projects are encoded in the URL. Share designs with a simple link, no account needed.
+					</p>
+				</div>
+
+				<!-- Feature 3 -->
+				<div class="rounded-lg bg-white p-6 shadow">
+					<div class="mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-purple-100">
+						<svg
+							class="h-6 w-6 text-purple-600"
+							fill="none"
+							stroke="currentColor"
+							viewBox="0 0 24 24"
+						>
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M12 18h.01M8 21h8a2 2 0 002-2V5a2 2 0 00-2-2H8a2 2 0 00-2 2v14a2 2 0 002 2z"
+							/>
+						</svg>
+					</div>
+					<h3 class="mb-2 text-lg font-semibold text-gray-900">Mobile-Friendly</h3>
+					<p class="text-gray-600">
+						Panel navigator works great on mobile. Do hydraulic calcs in the field.
+					</p>
+				</div>
+			</div>
+		</div>
+
+		<!-- Quick Start Section -->
+		<div class="bg-gray-100 py-12">
+			<div class="mx-auto max-w-4xl px-4">
+				<h2 class="mb-8 text-center text-2xl font-bold text-gray-900">How It Works</h2>
+
+				<div class="grid gap-4 md:grid-cols-4">
+					<div class="text-center">
+						<div
+							class="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 font-bold text-white"
+						>
+							1
+						</div>
+						<h3 class="font-semibold text-gray-900">Define System</h3>
+						<p class="text-sm text-gray-600">Add components like pipes, pumps, and fittings</p>
+					</div>
+					<div class="text-center">
+						<div
+							class="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 font-bold text-white"
+						>
+							2
+						</div>
+						<h3 class="font-semibold text-gray-900">Select Fluid</h3>
+						<p class="text-sm text-gray-600">Water, glycols, fuels, or custom fluids</p>
+					</div>
+					<div class="text-center">
+						<div
+							class="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 font-bold text-white"
+						>
+							3
+						</div>
+						<h3 class="font-semibold text-gray-900">Solve</h3>
+						<p class="text-sm text-gray-600">Calculate flows, pressures, and head losses</p>
+					</div>
+					<div class="text-center">
+						<div
+							class="mx-auto mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 font-bold text-white"
+						>
+							4
+						</div>
+						<h3 class="font-semibold text-gray-900">Share</h3>
+						<p class="text-sm text-gray-600">Copy URL to share your design with others</p>
+					</div>
+				</div>
+			</div>
+		</div>
+	</main>
+
+	<!-- Footer -->
+	<footer class="border-t border-gray-200 bg-white py-6">
+		<div class="mx-auto max-w-4xl px-4 text-center text-sm text-gray-500">
+			<p>
+				OpenSolve Pipe - Free hydraulic analysis tool.
+				<a
+					href="https://github.com/ccirone2/opensolve-pipe"
+					class="text-blue-600 hover:underline"
+				>
+					View on GitHub
+				</a>
+			</p>
+		</div>
+	</footer>
+</div>

--- a/apps/web/src/routes/p/[...encoded]/+page.svelte
+++ b/apps/web/src/routes/p/[...encoded]/+page.svelte
@@ -1,0 +1,91 @@
+<script lang="ts">
+	import Header from '$lib/components/Header.svelte';
+	import { page } from '$app/stores';
+
+	type ViewMode = 'panel' | 'results';
+
+	// Get encoded project data from URL
+	let encoded = $derived($page.params.encoded || '');
+
+	// View mode state
+	let viewMode: ViewMode = $state('panel');
+
+	// Placeholder project name - will be decoded from URL in future
+	let projectName = $derived(encoded ? 'Project View' : 'New Project');
+
+	function handleViewModeChange(mode: ViewMode) {
+		viewMode = mode;
+	}
+</script>
+
+<svelte:head>
+	<title>{projectName} - OpenSolve Pipe</title>
+</svelte:head>
+
+<div class="flex min-h-screen flex-col bg-gray-50">
+	<Header
+		{projectName}
+		{viewMode}
+		onViewModeChange={handleViewModeChange}
+		showViewSwitcher={true}
+	/>
+
+	<main class="flex-1">
+		{#if viewMode === 'panel'}
+			<!-- Panel Navigator View -->
+			<div class="mx-auto max-w-4xl p-4">
+				<div class="rounded-lg bg-white p-6 shadow">
+					<h2 class="mb-4 text-lg font-medium text-gray-800">Panel Navigator</h2>
+					<p class="text-gray-600">
+						Walk through your hydraulic system element by element. Edit properties, configure
+						piping, and navigate the component chain.
+					</p>
+
+					{#if encoded}
+						<div class="mt-4 rounded-md bg-blue-50 p-4">
+							<p class="text-sm text-blue-700">
+								<strong>Encoded Project Data:</strong>
+								<code class="break-all text-xs">{encoded.slice(0, 100)}...</code>
+							</p>
+						</div>
+					{:else}
+						<div class="mt-4 rounded-md bg-yellow-50 p-4">
+							<p class="text-sm text-yellow-700">
+								No project data found. Create a new project or load an existing one.
+							</p>
+						</div>
+					{/if}
+
+					<!-- Placeholder for Panel Navigator -->
+					<div
+						class="mt-6 flex h-64 items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-gray-50"
+					>
+						<p class="text-gray-500">Panel Navigator will be implemented here</p>
+					</div>
+				</div>
+			</div>
+		{:else}
+			<!-- Results View -->
+			<div class="mx-auto max-w-4xl p-4">
+				<div class="rounded-lg bg-white p-6 shadow">
+					<h2 class="mb-4 text-lg font-medium text-gray-800">Results</h2>
+					<p class="text-gray-600">
+						View solved state with pressures, flows, velocities, and system curves.
+					</p>
+
+					<!-- Placeholder for Results Display -->
+					<div
+						class="mt-6 flex h-64 items-center justify-center rounded-lg border-2 border-dashed border-gray-300 bg-gray-50"
+					>
+						<p class="text-gray-500">Results display will be implemented here</p>
+					</div>
+				</div>
+			</div>
+		{/if}
+	</main>
+
+	<!-- Mobile-friendly bottom navigation hint -->
+	<div class="border-t border-gray-200 bg-white p-4 text-center text-sm text-gray-500 md:hidden">
+		Swipe left/right to navigate components
+	</div>
+</div>


### PR DESCRIPTION
## Summary

- Implement SvelteKit frontend structure with routing and basic UI components
- Create landing page with hero section, features overview, and how-it-works guide
- Add project viewer route for encoded project URLs

## Routes Added

- `/` - Landing page with marketing content
- `/p/[...encoded]` - Project viewer route for URL-encoded projects

## Components Added

- `Header.svelte` - Sticky header with logo, project name, and view mode switcher
- View mode toggle (panel / results) for switching between editing and results views

## Features

- Mobile-first responsive design using Tailwind CSS v4
- Svelte 5 with TypeScript
- SVG icons for visual polish
- Placeholder sections for Panel Navigator and Results display
- Footer with GitHub link

## Test plan

- [x] svelte-check passes with no errors
- [x] ESLint passes
- [x] Pre-commit hooks pass
- [ ] Manual testing: Landing page renders correctly
- [ ] Manual testing: Project route loads with view mode switcher
- [ ] Manual testing: Responsive design works on mobile (< 768px)

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)