### PR TITLE
feat(web): add TypeScript interfaces matching backend models

### DIFF
--- a/apps/web/src/lib/models/components.ts
+++ b/apps/web/src/lib/models/components.ts
@@ -1,0 +1,302 @@
+/**
+ * Component models for hydraulic network elements.
+ * Mirrors: apps/api/src/opensolve_pipe/models/components.py
+ */
+
+import type { PipingSegment } from './piping';
+
+/** Types of network components. */
+export type ComponentType =
+	| 'reservoir'
+	| 'tank'
+	| 'junction'
+	| 'pump'
+	| 'valve'
+	| 'heat_exchanger'
+	| 'strainer'
+	| 'orifice'
+	| 'sprinkler';
+
+/** Display names for component types. */
+export const COMPONENT_TYPE_LABELS: Record<ComponentType, string> = {
+	reservoir: 'Reservoir',
+	tank: 'Tank',
+	junction: 'Junction',
+	pump: 'Pump',
+	valve: 'Valve',
+	heat_exchanger: 'Heat Exchanger',
+	strainer: 'Strainer',
+	orifice: 'Orifice',
+	sprinkler: 'Sprinkler'
+};
+
+/** Component categories for UI grouping. */
+export const COMPONENT_CATEGORIES = {
+	Nodes: ['reservoir', 'tank', 'junction', 'sprinkler', 'orifice'] as ComponentType[],
+	Links: ['pump', 'valve', 'heat_exchanger', 'strainer'] as ComponentType[]
+};
+
+/** Types of control valves. */
+export type ValveType =
+	| 'gate'
+	| 'ball'
+	| 'butterfly'
+	| 'globe'
+	| 'check'
+	| 'stop_check'
+	| 'prv'
+	| 'psv'
+	| 'fcv'
+	| 'tcv'
+	| 'relief';
+
+/** Display names for valve types. */
+export const VALVE_TYPE_LABELS: Record<ValveType, string> = {
+	gate: 'Gate Valve',
+	ball: 'Ball Valve',
+	butterfly: 'Butterfly Valve',
+	globe: 'Globe Valve',
+	check: 'Check Valve',
+	stop_check: 'Stop Check Valve',
+	prv: 'Pressure Reducing Valve (PRV)',
+	psv: 'Pressure Sustaining Valve (PSV)',
+	fcv: 'Flow Control Valve (FCV)',
+	tcv: 'Throttle Control Valve (TCV)',
+	relief: 'Relief Valve'
+};
+
+/** Valve types that require a setpoint. */
+export const CONTROL_VALVE_TYPES: ValveType[] = ['prv', 'psv', 'fcv', 'tcv'];
+
+/** Connection to a downstream component. */
+export interface Connection {
+	/** ID of the downstream component. */
+	target_component_id: string;
+	/** Piping segment to downstream component. */
+	piping?: PipingSegment;
+}
+
+/** Base properties common to all components. */
+interface BaseComponentProps {
+	/** Unique component identifier. */
+	id: string;
+	/** Display name. */
+	name: string;
+	/** Component elevation (can be negative). */
+	elevation: number;
+	/** Piping from upstream component. */
+	upstream_piping?: PipingSegment;
+	/** Connections to downstream components. */
+	downstream_connections: Connection[];
+}
+
+/** Fixed-head water source (infinite capacity). */
+export interface Reservoir extends BaseComponentProps {
+	type: 'reservoir';
+	/** Water level above reservoir bottom. */
+	water_level: number;
+}
+
+/** Variable-level storage tank. */
+export interface Tank extends BaseComponentProps {
+	type: 'tank';
+	/** Tank diameter. */
+	diameter: number;
+	/** Minimum water level. Default: 0 */
+	min_level: number;
+	/** Maximum water level. */
+	max_level: number;
+	/** Initial water level. */
+	initial_level: number;
+}
+
+/** Connection point, optionally with demand. */
+export interface Junction extends BaseComponentProps {
+	type: 'junction';
+	/** Flow demand withdrawn at this junction. Default: 0 */
+	demand: number;
+}
+
+/** Pump component that references a pump curve from the project library. */
+export interface PumpComponent extends BaseComponentProps {
+	type: 'pump';
+	/** Reference to pump curve in project pump_library. */
+	curve_id: string;
+	/** Fraction of rated speed (1.0 = 100%). Default: 1.0 */
+	speed: number;
+	/** Pump status. Default: 'on' */
+	status: 'on' | 'off';
+}
+
+/** Valve component for flow/pressure control. */
+export interface ValveComponent extends BaseComponentProps {
+	type: 'valve';
+	/** Type of valve. */
+	valve_type: ValveType;
+	/** Setpoint for control valves (pressure or flow depending on type). */
+	setpoint?: number;
+	/** Valve position for throttling (0=closed, 1=open). */
+	position?: number;
+	/** Valve Cv coefficient (optional, for detailed model). */
+	cv?: number;
+}
+
+/** Heat exchanger with known pressure drop. */
+export interface HeatExchanger extends BaseComponentProps {
+	type: 'heat_exchanger';
+	/** Pressure drop at design flow (in project units). */
+	pressure_drop: number;
+	/** Design flow rate (in project units). */
+	design_flow: number;
+}
+
+/** Strainer with known pressure drop or K-factor. */
+export interface Strainer extends BaseComponentProps {
+	type: 'strainer';
+	/** K-factor for head loss calculation. */
+	k_factor?: number;
+	/** Fixed pressure drop (alternative to K-factor). */
+	pressure_drop?: number;
+	/** Design flow for fixed pressure drop. */
+	design_flow?: number;
+}
+
+/** Orifice plate for flow measurement or restriction. */
+export interface Orifice extends BaseComponentProps {
+	type: 'orifice';
+	/** Orifice diameter. */
+	orifice_diameter: number;
+	/** Discharge coefficient (Cd). Default: 0.62 */
+	discharge_coefficient: number;
+}
+
+/** Sprinkler head with known K-factor. */
+export interface Sprinkler extends BaseComponentProps {
+	type: 'sprinkler';
+	/** Sprinkler K-factor (flow = K * sqrt(pressure)). */
+	k_factor: number;
+	/** Design operating pressure. */
+	design_pressure?: number;
+}
+
+/** Discriminated union for all component types. */
+export type Component =
+	| Reservoir
+	| Tank
+	| Junction
+	| PumpComponent
+	| ValveComponent
+	| HeatExchanger
+	| Strainer
+	| Orifice
+	| Sprinkler;
+
+// Type guards for component discrimination
+
+/** Type guard for Reservoir. */
+export function isReservoir(component: Component): component is Reservoir {
+	return component.type === 'reservoir';
+}
+
+/** Type guard for Tank. */
+export function isTank(component: Component): component is Tank {
+	return component.type === 'tank';
+}
+
+/** Type guard for Junction. */
+export function isJunction(component: Component): component is Junction {
+	return component.type === 'junction';
+}
+
+/** Type guard for PumpComponent. */
+export function isPump(component: Component): component is PumpComponent {
+	return component.type === 'pump';
+}
+
+/** Type guard for ValveComponent. */
+export function isValve(component: Component): component is ValveComponent {
+	return component.type === 'valve';
+}
+
+/** Type guard for HeatExchanger. */
+export function isHeatExchanger(component: Component): component is HeatExchanger {
+	return component.type === 'heat_exchanger';
+}
+
+/** Type guard for Strainer. */
+export function isStrainer(component: Component): component is Strainer {
+	return component.type === 'strainer';
+}
+
+/** Type guard for Orifice. */
+export function isOrifice(component: Component): component is Orifice {
+	return component.type === 'orifice';
+}
+
+/** Type guard for Sprinkler. */
+export function isSprinkler(component: Component): component is Sprinkler {
+	return component.type === 'sprinkler';
+}
+
+/** Check if a component is a node type (has pressure state). */
+export function isNodeComponent(component: Component): boolean {
+	return COMPONENT_CATEGORIES.Nodes.includes(component.type);
+}
+
+/** Check if a component is a link type (connects nodes). */
+export function isLinkComponent(component: Component): boolean {
+	return COMPONENT_CATEGORIES.Links.includes(component.type);
+}
+
+/** Get total head for a reservoir. */
+export function getReservoirTotalHead(reservoir: Reservoir): number {
+	return reservoir.elevation + reservoir.water_level;
+}
+
+/** Generate a unique component ID. */
+export function generateComponentId(): string {
+	return `comp_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+}
+
+/** Create a default component of the specified type. */
+export function createDefaultComponent(type: ComponentType, id?: string): Component {
+	const baseProps: BaseComponentProps = {
+		id: id ?? generateComponentId(),
+		name: `New ${COMPONENT_TYPE_LABELS[type]}`,
+		elevation: 0,
+		downstream_connections: []
+	};
+
+	switch (type) {
+		case 'reservoir':
+			return { ...baseProps, type: 'reservoir', water_level: 0 };
+		case 'tank':
+			return {
+				...baseProps,
+				type: 'tank',
+				diameter: 10,
+				min_level: 0,
+				max_level: 20,
+				initial_level: 10
+			};
+		case 'junction':
+			return { ...baseProps, type: 'junction', demand: 0 };
+		case 'pump':
+			return { ...baseProps, type: 'pump', curve_id: '', speed: 1.0, status: 'on' };
+		case 'valve':
+			return { ...baseProps, type: 'valve', valve_type: 'gate' };
+		case 'heat_exchanger':
+			return { ...baseProps, type: 'heat_exchanger', pressure_drop: 5, design_flow: 100 };
+		case 'strainer':
+			return { ...baseProps, type: 'strainer', k_factor: 2.5 };
+		case 'orifice':
+			return {
+				...baseProps,
+				type: 'orifice',
+				orifice_diameter: 2,
+				discharge_coefficient: 0.62
+			};
+		case 'sprinkler':
+			return { ...baseProps, type: 'sprinkler', k_factor: 5.6 };
+	}
+}

--- a/apps/web/src/lib/models/fluids.ts
+++ b/apps/web/src/lib/models/fluids.ts
@@ -1,0 +1,99 @@
+/**
+ * Fluid definition and properties models.
+ * Mirrors: apps/api/src/opensolve_pipe/models/fluids.py
+ */
+
+/** Available fluid types. */
+export type FluidType =
+	| 'water'
+	| 'ethylene_glycol'
+	| 'propylene_glycol'
+	| 'diesel'
+	| 'gasoline'
+	| 'kerosene'
+	| 'hydraulic_oil'
+	| 'custom';
+
+/** Display names for fluid types. */
+export const FLUID_TYPE_LABELS: Record<FluidType, string> = {
+	water: 'Water',
+	ethylene_glycol: 'Ethylene Glycol',
+	propylene_glycol: 'Propylene Glycol',
+	diesel: 'Diesel',
+	gasoline: 'Gasoline',
+	kerosene: 'Kerosene',
+	hydraulic_oil: 'Hydraulic Oil',
+	custom: 'Custom Fluid'
+};
+
+/** Fluid types that require concentration. */
+export const GLYCOL_FLUID_TYPES: FluidType[] = ['ethylene_glycol', 'propylene_glycol'];
+
+/** Definition of the working fluid. */
+export interface FluidDefinition {
+	/** Type of fluid. Default: 'water' */
+	type: FluidType;
+	/** Operating temperature in project units (F or C). Default: 68.0 */
+	temperature: number;
+	/** Concentration percentage for glycol mixtures (0-100). */
+	concentration?: number;
+	/** Custom fluid density (kg/m³ for SI calculation). Required if type is 'custom'. */
+	custom_density?: number;
+	/** Custom fluid kinematic viscosity (m²/s for SI calculation). Required if type is 'custom'. */
+	custom_kinematic_viscosity?: number;
+	/** Custom fluid vapor pressure (Pa for SI calculation). Required if type is 'custom'. */
+	custom_vapor_pressure?: number;
+}
+
+/** Calculated fluid properties at operating conditions (always in SI units). */
+export interface FluidProperties {
+	/** Density in kg/m³. */
+	density: number;
+	/** Kinematic viscosity in m²/s. */
+	kinematic_viscosity: number;
+	/** Dynamic viscosity in Pa·s. */
+	dynamic_viscosity: number;
+	/** Vapor pressure in Pa. */
+	vapor_pressure: number;
+	/** Specific gravity relative to water at 4°C. Default: 1.0 */
+	specific_gravity: number;
+}
+
+/** Default fluid definition (water at 68°F). */
+export const DEFAULT_FLUID_DEFINITION: FluidDefinition = {
+	type: 'water',
+	temperature: 68.0
+};
+
+/** Check if a fluid type requires concentration. */
+export function requiresConcentration(type: FluidType): boolean {
+	return GLYCOL_FLUID_TYPES.includes(type);
+}
+
+/** Check if a fluid type is custom (requires all custom properties). */
+export function isCustomFluid(type: FluidType): boolean {
+	return type === 'custom';
+}
+
+/** Validate fluid definition. Returns error message or null if valid. */
+export function validateFluidDefinition(fluid: FluidDefinition): string | null {
+	if (requiresConcentration(fluid.type) && fluid.concentration === undefined) {
+		return `${FLUID_TYPE_LABELS[fluid.type]} requires concentration to be specified`;
+	}
+
+	if (isCustomFluid(fluid.type)) {
+		const missing: string[] = [];
+		if (fluid.custom_density === undefined) missing.push('custom_density');
+		if (fluid.custom_kinematic_viscosity === undefined) missing.push('custom_kinematic_viscosity');
+		if (fluid.custom_vapor_pressure === undefined) missing.push('custom_vapor_pressure');
+		if (missing.length > 0) {
+			return `Custom fluid requires: ${missing.join(', ')}`;
+		}
+	}
+
+	if (fluid.concentration !== undefined && (fluid.concentration < 0 || fluid.concentration > 100)) {
+		return 'Concentration must be between 0 and 100';
+	}
+
+	return null;
+}

--- a/apps/web/src/lib/models/index.ts
+++ b/apps/web/src/lib/models/index.ts
@@ -1,0 +1,136 @@
+/**
+ * OpenSolve Pipe TypeScript Models
+ *
+ * This module exports all TypeScript interfaces and types that mirror
+ * the backend Pydantic models in apps/api/src/opensolve_pipe/models/
+ */
+
+// Units
+export type { UnitSystem, UnitPreferences, SolverOptions } from './units';
+export {
+	SYSTEM_PRESETS,
+	createUnitPreferencesFromSystem,
+	DEFAULT_UNIT_PREFERENCES,
+	DEFAULT_SOLVER_OPTIONS
+} from './units';
+
+// Fluids
+export type { FluidType, FluidDefinition, FluidProperties } from './fluids';
+export {
+	FLUID_TYPE_LABELS,
+	GLYCOL_FLUID_TYPES,
+	DEFAULT_FLUID_DEFINITION,
+	requiresConcentration,
+	isCustomFluid,
+	validateFluidDefinition
+} from './fluids';
+
+// Piping
+export type {
+	PipeMaterial,
+	PipeSchedule,
+	FittingType,
+	PipeDefinition,
+	Fitting,
+	PipingSegment
+} from './piping';
+export {
+	PIPE_MATERIAL_LABELS,
+	PIPE_SCHEDULE_LABELS,
+	FITTING_TYPE_LABELS,
+	FITTING_CATEGORIES,
+	createDefaultPipeDefinition,
+	createDefaultFitting,
+	createDefaultPipingSegment
+} from './piping';
+
+// Pump
+export type {
+	FlowHeadPoint,
+	FlowEfficiencyPoint,
+	NPSHRPoint,
+	PumpCurve
+} from './pump';
+export {
+	validatePumpCurve,
+	createDefaultPumpCurve,
+	interpolatePumpHead
+} from './pump';
+
+// Components
+export type {
+	ComponentType,
+	ValveType,
+	Connection,
+	Reservoir,
+	Tank,
+	Junction,
+	PumpComponent,
+	ValveComponent,
+	HeatExchanger,
+	Strainer,
+	Orifice,
+	Sprinkler,
+	Component
+} from './components';
+export {
+	COMPONENT_TYPE_LABELS,
+	COMPONENT_CATEGORIES,
+	VALVE_TYPE_LABELS,
+	CONTROL_VALVE_TYPES,
+	isReservoir,
+	isTank,
+	isJunction,
+	isPump,
+	isValve,
+	isHeatExchanger,
+	isStrainer,
+	isOrifice,
+	isSprinkler,
+	isNodeComponent,
+	isLinkComponent,
+	getReservoirTotalHead,
+	generateComponentId,
+	createDefaultComponent
+} from './components';
+
+// Results
+export type {
+	FlowRegime,
+	NodeResult,
+	LinkResult,
+	PumpResult,
+	WarningCategory,
+	WarningSeverity,
+	Warning,
+	SolvedState
+} from './results';
+export {
+	FLOW_REGIME_LABELS,
+	WARNING_CATEGORY_LABELS,
+	isSolveSuccessful,
+	getWarningsBySeverity,
+	getWarningsForComponent,
+	hasErrors,
+	getNodeResult,
+	getLinkResult,
+	getPumpResult
+} from './results';
+
+// Project
+export type { ProjectMetadata, ProjectSettings, Project } from './project';
+export {
+	generateProjectId,
+	createDefaultMetadata,
+	createDefaultSettings,
+	createNewProject,
+	getComponentById,
+	getPumpCurveById,
+	validateComponentIds,
+	validateConnectionReferences,
+	validatePumpCurveIds,
+	validatePumpCurveReferences,
+	validateProject,
+	touchProject,
+	branchProject
+} from './project';

--- a/apps/web/src/lib/models/piping.ts
+++ b/apps/web/src/lib/models/piping.ts
@@ -1,0 +1,185 @@
+/**
+ * Piping, pipe definition, and fitting models.
+ * Mirrors: apps/api/src/opensolve_pipe/models/piping.py
+ */
+
+/** Available pipe materials. */
+export type PipeMaterial =
+	| 'carbon_steel'
+	| 'stainless_steel'
+	| 'pvc'
+	| 'cpvc'
+	| 'hdpe'
+	| 'ductile_iron'
+	| 'cast_iron'
+	| 'copper'
+	| 'grp';
+
+/** Display names for pipe materials. */
+export const PIPE_MATERIAL_LABELS: Record<PipeMaterial, string> = {
+	carbon_steel: 'Carbon Steel',
+	stainless_steel: 'Stainless Steel',
+	pvc: 'PVC',
+	cpvc: 'CPVC',
+	hdpe: 'HDPE',
+	ductile_iron: 'Ductile Iron',
+	cast_iron: 'Cast Iron',
+	copper: 'Copper',
+	grp: 'GRP (Fiberglass)'
+};
+
+/** Common pipe schedules. */
+export type PipeSchedule = '5' | '10' | '40' | '80' | '160' | 'STD' | 'XS' | 'XXS';
+
+/** Display names for pipe schedules. */
+export const PIPE_SCHEDULE_LABELS: Record<PipeSchedule, string> = {
+	'5': 'Schedule 5',
+	'10': 'Schedule 10',
+	'40': 'Schedule 40',
+	'80': 'Schedule 80',
+	'160': 'Schedule 160',
+	STD: 'Standard',
+	XS: 'Extra Strong',
+	XXS: 'Double Extra Strong'
+};
+
+/** Types of pipe fittings. */
+export type FittingType =
+	// Elbows
+	| 'elbow_90_lr'
+	| 'elbow_90_sr'
+	| 'elbow_45'
+	// Tees
+	| 'tee_through'
+	| 'tee_branch'
+	// Reducers
+	| 'reducer_concentric'
+	| 'reducer_eccentric'
+	| 'expander_concentric'
+	| 'expander_eccentric'
+	// Valves (as fittings - for K-factor calculation)
+	| 'gate_valve'
+	| 'ball_valve'
+	| 'butterfly_valve'
+	| 'globe_valve'
+	| 'check_valve_swing'
+	| 'check_valve_lift'
+	// Entrances and exits
+	| 'entrance_sharp'
+	| 'entrance_rounded'
+	| 'entrance_projecting'
+	| 'exit'
+	// Other
+	| 'strainer_basket'
+	| 'strainer_y'
+	| 'union'
+	| 'coupling';
+
+/** Display names for fitting types. */
+export const FITTING_TYPE_LABELS: Record<FittingType, string> = {
+	elbow_90_lr: '90° Elbow (Long Radius)',
+	elbow_90_sr: '90° Elbow (Short Radius)',
+	elbow_45: '45° Elbow',
+	tee_through: 'Tee (Through Run)',
+	tee_branch: 'Tee (Into Branch)',
+	reducer_concentric: 'Concentric Reducer',
+	reducer_eccentric: 'Eccentric Reducer',
+	expander_concentric: 'Concentric Expander',
+	expander_eccentric: 'Eccentric Expander',
+	gate_valve: 'Gate Valve',
+	ball_valve: 'Ball Valve',
+	butterfly_valve: 'Butterfly Valve',
+	globe_valve: 'Globe Valve',
+	check_valve_swing: 'Check Valve (Swing)',
+	check_valve_lift: 'Check Valve (Lift)',
+	entrance_sharp: 'Sharp Entrance',
+	entrance_rounded: 'Rounded Entrance',
+	entrance_projecting: 'Projecting Entrance',
+	exit: 'Pipe Exit',
+	strainer_basket: 'Basket Strainer',
+	strainer_y: 'Y-Strainer',
+	union: 'Union',
+	coupling: 'Coupling'
+};
+
+/** Fitting categories for grouping in UI. */
+export const FITTING_CATEGORIES: Record<string, FittingType[]> = {
+	Elbows: ['elbow_90_lr', 'elbow_90_sr', 'elbow_45'],
+	Tees: ['tee_through', 'tee_branch'],
+	'Reducers/Expanders': [
+		'reducer_concentric',
+		'reducer_eccentric',
+		'expander_concentric',
+		'expander_eccentric'
+	],
+	Valves: [
+		'gate_valve',
+		'ball_valve',
+		'butterfly_valve',
+		'globe_valve',
+		'check_valve_swing',
+		'check_valve_lift'
+	],
+	'Entrances/Exits': ['entrance_sharp', 'entrance_rounded', 'entrance_projecting', 'exit'],
+	Other: ['strainer_basket', 'strainer_y', 'union', 'coupling']
+};
+
+/** Definition of a pipe segment. */
+export interface PipeDefinition {
+	/** Pipe material. */
+	material: PipeMaterial;
+	/** Nominal pipe diameter in project units (typically inches). */
+	nominal_diameter: number;
+	/** Pipe schedule or class. Default: "40" */
+	schedule: string;
+	/** Pipe length in project units. */
+	length: number;
+	/** Override calculated roughness (absolute roughness in project units). */
+	roughness_override?: number;
+}
+
+/** A fitting or valve in a piping segment. */
+export interface Fitting {
+	/** Type of fitting. */
+	type: FittingType;
+	/** Number of this fitting. Default: 1 */
+	quantity: number;
+	/** User-specified K-factor override. */
+	k_factor_override?: number;
+	/** Optional description or notes. */
+	description?: string;
+}
+
+/** A piping segment consisting of a pipe and zero or more fittings. */
+export interface PipingSegment {
+	/** The pipe definition. */
+	pipe: PipeDefinition;
+	/** List of fittings in this segment. */
+	fittings: Fitting[];
+}
+
+/** Create a default pipe definition. */
+export function createDefaultPipeDefinition(): PipeDefinition {
+	return {
+		material: 'carbon_steel',
+		nominal_diameter: 4,
+		schedule: '40',
+		length: 100
+	};
+}
+
+/** Create a default fitting. */
+export function createDefaultFitting(type: FittingType): Fitting {
+	return {
+		type,
+		quantity: 1
+	};
+}
+
+/** Create a default piping segment. */
+export function createDefaultPipingSegment(): PipingSegment {
+	return {
+		pipe: createDefaultPipeDefinition(),
+		fittings: []
+	};
+}

--- a/apps/web/src/lib/models/project.ts
+++ b/apps/web/src/lib/models/project.ts
@@ -1,0 +1,201 @@
+/**
+ * Project container and metadata models.
+ * Mirrors: apps/api/src/opensolve_pipe/models/project.py
+ */
+
+import type { Component } from './components';
+import type { FluidDefinition } from './fluids';
+import { DEFAULT_FLUID_DEFINITION } from './fluids';
+import type { PumpCurve } from './pump';
+import type { SolvedState } from './results';
+import type { SolverOptions, UnitPreferences } from './units';
+import { DEFAULT_SOLVER_OPTIONS, DEFAULT_UNIT_PREFERENCES } from './units';
+
+/** Project metadata and versioning info. */
+export interface ProjectMetadata {
+	/** Project name. Default: "Untitled Project" */
+	name: string;
+	/** Project description. */
+	description?: string;
+	/** Project author. */
+	author?: string;
+	/** Creation timestamp (ISO 8601 string). */
+	created: string;
+	/** Last modification timestamp (ISO 8601 string). */
+	modified: string;
+	/** Project version. Default: "1" */
+	version: string;
+	/** Parent version for branching. */
+	parent_version?: string;
+}
+
+/** Project-level settings. */
+export interface ProjectSettings {
+	/** Unit preferences. */
+	units: UnitPreferences;
+	/** Enabled design checks. */
+	enabled_checks: string[];
+	/** Solver configuration. */
+	solver_options: SolverOptions;
+}
+
+/** Top-level project container. */
+export interface Project {
+	/** Unique project identifier. */
+	id: string;
+	/** Project metadata. */
+	metadata: ProjectMetadata;
+	/** Project settings. */
+	settings: ProjectSettings;
+	/** Working fluid definition. */
+	fluid: FluidDefinition;
+	/** Network components. */
+	components: Component[];
+	/** Available pump curves. */
+	pump_library: PumpCurve[];
+	/** Solved state (if network has been solved). */
+	results?: SolvedState;
+}
+
+/** Generate a unique project ID. */
+export function generateProjectId(): string {
+	return `proj_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
+}
+
+/** Create default project metadata. */
+export function createDefaultMetadata(): ProjectMetadata {
+	const now = new Date().toISOString();
+	return {
+		name: 'Untitled Project',
+		created: now,
+		modified: now,
+		version: '1'
+	};
+}
+
+/** Create default project settings. */
+export function createDefaultSettings(): ProjectSettings {
+	return {
+		units: { ...DEFAULT_UNIT_PREFERENCES },
+		enabled_checks: [],
+		solver_options: { ...DEFAULT_SOLVER_OPTIONS }
+	};
+}
+
+/** Create a new empty project. */
+export function createNewProject(): Project {
+	return {
+		id: generateProjectId(),
+		metadata: createDefaultMetadata(),
+		settings: createDefaultSettings(),
+		fluid: { ...DEFAULT_FLUID_DEFINITION },
+		components: [],
+		pump_library: []
+	};
+}
+
+/** Get a component by ID from a project. */
+export function getComponentById(project: Project, componentId: string): Component | undefined {
+	return project.components.find((c) => c.id === componentId);
+}
+
+/** Get a pump curve by ID from a project. */
+export function getPumpCurveById(project: Project, curveId: string): PumpCurve | undefined {
+	return project.pump_library.find((c) => c.id === curveId);
+}
+
+/** Check if all component IDs are unique. */
+export function validateComponentIds(project: Project): string | null {
+	const ids = project.components.map((c) => c.id);
+	const uniqueIds = new Set(ids);
+	if (ids.length !== uniqueIds.size) {
+		const duplicates = ids.filter((id, index) => ids.indexOf(id) !== index);
+		return `Duplicate component IDs: ${[...new Set(duplicates)].join(', ')}`;
+	}
+	return null;
+}
+
+/** Check if all downstream connection references are valid. */
+export function validateConnectionReferences(project: Project): string | null {
+	const componentIds = new Set(project.components.map((c) => c.id));
+	for (const component of project.components) {
+		for (const conn of component.downstream_connections) {
+			if (!componentIds.has(conn.target_component_id)) {
+				return `Component '${component.id}' references unknown target: '${conn.target_component_id}'`;
+			}
+		}
+	}
+	return null;
+}
+
+/** Check if all pump curve IDs are unique. */
+export function validatePumpCurveIds(project: Project): string | null {
+	const ids = project.pump_library.map((c) => c.id);
+	const uniqueIds = new Set(ids);
+	if (ids.length !== uniqueIds.size) {
+		const duplicates = ids.filter((id, index) => ids.indexOf(id) !== index);
+		return `Duplicate pump curve IDs: ${[...new Set(duplicates)].join(', ')}`;
+	}
+	return null;
+}
+
+/** Check if all pump components reference valid pump curves. */
+export function validatePumpCurveReferences(project: Project): string | null {
+	const curveIds = new Set(project.pump_library.map((c) => c.id));
+	for (const component of project.components) {
+		if (component.type === 'pump' && !curveIds.has(component.curve_id)) {
+			return `Pump '${component.id}' references unknown curve: '${component.curve_id}'`;
+		}
+	}
+	return null;
+}
+
+/** Validate entire project. Returns array of error messages (empty if valid). */
+export function validateProject(project: Project): string[] {
+	const errors: string[] = [];
+
+	const componentIdError = validateComponentIds(project);
+	if (componentIdError) errors.push(componentIdError);
+
+	const connectionError = validateConnectionReferences(project);
+	if (connectionError) errors.push(connectionError);
+
+	const curveIdError = validatePumpCurveIds(project);
+	if (curveIdError) errors.push(curveIdError);
+
+	const curveRefError = validatePumpCurveReferences(project);
+	if (curveRefError) errors.push(curveRefError);
+
+	return errors;
+}
+
+/** Update project modified timestamp. */
+export function touchProject(project: Project): Project {
+	return {
+		...project,
+		metadata: {
+			...project.metadata,
+			modified: new Date().toISOString()
+		}
+	};
+}
+
+/** Create a new version (branch) of a project. */
+export function branchProject(project: Project, newName?: string): Project {
+	const now = new Date().toISOString();
+	const newVersion = String(parseInt(project.metadata.version) + 1);
+
+	return {
+		...project,
+		id: generateProjectId(),
+		metadata: {
+			...project.metadata,
+			name: newName ?? `${project.metadata.name} (copy)`,
+			created: now,
+			modified: now,
+			version: newVersion,
+			parent_version: project.metadata.version
+		},
+		results: undefined // Clear results for new version
+	};
+}

--- a/apps/web/src/lib/models/pump.ts
+++ b/apps/web/src/lib/models/pump.ts
@@ -1,0 +1,123 @@
+/**
+ * Pump curve and pump-related models.
+ * Mirrors: apps/api/src/opensolve_pipe/models/pump.py
+ */
+
+/** A single point on a pump curve (flow vs head). */
+export interface FlowHeadPoint {
+	/** Flow rate in project units. */
+	flow: number;
+	/** Head in project units. */
+	head: number;
+}
+
+/** A single point on an efficiency curve (flow vs efficiency). */
+export interface FlowEfficiencyPoint {
+	/** Flow rate in project units. */
+	flow: number;
+	/** Pump efficiency as fraction (0-1). */
+	efficiency: number;
+}
+
+/** A single point on NPSH required curve. */
+export interface NPSHRPoint {
+	/** Flow rate in project units. */
+	flow: number;
+	/** NPSH required in project units. */
+	npsh_required: number;
+}
+
+/** Pump performance curve definition. */
+export interface PumpCurve {
+	/** Unique identifier for this pump curve. */
+	id: string;
+	/** Display name for this pump curve. */
+	name: string;
+	/** Pump manufacturer. */
+	manufacturer?: string;
+	/** Pump model number. */
+	model?: string;
+	/** Rated speed in RPM. */
+	rated_speed?: number;
+	/** Impeller diameter in project units. */
+	impeller_diameter?: number;
+	/** Pump curve points (minimum 2). */
+	points: FlowHeadPoint[];
+	/** Optional efficiency curve. */
+	efficiency_curve?: FlowEfficiencyPoint[];
+	/** Optional NPSH required curve. */
+	npshr_curve?: NPSHRPoint[];
+}
+
+/** Validate pump curve. Returns error message or null if valid. */
+export function validatePumpCurve(curve: PumpCurve): string | null {
+	if (curve.points.length < 2) {
+		return 'Pump curve must have at least 2 points';
+	}
+
+	// Check if points are sorted by flow
+	for (let i = 1; i < curve.points.length; i++) {
+		if (curve.points[i].flow < curve.points[i - 1].flow) {
+			return 'Pump curve points must be sorted by ascending flow';
+		}
+	}
+
+	// Check for negative values
+	for (const point of curve.points) {
+		if (point.flow < 0) {
+			return 'Flow values cannot be negative';
+		}
+		if (point.head < 0) {
+			return 'Head values cannot be negative';
+		}
+	}
+
+	// Validate efficiency curve if present
+	if (curve.efficiency_curve) {
+		for (const point of curve.efficiency_curve) {
+			if (point.efficiency < 0 || point.efficiency > 1) {
+				return 'Efficiency values must be between 0 and 1';
+			}
+		}
+	}
+
+	return null;
+}
+
+/** Create a default pump curve with sample points. */
+export function createDefaultPumpCurve(id: string): PumpCurve {
+	return {
+		id,
+		name: 'New Pump Curve',
+		points: [
+			{ flow: 0, head: 100 },
+			{ flow: 50, head: 95 },
+			{ flow: 100, head: 85 },
+			{ flow: 150, head: 70 },
+			{ flow: 200, head: 50 }
+		]
+	};
+}
+
+/** Interpolate head at a given flow using the pump curve. */
+export function interpolatePumpHead(curve: PumpCurve, flow: number): number | null {
+	if (curve.points.length < 2) return null;
+
+	const points = curve.points;
+
+	// Handle flow outside curve range
+	if (flow <= points[0].flow) return points[0].head;
+	if (flow >= points[points.length - 1].flow) return points[points.length - 1].head;
+
+	// Find surrounding points and interpolate
+	for (let i = 1; i < points.length; i++) {
+		if (flow <= points[i].flow) {
+			const p0 = points[i - 1];
+			const p1 = points[i];
+			const t = (flow - p0.flow) / (p1.flow - p0.flow);
+			return p0.head + t * (p1.head - p0.head);
+		}
+	}
+
+	return null;
+}

--- a/apps/web/src/lib/models/results.ts
+++ b/apps/web/src/lib/models/results.ts
@@ -1,0 +1,165 @@
+/**
+ * Solved state and result models.
+ * Mirrors: apps/api/src/opensolve_pipe/models/results.py
+ */
+
+import type { FlowHeadPoint } from './pump';
+
+/** Flow regime classification. */
+export type FlowRegime = 'laminar' | 'transitional' | 'turbulent';
+
+/** Display labels for flow regimes. */
+export const FLOW_REGIME_LABELS: Record<FlowRegime, string> = {
+	laminar: 'Laminar',
+	transitional: 'Transitional',
+	turbulent: 'Turbulent'
+};
+
+/** Solved state for a node (reservoir, tank, junction, etc.). */
+export interface NodeResult {
+	/** ID of the component. */
+	component_id: string;
+	/** Static pressure in project units. */
+	pressure: number;
+	/** Dynamic pressure (velocity head) in project units. Default: 0 */
+	dynamic_pressure: number;
+	/** Total pressure in project units. */
+	total_pressure: number;
+	/** Hydraulic Grade Line elevation. */
+	hgl: number;
+	/** Energy Grade Line elevation. */
+	egl: number;
+}
+
+/** Solved state for a link (pipe segment between components). */
+export interface LinkResult {
+	/** ID of the upstream component. */
+	component_id: string;
+	/** ID of the upstream node. */
+	upstream_node_id: string;
+	/** ID of the downstream node. */
+	downstream_node_id: string;
+	/** Flow rate in project units (positive = forward). */
+	flow: number;
+	/** Flow velocity in project units. */
+	velocity: number;
+	/** Head loss across the link in project units. */
+	head_loss: number;
+	/** Head loss due to pipe friction. Default: 0 */
+	friction_head_loss: number;
+	/** Head loss due to fittings (minor losses). Default: 0 */
+	minor_head_loss: number;
+	/** Reynolds number. */
+	reynolds_number: number;
+	/** Darcy friction factor. */
+	friction_factor: number;
+	/** Flow regime classification. */
+	regime: FlowRegime;
+}
+
+/** Solved state for a pump at its operating point. */
+export interface PumpResult {
+	/** ID of the pump component. */
+	component_id: string;
+	/** Operating flow rate in project units. */
+	operating_flow: number;
+	/** Operating head in project units. */
+	operating_head: number;
+	/** NPSH available at pump suction. */
+	npsh_available: number;
+	/** NPSH margin (NPSHa - NPSHr) if NPSHR curve provided. */
+	npsh_margin?: number;
+	/** Pump efficiency at operating point (if efficiency curve provided). */
+	efficiency?: number;
+	/** Power consumption in kW (if efficiency provided). */
+	power?: number;
+	/** System curve points. */
+	system_curve: FlowHeadPoint[];
+}
+
+/** Categories of warnings and design check results. */
+export type WarningCategory = 'velocity' | 'pressure' | 'npsh' | 'convergence' | 'topology' | 'data';
+
+/** Display labels for warning categories. */
+export const WARNING_CATEGORY_LABELS: Record<WarningCategory, string> = {
+	velocity: 'Velocity',
+	pressure: 'Pressure',
+	npsh: 'NPSH',
+	convergence: 'Convergence',
+	topology: 'Topology',
+	data: 'Data'
+};
+
+/** Warning severity levels. */
+export type WarningSeverity = 'info' | 'warning' | 'error';
+
+/** Design check warning or solver message. */
+export interface Warning {
+	/** Warning category. */
+	category: WarningCategory;
+	/** Warning severity. */
+	severity: WarningSeverity;
+	/** Related component ID (if applicable). */
+	component_id?: string;
+	/** Human-readable warning message. */
+	message: string;
+	/** Additional details. */
+	details?: Record<string, unknown>;
+}
+
+/** Complete solved state of the network. */
+export interface SolvedState {
+	/** Whether the solver converged. */
+	converged: boolean;
+	/** Number of solver iterations. */
+	iterations: number;
+	/** Solve timestamp (ISO 8601 string). */
+	timestamp: string;
+	/** Time taken to solve in seconds. */
+	solve_time_seconds?: number;
+	/** Error message if not converged. */
+	error?: string;
+	/** Results keyed by node component ID. */
+	node_results: Record<string, NodeResult>;
+	/** Results keyed by upstream component ID. */
+	link_results: Record<string, LinkResult>;
+	/** Results keyed by pump component ID. */
+	pump_results: Record<string, PumpResult>;
+	/** Warnings and design check results. */
+	warnings: Warning[];
+}
+
+/** Check if the solver converged successfully. */
+export function isSolveSuccessful(state: SolvedState): boolean {
+	return state.converged && !state.error;
+}
+
+/** Get warnings filtered by severity. */
+export function getWarningsBySeverity(state: SolvedState, severity: WarningSeverity): Warning[] {
+	return state.warnings.filter((w) => w.severity === severity);
+}
+
+/** Get warnings for a specific component. */
+export function getWarningsForComponent(state: SolvedState, componentId: string): Warning[] {
+	return state.warnings.filter((w) => w.component_id === componentId);
+}
+
+/** Check if there are any errors in warnings. */
+export function hasErrors(state: SolvedState): boolean {
+	return state.warnings.some((w) => w.severity === 'error');
+}
+
+/** Get the result for a node component. */
+export function getNodeResult(state: SolvedState, componentId: string): NodeResult | undefined {
+	return state.node_results[componentId];
+}
+
+/** Get the result for a link component. */
+export function getLinkResult(state: SolvedState, componentId: string): LinkResult | undefined {
+	return state.link_results[componentId];
+}
+
+/** Get the result for a pump component. */
+export function getPumpResult(state: SolvedState, componentId: string): PumpResult | undefined {
+	return state.pump_results[componentId];
+}

--- a/apps/web/src/lib/models/units.ts
+++ b/apps/web/src/lib/models/units.ts
@@ -1,0 +1,99 @@
+/**
+ * Unit system and solver configuration models.
+ * Mirrors: apps/api/src/opensolve_pipe/models/units.py
+ */
+
+/** Available unit systems. */
+export type UnitSystem = 'imperial' | 'si' | 'mixed';
+
+/** User's preferred units for display and input. */
+export interface UnitPreferences {
+	system: UnitSystem;
+	length: string;
+	diameter: string;
+	pressure: string;
+	head: string;
+	flow: string;
+	velocity: string;
+	temperature: string;
+	viscosity_kinematic: string;
+	viscosity_dynamic: string;
+	density: string;
+}
+
+/** Preset unit configurations for each system. */
+export const SYSTEM_PRESETS: Record<UnitSystem, Omit<UnitPreferences, 'system'>> = {
+	imperial: {
+		length: 'ft',
+		diameter: 'in',
+		pressure: 'psi',
+		head: 'ft_head',
+		flow: 'GPM',
+		velocity: 'ft/s',
+		temperature: 'F',
+		viscosity_kinematic: 'ft2/s',
+		viscosity_dynamic: 'cP',
+		density: 'lb/ft3'
+	},
+	si: {
+		length: 'm',
+		diameter: 'mm',
+		pressure: 'kPa',
+		head: 'm_head',
+		flow: 'L/s',
+		velocity: 'm/s',
+		temperature: 'C',
+		viscosity_kinematic: 'm2/s',
+		viscosity_dynamic: 'Pa.s',
+		density: 'kg/m3'
+	},
+	mixed: {
+		length: 'm',
+		diameter: 'in',
+		pressure: 'bar',
+		head: 'm_head',
+		flow: 'm3/h',
+		velocity: 'm/s',
+		temperature: 'C',
+		viscosity_kinematic: 'cSt',
+		viscosity_dynamic: 'cP',
+		density: 'kg/m3'
+	}
+};
+
+/** Create UnitPreferences from a preset system. */
+export function createUnitPreferencesFromSystem(system: UnitSystem): UnitPreferences {
+	return {
+		system,
+		...SYSTEM_PRESETS[system]
+	};
+}
+
+/** Default unit preferences (Imperial). */
+export const DEFAULT_UNIT_PREFERENCES: UnitPreferences = createUnitPreferencesFromSystem('imperial');
+
+/** Configuration options for the hydraulic solver. */
+export interface SolverOptions {
+	/** Maximum solver iterations. Default: 100 */
+	max_iterations: number;
+	/** Convergence tolerance. Default: 0.001 */
+	tolerance: number;
+	/** Generate system curve in results. Default: true */
+	include_system_curve: boolean;
+	/** Minimum flow for system curve (project units). Default: 0 */
+	flow_range_min: number;
+	/** Maximum flow for system curve (project units). Default: 500 */
+	flow_range_max: number;
+	/** Number of points for system curve. Default: 51 */
+	flow_points: number;
+}
+
+/** Default solver options. */
+export const DEFAULT_SOLVER_OPTIONS: SolverOptions = {
+	max_iterations: 100,
+	tolerance: 0.001,
+	include_system_curve: true,
+	flow_range_min: 0,
+	flow_range_max: 500,
+	flow_points: 51
+};


### PR DESCRIPTION
## Summary

- Add TypeScript interfaces matching all backend Pydantic models
- Include type guards for component type discrimination
- Export all types from a central index file
- Add helper functions for validation and default creation

## Changes

### New Files
- `apps/web/src/lib/models/units.ts` - Unit system, preferences, solver options
- `apps/web/src/lib/models/fluids.ts` - Fluid types and definitions
- `apps/web/src/lib/models/piping.ts` - Pipe, fitting, and piping segment models
- `apps/web/src/lib/models/pump.ts` - Pump curve and related models
- `apps/web/src/lib/models/components.ts` - All component types with type guards
- `apps/web/src/lib/models/results.ts` - Solved state and result models
- `apps/web/src/lib/models/project.ts` - Project container and metadata
- `apps/web/src/lib/models/index.ts` - Central export file

### Key Features
- Type guards (`isReservoir()`, `isPump()`, etc.) for runtime type checking
- Label constants for UI display
- Validation helpers for fluids, pump curves, and projects
- Default factory functions for all model types

## Test Plan

- [x] `svelte-check` passes with no errors
- [x] ESLint passes with no warnings
- [x] All types compile correctly

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)