### PR TITLE
feat(web): add dedicated component property forms with validation

### DIFF
--- a/apps/web/src/lib/components/forms/FittingsTable.svelte
+++ b/apps/web/src/lib/components/forms/FittingsTable.svelte
@@ -1,0 +1,169 @@
+<script lang="ts">
+	import type { Fitting, FittingType } from '$lib/models';
+	import { FITTING_TYPE_LABELS, FITTING_CATEGORIES, createDefaultFitting } from '$lib/models';
+
+	interface Props {
+		/** Current list of fittings. */
+		fittings: Fitting[];
+		/** Callback when fittings change. */
+		onUpdate: (fittings: Fitting[]) => void;
+	}
+
+	let { fittings, onUpdate }: Props = $props();
+
+	let showSelector = $state(false);
+
+	function addFitting(type: FittingType) {
+		const newFitting = createDefaultFitting(type);
+		onUpdate([...fittings, newFitting]);
+		showSelector = false;
+	}
+
+	function updateFitting(index: number, field: keyof Fitting, value: unknown) {
+		const newFittings = [...fittings];
+		newFittings[index] = { ...newFittings[index], [field]: value };
+		onUpdate(newFittings);
+	}
+
+	function removeFitting(index: number) {
+		onUpdate(fittings.filter((_, i) => i !== index));
+	}
+
+	function duplicateFitting(index: number) {
+		const newFitting = { ...fittings[index], id: crypto.randomUUID() };
+		const newFittings = [...fittings];
+		newFittings.splice(index + 1, 0, newFitting);
+		onUpdate(newFittings);
+	}
+</script>
+
+<div class="space-y-3">
+	<div class="flex items-center justify-between">
+		<h4 class="text-sm font-medium text-gray-900">Fittings</h4>
+		<div class="relative">
+			<button
+				type="button"
+				onclick={() => (showSelector = !showSelector)}
+				class="inline-flex items-center gap-1 text-sm font-medium text-blue-600 hover:text-blue-700"
+			>
+				<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+				</svg>
+				Add Fitting
+			</button>
+
+			<!-- Fitting Selector Dropdown -->
+			{#if showSelector}
+				<button
+					type="button"
+					class="fixed inset-0 z-40"
+					onclick={() => (showSelector = false)}
+					aria-label="Close menu"
+				></button>
+				<div class="absolute right-0 z-50 mt-2 w-64 rounded-lg border border-gray-200 bg-white shadow-lg">
+					<div class="max-h-64 overflow-y-auto p-2">
+						{#each Object.entries(FITTING_CATEGORIES) as [category, types]}
+							<div class="py-1">
+								<p class="px-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+									{category}
+								</p>
+								{#each types as type}
+									<button
+										type="button"
+										onclick={() => addFitting(type)}
+										class="block w-full px-2 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-100 rounded"
+									>
+										{FITTING_TYPE_LABELS[type]}
+									</button>
+								{/each}
+							</div>
+						{/each}
+					</div>
+				</div>
+			{/if}
+		</div>
+	</div>
+
+	{#if fittings.length === 0}
+		<p class="text-sm text-gray-500 italic">No fittings added</p>
+	{:else}
+		<div class="overflow-hidden rounded-md border border-gray-200">
+			<table class="min-w-full divide-y divide-gray-200">
+				<thead class="bg-gray-50">
+					<tr>
+						<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+							Type
+						</th>
+						<th class="w-20 px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+							Qty
+						</th>
+						<th class="w-24 px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+							K-Factor
+						</th>
+						<th class="w-20 px-3 py-2"></th>
+					</tr>
+				</thead>
+				<tbody class="divide-y divide-gray-200 bg-white">
+					{#each fittings as fitting, index}
+						<tr>
+							<td class="px-3 py-2">
+								<span class="text-sm text-gray-900">{FITTING_TYPE_LABELS[fitting.type]}</span>
+							</td>
+							<td class="px-3 py-2">
+								<input
+									type="number"
+									value={fitting.quantity}
+									min={1}
+									max={99}
+									onchange={(e) => updateFitting(index, 'quantity', parseInt((e.target as HTMLInputElement).value) || 1)}
+									class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+								/>
+							</td>
+							<td class="px-3 py-2">
+								<input
+									type="number"
+									value={fitting.k_factor_override ?? ''}
+									placeholder="auto"
+									min={0}
+									step={0.1}
+									onchange={(e) => {
+										const val = (e.target as HTMLInputElement).value;
+										updateFitting(index, 'k_factor_override', val ? parseFloat(val) : undefined);
+									}}
+									class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+								/>
+							</td>
+							<td class="px-3 py-2">
+								<div class="flex gap-1">
+									<button
+										type="button"
+										onclick={() => duplicateFitting(index)}
+										class="text-gray-400 hover:text-gray-600"
+										title="Duplicate"
+									>
+										<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+										</svg>
+									</button>
+									<button
+										type="button"
+										onclick={() => removeFitting(index)}
+										class="text-gray-400 hover:text-red-500"
+										title="Remove"
+									>
+										<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+											<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+										</svg>
+									</button>
+								</div>
+							</td>
+						</tr>
+					{/each}
+				</tbody>
+			</table>
+		</div>
+		<p class="text-xs text-gray-500">
+			K-Factor: Leave blank to use standard values based on diameter
+		</p>
+	{/if}
+</div>

--- a/apps/web/src/lib/components/forms/HeatExchangerForm.svelte
+++ b/apps/web/src/lib/components/forms/HeatExchangerForm.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import type { HeatExchanger } from '$lib/models';
+	import NumberInput from './NumberInput.svelte';
+
+	interface Props {
+		/** The heat exchanger component to edit. */
+		component: HeatExchanger;
+		/** Callback when a field value changes. */
+		onUpdate: (field: string, value: unknown) => void;
+	}
+
+	let { component, onUpdate }: Props = $props();
+</script>
+
+<div class="space-y-4">
+	<NumberInput
+		id="elevation"
+		label="Elevation"
+		value={component.elevation}
+		unit="ft"
+		onchange={(value) => onUpdate('elevation', value)}
+	/>
+
+	<NumberInput
+		id="pressure_drop"
+		label="Pressure Drop"
+		value={component.pressure_drop}
+		unit="psi"
+		min={0}
+		required
+		onchange={(value) => onUpdate('pressure_drop', value)}
+		hint="Pressure drop at design flow rate"
+	/>
+
+	<NumberInput
+		id="design_flow"
+		label="Design Flow"
+		value={component.design_flow}
+		unit="GPM"
+		min={0}
+		required
+		onchange={(value) => onUpdate('design_flow', value)}
+		hint="Flow rate at which pressure drop was measured"
+	/>
+</div>

--- a/apps/web/src/lib/components/forms/JunctionForm.svelte
+++ b/apps/web/src/lib/components/forms/JunctionForm.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import type { Junction } from '$lib/models';
+	import NumberInput from './NumberInput.svelte';
+
+	interface Props {
+		/** The junction component to edit. */
+		component: Junction;
+		/** Callback when a field value changes. */
+		onUpdate: (field: string, value: unknown) => void;
+	}
+
+	let { component, onUpdate }: Props = $props();
+</script>
+
+<div class="space-y-4">
+	<NumberInput
+		id="elevation"
+		label="Elevation"
+		value={component.elevation}
+		unit="ft"
+		onchange={(value) => onUpdate('elevation', value)}
+	/>
+
+	<NumberInput
+		id="demand"
+		label="Demand"
+		value={component.demand}
+		unit="GPM"
+		min={0}
+		onchange={(value) => onUpdate('demand', value)}
+		hint="Flow rate demand at this junction"
+	/>
+</div>

--- a/apps/web/src/lib/components/forms/NumberInput.svelte
+++ b/apps/web/src/lib/components/forms/NumberInput.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+	interface Props {
+		/** Unique ID for the input element. */
+		id: string;
+		/** Label text to display above the input. */
+		label: string;
+		/** Current value of the input. */
+		value: number | undefined;
+		/** Unit to display (e.g., "ft", "psi", "GPM"). */
+		unit?: string;
+		/** Minimum allowed value. */
+		min?: number;
+		/** Maximum allowed value. */
+		max?: number;
+		/** Step increment for the input. */
+		step?: number | 'any';
+		/** Whether the field is required. */
+		required?: boolean;
+		/** Placeholder text. */
+		placeholder?: string;
+		/** Helper text to show below input. */
+		hint?: string;
+		/** Callback when value changes. */
+		onchange: (value: number) => void;
+	}
+
+	let {
+		id,
+		label,
+		value,
+		unit,
+		min,
+		max,
+		step = 'any',
+		required = false,
+		placeholder,
+		hint,
+		onchange
+	}: Props = $props();
+
+	let error = $state('');
+
+	function handleInput(e: Event) {
+		const input = e.target as HTMLInputElement;
+		const numValue = parseFloat(input.value);
+
+		// Validate
+		if (input.value === '' && required) {
+			error = 'This field is required';
+			return;
+		}
+
+		if (isNaN(numValue) && input.value !== '') {
+			error = 'Please enter a valid number';
+			return;
+		}
+
+		if (min !== undefined && numValue < min) {
+			error = `Value must be at least ${min}`;
+			return;
+		}
+
+		if (max !== undefined && numValue > max) {
+			error = `Value must be at most ${max}`;
+			return;
+		}
+
+		error = '';
+		if (!isNaN(numValue)) {
+			onchange(numValue);
+		}
+	}
+</script>
+
+<div>
+	<label for={id} class="block text-sm font-medium text-gray-700">
+		{label}
+		{#if required}
+			<span class="text-red-500">*</span>
+		{/if}
+	</label>
+	<div class="mt-1 flex rounded-md shadow-sm">
+		<input
+			type="number"
+			{id}
+			value={value ?? ''}
+			{min}
+			{max}
+			{step}
+			{placeholder}
+			oninput={handleInput}
+			class="block w-full rounded-{unit ? 'l' : ''}md border px-3 py-2 text-sm focus:outline-none focus:ring-1
+				{error
+				? 'border-red-300 focus:border-red-500 focus:ring-red-500'
+				: 'border-gray-300 focus:border-blue-500 focus:ring-blue-500'}
+				{unit ? 'rounded-r-none' : ''}"
+			aria-invalid={!!error}
+			aria-describedby={error ? `${id}-error` : hint ? `${id}-hint` : undefined}
+		/>
+		{#if unit}
+			<span
+				class="inline-flex items-center rounded-r-md border border-l-0 border-gray-300 bg-gray-50 px-3 text-sm text-gray-500"
+			>
+				{unit}
+			</span>
+		{/if}
+	</div>
+	{#if error}
+		<p id="{id}-error" class="mt-1 text-xs text-red-600">{error}</p>
+	{:else if hint}
+		<p id="{id}-hint" class="mt-1 text-xs text-gray-500">{hint}</p>
+	{/if}
+</div>

--- a/apps/web/src/lib/components/forms/OrificeForm.svelte
+++ b/apps/web/src/lib/components/forms/OrificeForm.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import type { Orifice } from '$lib/models';
+	import NumberInput from './NumberInput.svelte';
+
+	interface Props {
+		/** The orifice component to edit. */
+		component: Orifice;
+		/** Callback when a field value changes. */
+		onUpdate: (field: string, value: unknown) => void;
+	}
+
+	let { component, onUpdate }: Props = $props();
+</script>
+
+<div class="space-y-4">
+	<NumberInput
+		id="elevation"
+		label="Elevation"
+		value={component.elevation}
+		unit="ft"
+		onchange={(value) => onUpdate('elevation', value)}
+	/>
+
+	<NumberInput
+		id="orifice_diameter"
+		label="Orifice Diameter"
+		value={component.orifice_diameter}
+		unit="in"
+		min={0}
+		required
+		onchange={(value) => onUpdate('orifice_diameter', value)}
+	/>
+
+	<NumberInput
+		id="discharge_coefficient"
+		label="Discharge Coefficient (Cd)"
+		value={component.discharge_coefficient}
+		min={0}
+		max={1}
+		step={0.01}
+		onchange={(value) => onUpdate('discharge_coefficient', value)}
+		hint="Typically 0.6-0.65 for sharp-edged orifice"
+	/>
+</div>

--- a/apps/web/src/lib/components/forms/PipeForm.svelte
+++ b/apps/web/src/lib/components/forms/PipeForm.svelte
@@ -1,0 +1,83 @@
+<script lang="ts">
+	import type { PipeDefinition } from '$lib/models';
+	import { PIPE_MATERIAL_LABELS, PIPE_SCHEDULE_LABELS } from '$lib/models';
+	import NumberInput from './NumberInput.svelte';
+
+	interface Props {
+		/** The pipe definition to edit. */
+		pipe: PipeDefinition;
+		/** Callback when a field value changes. */
+		onUpdate: (field: string, value: unknown) => void;
+	}
+
+	let { pipe, onUpdate }: Props = $props();
+</script>
+
+<div class="space-y-4">
+	<div class="grid grid-cols-2 gap-3">
+		<div>
+			<label for="material" class="block text-sm font-medium text-gray-700">Material</label>
+			<select
+				id="material"
+				value={pipe.material}
+				onchange={(e) => onUpdate('material', (e.target as HTMLSelectElement).value)}
+				class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+			>
+				{#each Object.entries(PIPE_MATERIAL_LABELS) as [value, label]}
+					<option {value}>{label}</option>
+				{/each}
+			</select>
+		</div>
+
+		<div>
+			<label for="schedule" class="block text-sm font-medium text-gray-700">Schedule</label>
+			<select
+				id="schedule"
+				value={pipe.schedule}
+				onchange={(e) => onUpdate('schedule', (e.target as HTMLSelectElement).value)}
+				class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+			>
+				{#each Object.entries(PIPE_SCHEDULE_LABELS) as [value, label]}
+					<option {value}>{label}</option>
+				{/each}
+			</select>
+		</div>
+	</div>
+
+	<div class="grid grid-cols-2 gap-3">
+		<NumberInput
+			id="nominal_diameter"
+			label="Nominal Diameter"
+			value={pipe.nominal_diameter}
+			unit="in"
+			min={0.125}
+			max={48}
+			step={0.125}
+			required
+			onchange={(value) => onUpdate('nominal_diameter', value)}
+		/>
+
+		<NumberInput
+			id="length"
+			label="Length"
+			value={pipe.length}
+			unit="ft"
+			min={0}
+			required
+			onchange={(value) => onUpdate('length', value)}
+		/>
+	</div>
+
+	{#if pipe.roughness_override !== undefined}
+		<NumberInput
+			id="roughness"
+			label="Roughness Override"
+			value={pipe.roughness_override}
+			unit="ft"
+			min={0}
+			step={0.00001}
+			onchange={(value) => onUpdate('roughness_override', value)}
+			hint="Leave blank to use material default"
+		/>
+	{/if}
+</div>

--- a/apps/web/src/lib/components/forms/PumpForm.svelte
+++ b/apps/web/src/lib/components/forms/PumpForm.svelte
@@ -1,0 +1,325 @@
+<script lang="ts">
+	import type { PumpComponent, PumpCurve, FlowHeadPoint } from '$lib/models';
+	import { pumpLibrary, projectStore } from '$lib/stores';
+	import NumberInput from './NumberInput.svelte';
+
+	interface Props {
+		/** The pump component to edit. */
+		component: PumpComponent;
+		/** Callback when a field value changes. */
+		onUpdate: (field: string, value: unknown) => void;
+	}
+
+	let { component, onUpdate }: Props = $props();
+
+	let showCurveEditor = $state(false);
+	let editingCurve = $state<PumpCurve | null>(null);
+	let newPoint = $state({ flow: 0, head: 0 });
+
+	// Get the selected curve
+	let selectedCurve = $derived($pumpLibrary.find((c) => c.id === component.curve_id));
+
+	function startNewCurve() {
+		editingCurve = {
+			id: crypto.randomUUID(),
+			name: 'New Pump Curve',
+			points: [
+				{ flow: 0, head: 100 },
+				{ flow: 50, head: 90 },
+				{ flow: 100, head: 75 },
+				{ flow: 150, head: 50 }
+			]
+		};
+		showCurveEditor = true;
+	}
+
+	function editExistingCurve() {
+		if (selectedCurve) {
+			editingCurve = JSON.parse(JSON.stringify(selectedCurve));
+			showCurveEditor = true;
+		}
+	}
+
+	function saveCurve() {
+		if (!editingCurve) return;
+
+		// Sort points by flow
+		editingCurve.points.sort((a, b) => a.flow - b.flow);
+
+		// Check if curve already exists
+		const existingIndex = $pumpLibrary.findIndex((c) => c.id === editingCurve!.id);
+		if (existingIndex >= 0) {
+			projectStore.updatePumpCurve(editingCurve.id, {
+				name: editingCurve.name,
+				points: editingCurve.points
+			});
+		} else {
+			projectStore.addPumpCurve(editingCurve);
+		}
+
+		// Select the curve for this pump
+		onUpdate('curve_id', editingCurve.id);
+
+		showCurveEditor = false;
+		editingCurve = null;
+	}
+
+	function cancelCurveEdit() {
+		showCurveEditor = false;
+		editingCurve = null;
+	}
+
+	function addPoint() {
+		if (!editingCurve) return;
+		editingCurve.points = [...editingCurve.points, { ...newPoint }];
+		newPoint = { flow: 0, head: 0 };
+	}
+
+	function removePoint(index: number) {
+		if (!editingCurve) return;
+		editingCurve.points = editingCurve.points.filter((_, i) => i !== index);
+	}
+
+	function updatePoint(index: number, field: keyof FlowHeadPoint, value: number) {
+		if (!editingCurve) return;
+		const newPoints = [...editingCurve.points];
+		newPoints[index] = { ...newPoints[index], [field]: value };
+		editingCurve.points = newPoints;
+	}
+</script>
+
+<div class="space-y-4">
+	<NumberInput
+		id="elevation"
+		label="Elevation"
+		value={component.elevation}
+		unit="ft"
+		onchange={(value) => onUpdate('elevation', value)}
+	/>
+
+	<!-- Pump Curve Selection -->
+	<div>
+		<label for="curve_id" class="block text-sm font-medium text-gray-700">Pump Curve</label>
+		<div class="mt-1 flex gap-2">
+			<select
+				id="curve_id"
+				value={component.curve_id}
+				onchange={(e) => onUpdate('curve_id', (e.target as HTMLSelectElement).value)}
+				class="block flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+			>
+				<option value="">Select a curve...</option>
+				{#each $pumpLibrary as curve}
+					<option value={curve.id}>{curve.name}</option>
+				{/each}
+			</select>
+			<button
+				type="button"
+				onclick={startNewCurve}
+				class="rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200"
+				title="Create new curve"
+			>
+				+
+			</button>
+			{#if selectedCurve}
+				<button
+					type="button"
+					onclick={editExistingCurve}
+					class="rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200"
+					title="Edit selected curve"
+				>
+					Edit
+				</button>
+			{/if}
+		</div>
+	</div>
+
+	<!-- Curve Preview -->
+	{#if selectedCurve}
+		<div class="rounded-md border border-gray-200 bg-gray-50 p-3">
+			<p class="text-xs font-medium text-gray-500">Curve Points</p>
+			<div class="mt-1 flex flex-wrap gap-2">
+				{#each selectedCurve.points as point}
+					<span class="rounded bg-white px-2 py-1 text-xs text-gray-700 shadow-sm">
+						{point.flow} GPM @ {point.head} ft
+					</span>
+				{/each}
+			</div>
+		</div>
+	{/if}
+
+	<NumberInput
+		id="speed"
+		label="Speed"
+		value={component.speed * 100}
+		unit="%"
+		min={0}
+		max={100}
+		step={1}
+		onchange={(value) => onUpdate('speed', value / 100)}
+		hint="100% = design speed"
+	/>
+
+	<!-- Status -->
+	<fieldset>
+		<legend class="block text-sm font-medium text-gray-700">Status</legend>
+		<div class="mt-2 flex gap-4">
+			<label class="flex items-center">
+				<input
+					type="radio"
+					name="status"
+					value="on"
+					checked={component.status === 'on'}
+					onchange={() => onUpdate('status', 'on')}
+					class="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+				/>
+				<span class="ml-2 text-sm text-gray-700">On</span>
+			</label>
+			<label class="flex items-center">
+				<input
+					type="radio"
+					name="status"
+					value="off"
+					checked={component.status === 'off'}
+					onchange={() => onUpdate('status', 'off')}
+					class="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+				/>
+				<span class="ml-2 text-sm text-gray-700">Off</span>
+			</label>
+		</div>
+	</fieldset>
+</div>
+
+<!-- Curve Editor Modal -->
+{#if showCurveEditor && editingCurve}
+	<div class="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+		<div class="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg bg-white p-6 shadow-xl">
+			<h3 class="text-lg font-semibold text-gray-900">Edit Pump Curve</h3>
+
+			<div class="mt-4 space-y-4">
+				<div>
+					<label for="curve_name" class="block text-sm font-medium text-gray-700">Curve Name</label>
+					<input
+						type="text"
+						id="curve_name"
+						value={editingCurve.name}
+						oninput={(e) => {
+							if (editingCurve) editingCurve.name = (e.target as HTMLInputElement).value;
+						}}
+						class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+					/>
+				</div>
+
+				<!-- Points Table -->
+				<div>
+					<p class="text-sm font-medium text-gray-700">Flow-Head Points</p>
+					<div class="mt-2 overflow-hidden rounded-md border border-gray-200">
+						<table class="min-w-full divide-y divide-gray-200">
+							<thead class="bg-gray-50">
+								<tr>
+									<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+										Flow (GPM)
+									</th>
+									<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+										Head (ft)
+									</th>
+									<th class="w-12 px-3 py-2"></th>
+								</tr>
+							</thead>
+							<tbody class="divide-y divide-gray-200 bg-white">
+								{#each editingCurve.points as point, index}
+									<tr>
+										<td class="px-3 py-2">
+											<input
+												type="number"
+												value={point.flow}
+												min={0}
+												oninput={(e) =>
+													updatePoint(index, 'flow', parseFloat((e.target as HTMLInputElement).value) || 0)}
+												class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+											/>
+										</td>
+										<td class="px-3 py-2">
+											<input
+												type="number"
+												value={point.head}
+												min={0}
+												oninput={(e) =>
+													updatePoint(index, 'head', parseFloat((e.target as HTMLInputElement).value) || 0)}
+												class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+											/>
+										</td>
+										<td class="px-3 py-2">
+											<button
+												type="button"
+												onclick={() => removePoint(index)}
+												class="text-red-500 hover:text-red-700"
+												disabled={editingCurve.points.length <= 2}
+												aria-label="Remove point"
+											>
+												<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+													<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+												</svg>
+											</button>
+										</td>
+									</tr>
+								{/each}
+								<!-- Add new point row -->
+								<tr class="bg-gray-50">
+									<td class="px-3 py-2">
+										<input
+											type="number"
+											placeholder="Flow"
+											bind:value={newPoint.flow}
+											min={0}
+											class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+										/>
+									</td>
+									<td class="px-3 py-2">
+										<input
+											type="number"
+											placeholder="Head"
+											bind:value={newPoint.head}
+											min={0}
+											class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+										/>
+									</td>
+									<td class="px-3 py-2">
+										<button
+											type="button"
+											onclick={addPoint}
+											class="text-blue-500 hover:text-blue-700"
+											aria-label="Add point"
+										>
+											<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+												<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+											</svg>
+										</button>
+									</td>
+								</tr>
+							</tbody>
+						</table>
+					</div>
+					<p class="mt-1 text-xs text-gray-500">Minimum 2 points required</p>
+				</div>
+			</div>
+
+			<div class="mt-6 flex justify-end gap-3">
+				<button
+					type="button"
+					onclick={cancelCurveEdit}
+					class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+				>
+					Cancel
+				</button>
+				<button
+					type="button"
+					onclick={saveCurve}
+					disabled={editingCurve.points.length < 2}
+					class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:bg-gray-400"
+				>
+					Save Curve
+				</button>
+			</div>
+		</div>
+	</div>
+{/if}

--- a/apps/web/src/lib/components/forms/ReservoirForm.svelte
+++ b/apps/web/src/lib/components/forms/ReservoirForm.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+	import type { Reservoir } from '$lib/models';
+	import NumberInput from './NumberInput.svelte';
+
+	interface Props {
+		/** The reservoir component to edit. */
+		component: Reservoir;
+		/** Callback when a field value changes. */
+		onUpdate: (field: string, value: unknown) => void;
+	}
+
+	let { component, onUpdate }: Props = $props();
+</script>
+
+<div class="space-y-4">
+	<NumberInput
+		id="elevation"
+		label="Elevation"
+		value={component.elevation}
+		unit="ft"
+		onchange={(value) => onUpdate('elevation', value)}
+	/>
+
+	<NumberInput
+		id="water_level"
+		label="Water Level"
+		value={component.water_level}
+		unit="ft"
+		min={0}
+		onchange={(value) => onUpdate('water_level', value)}
+	/>
+</div>

--- a/apps/web/src/lib/components/forms/SprinklerForm.svelte
+++ b/apps/web/src/lib/components/forms/SprinklerForm.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+	import type { Sprinkler } from '$lib/models';
+	import NumberInput from './NumberInput.svelte';
+
+	interface Props {
+		/** The sprinkler component to edit. */
+		component: Sprinkler;
+		/** Callback when a field value changes. */
+		onUpdate: (field: string, value: unknown) => void;
+	}
+
+	let { component, onUpdate }: Props = $props();
+</script>
+
+<div class="space-y-4">
+	<NumberInput
+		id="elevation"
+		label="Elevation"
+		value={component.elevation}
+		unit="ft"
+		onchange={(value) => onUpdate('elevation', value)}
+	/>
+
+	<NumberInput
+		id="k_factor"
+		label="K-Factor"
+		value={component.k_factor}
+		min={0}
+		step={0.1}
+		required
+		onchange={(value) => onUpdate('k_factor', value)}
+		hint="Q = K x sqrt(P), where Q is GPM and P is psi"
+	/>
+
+	<NumberInput
+		id="design_pressure"
+		label="Design Pressure"
+		value={component.design_pressure}
+		unit="psi"
+		min={0}
+		onchange={(value) => onUpdate('design_pressure', value)}
+		hint="Optional target pressure at sprinkler"
+	/>
+</div>

--- a/apps/web/src/lib/components/forms/StrainerForm.svelte
+++ b/apps/web/src/lib/components/forms/StrainerForm.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import type { Strainer } from '$lib/models';
+	import NumberInput from './NumberInput.svelte';
+
+	interface Props {
+		/** The strainer component to edit. */
+		component: Strainer;
+		/** Callback when a field value changes. */
+		onUpdate: (field: string, value: unknown) => void;
+	}
+
+	let { component, onUpdate }: Props = $props();
+</script>
+
+<div class="space-y-4">
+	<NumberInput
+		id="elevation"
+		label="Elevation"
+		value={component.elevation}
+		unit="ft"
+		onchange={(value) => onUpdate('elevation', value)}
+	/>
+
+	<NumberInput
+		id="k_factor"
+		label="K-Factor"
+		value={component.k_factor}
+		min={0}
+		step={0.1}
+		onchange={(value) => onUpdate('k_factor', value)}
+		hint="Resistance coefficient (leave blank for default)"
+	/>
+</div>

--- a/apps/web/src/lib/components/forms/TankForm.svelte
+++ b/apps/web/src/lib/components/forms/TankForm.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+	import type { Tank } from '$lib/models';
+	import NumberInput from './NumberInput.svelte';
+
+	interface Props {
+		/** The tank component to edit. */
+		component: Tank;
+		/** Callback when a field value changes. */
+		onUpdate: (field: string, value: unknown) => void;
+	}
+
+	let { component, onUpdate }: Props = $props();
+</script>
+
+<div class="space-y-4">
+	<NumberInput
+		id="elevation"
+		label="Elevation"
+		value={component.elevation}
+		unit="ft"
+		onchange={(value) => onUpdate('elevation', value)}
+	/>
+
+	<NumberInput
+		id="diameter"
+		label="Diameter"
+		value={component.diameter}
+		unit="ft"
+		min={0}
+		required
+		onchange={(value) => onUpdate('diameter', value)}
+	/>
+
+	<div class="grid grid-cols-3 gap-3">
+		<NumberInput
+			id="min_level"
+			label="Min Level"
+			value={component.min_level}
+			unit="ft"
+			min={0}
+			required
+			onchange={(value) => onUpdate('min_level', value)}
+		/>
+
+		<NumberInput
+			id="max_level"
+			label="Max Level"
+			value={component.max_level}
+			unit="ft"
+			min={0}
+			required
+			onchange={(value) => onUpdate('max_level', value)}
+		/>
+
+		<NumberInput
+			id="initial_level"
+			label="Initial Level"
+			value={component.initial_level}
+			unit="ft"
+			min={0}
+			required
+			onchange={(value) => onUpdate('initial_level', value)}
+		/>
+	</div>
+</div>

--- a/apps/web/src/lib/components/forms/ValveForm.svelte
+++ b/apps/web/src/lib/components/forms/ValveForm.svelte
@@ -1,0 +1,72 @@
+<script lang="ts">
+	import type { ValveComponent } from '$lib/models';
+	import { VALVE_TYPE_LABELS } from '$lib/models';
+	import NumberInput from './NumberInput.svelte';
+
+	interface Props {
+		/** The valve component to edit. */
+		component: ValveComponent;
+		/** Callback when a field value changes. */
+		onUpdate: (field: string, value: unknown) => void;
+	}
+
+	let { component, onUpdate }: Props = $props();
+</script>
+
+<div class="space-y-4">
+	<NumberInput
+		id="elevation"
+		label="Elevation"
+		value={component.elevation}
+		unit="ft"
+		onchange={(value) => onUpdate('elevation', value)}
+	/>
+
+	<div>
+		<label for="valve_type" class="block text-sm font-medium text-gray-700">Valve Type</label>
+		<select
+			id="valve_type"
+			value={component.valve_type}
+			onchange={(e) => onUpdate('valve_type', (e.target as HTMLSelectElement).value)}
+			class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+		>
+			{#each Object.entries(VALVE_TYPE_LABELS) as [value, label]}
+				<option {value}>{label}</option>
+			{/each}
+		</select>
+	</div>
+
+	<NumberInput
+		id="position"
+		label="Position"
+		value={(component.position ?? 1) * 100}
+		unit="%"
+		min={0}
+		max={100}
+		step={1}
+		onchange={(value) => onUpdate('position', value / 100)}
+		hint="0% = fully closed, 100% = fully open"
+	/>
+
+	{#if component.valve_type === 'prv' || component.valve_type === 'psv'}
+		<NumberInput
+			id="setpoint"
+			label={component.valve_type === 'prv' ? 'Downstream Pressure Setting' : 'Relief Pressure Setting'}
+			value={component.setpoint}
+			unit="psi"
+			min={0}
+			required
+			onchange={(value) => onUpdate('setpoint', value)}
+		/>
+	{:else if component.valve_type === 'fcv'}
+		<NumberInput
+			id="setpoint"
+			label="Flow Setting"
+			value={component.setpoint}
+			unit="GPM"
+			min={0}
+			required
+			onchange={(value) => onUpdate('setpoint', value)}
+		/>
+	{/if}
+</div>

--- a/apps/web/src/lib/components/forms/index.ts
+++ b/apps/web/src/lib/components/forms/index.ts
@@ -1,0 +1,26 @@
+/**
+ * Component Property Forms
+ *
+ * Dedicated forms for editing properties of each component type.
+ * Each form includes validation, unit display, and mobile-friendly inputs.
+ */
+
+// Base components
+export { default as NumberInput } from './NumberInput.svelte';
+
+// Node components
+export { default as ReservoirForm } from './ReservoirForm.svelte';
+export { default as TankForm } from './TankForm.svelte';
+export { default as JunctionForm } from './JunctionForm.svelte';
+export { default as SprinklerForm } from './SprinklerForm.svelte';
+export { default as OrificeForm } from './OrificeForm.svelte';
+
+// Link components
+export { default as PumpForm } from './PumpForm.svelte';
+export { default as ValveForm } from './ValveForm.svelte';
+export { default as HeatExchangerForm } from './HeatExchangerForm.svelte';
+export { default as StrainerForm } from './StrainerForm.svelte';
+
+// Piping components
+export { default as PipeForm } from './PipeForm.svelte';
+export { default as FittingsTable } from './FittingsTable.svelte';

--- a/apps/web/src/lib/components/panel/ElementPanel.svelte
+++ b/apps/web/src/lib/components/panel/ElementPanel.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
-	import { projectStore, pumpLibrary } from '$lib/stores';
+	import { projectStore } from '$lib/stores';
 	import {
 		COMPONENT_TYPE_LABELS,
-		VALVE_TYPE_LABELS,
 		isReservoir,
 		isTank,
 		isJunction,
@@ -14,6 +13,17 @@
 		isSprinkler,
 		type Component
 	} from '$lib/models';
+	import {
+		ReservoirForm,
+		TankForm,
+		JunctionForm,
+		PumpForm,
+		ValveForm,
+		HeatExchangerForm,
+		StrainerForm,
+		OrificeForm,
+		SprinklerForm
+	} from '$lib/components/forms';
 
 	interface Props {
 		/** The component to display/edit. */
@@ -26,22 +36,9 @@
 		projectStore.updateComponent(component.id, { [field]: value });
 	}
 
-	function handleNumberInput(field: string, e: Event) {
-		const input = e.target as HTMLInputElement;
-		const value = parseFloat(input.value);
-		if (!isNaN(value)) {
-			updateField(field, value);
-		}
-	}
-
 	function handleTextInput(field: string, e: Event) {
 		const input = e.target as HTMLInputElement;
 		updateField(field, input.value);
-	}
-
-	function handleSelectInput(field: string, e: Event) {
-		const select = e.target as HTMLSelectElement;
-		updateField(field, select.value);
 	}
 </script>
 
@@ -54,346 +51,37 @@
 	</div>
 
 	<!-- Common Fields -->
-	<div class="space-y-3">
-		<div>
-			<label for="name" class="block text-sm font-medium text-gray-700">Name</label>
-			<input
-				type="text"
-				id="name"
-				value={component.name}
-				oninput={(e) => handleTextInput('name', e)}
-				class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-			/>
-		</div>
-
-		<div>
-			<label for="elevation" class="block text-sm font-medium text-gray-700">Elevation</label>
-			<div class="mt-1 flex rounded-md shadow-sm">
-				<input
-					type="number"
-					id="elevation"
-					value={component.elevation}
-					oninput={(e) => handleNumberInput('elevation', e)}
-					class="block w-full rounded-l-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-				/>
-				<span class="inline-flex items-center rounded-r-md border border-l-0 border-gray-300 bg-gray-50 px-3 text-sm text-gray-500">
-					ft
-				</span>
-			</div>
-		</div>
+	<div>
+		<label for="name" class="block text-sm font-medium text-gray-700">Name</label>
+		<input
+			type="text"
+			id="name"
+			value={component.name}
+			oninput={(e) => handleTextInput('name', e)}
+			class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+		/>
 	</div>
 
 	<!-- Type-specific Fields -->
 	<div class="border-t border-gray-200 pt-4">
 		{#if isReservoir(component)}
-			<div>
-				<label for="water_level" class="block text-sm font-medium text-gray-700">Water Level</label>
-				<div class="mt-1 flex rounded-md shadow-sm">
-					<input
-						type="number"
-						id="water_level"
-						value={component.water_level}
-						min="0"
-						oninput={(e) => handleNumberInput('water_level', e)}
-						class="block w-full rounded-l-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-					/>
-					<span class="inline-flex items-center rounded-r-md border border-l-0 border-gray-300 bg-gray-50 px-3 text-sm text-gray-500">
-						ft
-					</span>
-				</div>
-			</div>
+			<ReservoirForm {component} onUpdate={updateField} />
 		{:else if isTank(component)}
-			<div class="space-y-3">
-				<div>
-					<label for="diameter" class="block text-sm font-medium text-gray-700">Diameter</label>
-					<div class="mt-1 flex rounded-md shadow-sm">
-						<input
-							type="number"
-							id="diameter"
-							value={component.diameter}
-							min="0"
-							oninput={(e) => handleNumberInput('diameter', e)}
-							class="block w-full rounded-l-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-						/>
-						<span class="inline-flex items-center rounded-r-md border border-l-0 border-gray-300 bg-gray-50 px-3 text-sm text-gray-500">
-							ft
-						</span>
-					</div>
-				</div>
-				<div class="grid grid-cols-3 gap-3">
-					<div>
-						<label for="min_level" class="block text-sm font-medium text-gray-700">Min Level</label>
-						<input
-							type="number"
-							id="min_level"
-							value={component.min_level}
-							min="0"
-							oninput={(e) => handleNumberInput('min_level', e)}
-							class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-						/>
-					</div>
-					<div>
-						<label for="max_level" class="block text-sm font-medium text-gray-700">Max Level</label>
-						<input
-							type="number"
-							id="max_level"
-							value={component.max_level}
-							min="0"
-							oninput={(e) => handleNumberInput('max_level', e)}
-							class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-						/>
-					</div>
-					<div>
-						<label for="initial_level" class="block text-sm font-medium text-gray-700">Initial</label>
-						<input
-							type="number"
-							id="initial_level"
-							value={component.initial_level}
-							min="0"
-							oninput={(e) => handleNumberInput('initial_level', e)}
-							class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-						/>
-					</div>
-				</div>
-			</div>
+			<TankForm {component} onUpdate={updateField} />
 		{:else if isJunction(component)}
-			<div>
-				<label for="demand" class="block text-sm font-medium text-gray-700">Demand</label>
-				<div class="mt-1 flex rounded-md shadow-sm">
-					<input
-						type="number"
-						id="demand"
-						value={component.demand}
-						min="0"
-						oninput={(e) => handleNumberInput('demand', e)}
-						class="block w-full rounded-l-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-					/>
-					<span class="inline-flex items-center rounded-r-md border border-l-0 border-gray-300 bg-gray-50 px-3 text-sm text-gray-500">
-						GPM
-					</span>
-				</div>
-			</div>
+			<JunctionForm {component} onUpdate={updateField} />
 		{:else if isPump(component)}
-			<div class="space-y-3">
-				<div>
-					<label for="curve_id" class="block text-sm font-medium text-gray-700">Pump Curve</label>
-					<select
-						id="curve_id"
-						value={component.curve_id}
-						onchange={(e) => handleSelectInput('curve_id', e)}
-						class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-					>
-						<option value="">Select a curve...</option>
-						{#each $pumpLibrary as curve}
-							<option value={curve.id}>{curve.name}</option>
-						{/each}
-					</select>
-				</div>
-				<div>
-					<label for="speed" class="block text-sm font-medium text-gray-700">Speed</label>
-					<div class="mt-1 flex rounded-md shadow-sm">
-						<input
-							type="number"
-							id="speed"
-							value={component.speed * 100}
-							min="0"
-							max="100"
-							step="1"
-							oninput={(e) => {
-								const input = e.target as HTMLInputElement;
-								const value = parseFloat(input.value);
-								if (!isNaN(value)) {
-									updateField('speed', value / 100);
-								}
-							}}
-							class="block w-full rounded-l-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-						/>
-						<span class="inline-flex items-center rounded-r-md border border-l-0 border-gray-300 bg-gray-50 px-3 text-sm text-gray-500">
-							%
-						</span>
-					</div>
-				</div>
-				<fieldset>
-					<legend class="block text-sm font-medium text-gray-700">Status</legend>
-					<div class="mt-2 flex gap-4">
-						<label class="flex items-center">
-							<input
-								type="radio"
-								name="status"
-								value="on"
-								checked={component.status === 'on'}
-								onchange={() => updateField('status', 'on')}
-								class="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
-							/>
-							<span class="ml-2 text-sm text-gray-700">On</span>
-						</label>
-						<label class="flex items-center">
-							<input
-								type="radio"
-								name="status"
-								value="off"
-								checked={component.status === 'off'}
-								onchange={() => updateField('status', 'off')}
-								class="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
-							/>
-							<span class="ml-2 text-sm text-gray-700">Off</span>
-						</label>
-					</div>
-				</fieldset>
-			</div>
+			<PumpForm {component} onUpdate={updateField} />
 		{:else if isValve(component)}
-			<div class="space-y-3">
-				<div>
-					<label for="valve_type" class="block text-sm font-medium text-gray-700">Valve Type</label>
-					<select
-						id="valve_type"
-						value={component.valve_type}
-						onchange={(e) => handleSelectInput('valve_type', e)}
-						class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-					>
-						{#each Object.entries(VALVE_TYPE_LABELS) as [value, label]}
-							<option {value}>{label}</option>
-						{/each}
-					</select>
-				</div>
-				<div>
-					<label for="position" class="block text-sm font-medium text-gray-700">Position</label>
-					<div class="mt-1 flex rounded-md shadow-sm">
-						<input
-							type="number"
-							id="position"
-							value={(component.position ?? 1) * 100}
-							min="0"
-							max="100"
-							step="1"
-							oninput={(e) => {
-								const input = e.target as HTMLInputElement;
-								const value = parseFloat(input.value);
-								if (!isNaN(value)) {
-									updateField('position', value / 100);
-								}
-							}}
-							class="block w-full rounded-l-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-						/>
-						<span class="inline-flex items-center rounded-r-md border border-l-0 border-gray-300 bg-gray-50 px-3 text-sm text-gray-500">
-							%
-						</span>
-					</div>
-					<p class="mt-1 text-xs text-gray-500">0% = fully closed, 100% = fully open</p>
-				</div>
-			</div>
+			<ValveForm {component} onUpdate={updateField} />
 		{:else if isHeatExchanger(component)}
-			<div class="space-y-3">
-				<div>
-					<label for="pressure_drop" class="block text-sm font-medium text-gray-700">Pressure Drop</label>
-					<div class="mt-1 flex rounded-md shadow-sm">
-						<input
-							type="number"
-							id="pressure_drop"
-							value={component.pressure_drop}
-							min="0"
-							oninput={(e) => handleNumberInput('pressure_drop', e)}
-							class="block w-full rounded-l-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-						/>
-						<span class="inline-flex items-center rounded-r-md border border-l-0 border-gray-300 bg-gray-50 px-3 text-sm text-gray-500">
-							psi
-						</span>
-					</div>
-				</div>
-				<div>
-					<label for="design_flow" class="block text-sm font-medium text-gray-700">Design Flow</label>
-					<div class="mt-1 flex rounded-md shadow-sm">
-						<input
-							type="number"
-							id="design_flow"
-							value={component.design_flow}
-							min="0"
-							oninput={(e) => handleNumberInput('design_flow', e)}
-							class="block w-full rounded-l-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-						/>
-						<span class="inline-flex items-center rounded-r-md border border-l-0 border-gray-300 bg-gray-50 px-3 text-sm text-gray-500">
-							GPM
-						</span>
-					</div>
-				</div>
-			</div>
+			<HeatExchangerForm {component} onUpdate={updateField} />
 		{:else if isStrainer(component)}
-			<div>
-				<label for="k_factor" class="block text-sm font-medium text-gray-700">K-Factor</label>
-				<input
-					type="number"
-					id="k_factor"
-					value={component.k_factor ?? ''}
-					min="0"
-					step="0.1"
-					oninput={(e) => handleNumberInput('k_factor', e)}
-					class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-				/>
-			</div>
+			<StrainerForm {component} onUpdate={updateField} />
 		{:else if isOrifice(component)}
-			<div class="space-y-3">
-				<div>
-					<label for="orifice_diameter" class="block text-sm font-medium text-gray-700">Orifice Diameter</label>
-					<div class="mt-1 flex rounded-md shadow-sm">
-						<input
-							type="number"
-							id="orifice_diameter"
-							value={component.orifice_diameter}
-							min="0"
-							oninput={(e) => handleNumberInput('orifice_diameter', e)}
-							class="block w-full rounded-l-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-						/>
-						<span class="inline-flex items-center rounded-r-md border border-l-0 border-gray-300 bg-gray-50 px-3 text-sm text-gray-500">
-							in
-						</span>
-					</div>
-				</div>
-				<div>
-					<label for="discharge_coefficient" class="block text-sm font-medium text-gray-700">Discharge Coefficient (Cd)</label>
-					<input
-						type="number"
-						id="discharge_coefficient"
-						value={component.discharge_coefficient}
-						min="0"
-						max="1"
-						step="0.01"
-						oninput={(e) => handleNumberInput('discharge_coefficient', e)}
-						class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-					/>
-				</div>
-			</div>
+			<OrificeForm {component} onUpdate={updateField} />
 		{:else if isSprinkler(component)}
-			<div class="space-y-3">
-				<div>
-					<label for="k_factor" class="block text-sm font-medium text-gray-700">K-Factor</label>
-					<input
-						type="number"
-						id="k_factor"
-						value={component.k_factor}
-						min="0"
-						step="0.1"
-						oninput={(e) => handleNumberInput('k_factor', e)}
-						class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-					/>
-					<p class="mt-1 text-xs text-gray-500">Q = K × √P</p>
-				</div>
-				<div>
-					<label for="design_pressure" class="block text-sm font-medium text-gray-700">Design Pressure (optional)</label>
-					<div class="mt-1 flex rounded-md shadow-sm">
-						<input
-							type="number"
-							id="design_pressure"
-							value={component.design_pressure ?? ''}
-							min="0"
-							oninput={(e) => handleNumberInput('design_pressure', e)}
-							class="block w-full rounded-l-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-						/>
-						<span class="inline-flex items-center rounded-r-md border border-l-0 border-gray-300 bg-gray-50 px-3 text-sm text-gray-500">
-							psi
-						</span>
-					</div>
-				</div>
-			</div>
+			<SprinklerForm {component} onUpdate={updateField} />
 		{/if}
 	</div>
 

--- a/apps/web/src/lib/components/panel/PipingPanel.svelte
+++ b/apps/web/src/lib/components/panel/PipingPanel.svelte
@@ -1,15 +1,7 @@
 <script lang="ts">
 	import { projectStore } from '$lib/stores';
-	import {
-		PIPE_MATERIAL_LABELS,
-		PIPE_SCHEDULE_LABELS,
-		FITTING_TYPE_LABELS,
-		FITTING_CATEGORIES,
-		createDefaultPipingSegment,
-		createDefaultFitting,
-		type PipingSegment,
-		type FittingType
-	} from '$lib/models';
+	import { createDefaultPipingSegment, type PipingSegment } from '$lib/models';
+	import { PipeForm, FittingsTable } from '$lib/components/forms';
 
 	interface Props {
 		/** The component ID this piping belongs to. */
@@ -19,8 +11,6 @@
 	}
 
 	let { componentId, piping }: Props = $props();
-
-	let showFittingSelector = $state(false);
 
 	function initializePiping() {
 		const newPiping = createDefaultPipingSegment();
@@ -39,41 +29,12 @@
 		});
 	}
 
-	function addFitting(type: FittingType) {
+	function updateFittings(fittings: PipingSegment['fittings']) {
 		if (!piping) return;
-		const newFitting = createDefaultFitting(type);
 		projectStore.updateUpstreamPiping(componentId, {
 			...piping,
-			fittings: [...piping.fittings, newFitting]
+			fittings
 		});
-		showFittingSelector = false;
-	}
-
-	function updateFitting(index: number, field: string, value: unknown) {
-		if (!piping) return;
-		const newFittings = [...piping.fittings];
-		newFittings[index] = { ...newFittings[index], [field]: value };
-		projectStore.updateUpstreamPiping(componentId, {
-			...piping,
-			fittings: newFittings
-		});
-	}
-
-	function removeFitting(index: number) {
-		if (!piping) return;
-		const newFittings = piping.fittings.filter((_, i) => i !== index);
-		projectStore.updateUpstreamPiping(componentId, {
-			...piping,
-			fittings: newFittings
-		});
-	}
-
-	function handleNumberInput(handler: (value: number) => void, e: Event) {
-		const input = e.target as HTMLInputElement;
-		const value = parseFloat(input.value);
-		if (!isNaN(value)) {
-			handler(value);
-		}
 	}
 </script>
 
@@ -107,156 +68,12 @@
 		<!-- Pipe Configuration -->
 		<div class="space-y-3">
 			<h4 class="text-sm font-medium text-gray-900">Pipe</h4>
-
-			<div class="grid grid-cols-2 gap-3">
-				<div>
-					<label for="material" class="block text-xs font-medium text-gray-700">Material</label>
-					<select
-						id="material"
-						value={piping.pipe.material}
-						onchange={(e) => updatePipeField('material', (e.target as HTMLSelectElement).value)}
-						class="mt-1 block w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-					>
-						{#each Object.entries(PIPE_MATERIAL_LABELS) as [value, label]}
-							<option {value}>{label}</option>
-						{/each}
-					</select>
-				</div>
-				<div>
-					<label for="schedule" class="block text-xs font-medium text-gray-700">Schedule</label>
-					<select
-						id="schedule"
-						value={piping.pipe.schedule}
-						onchange={(e) => updatePipeField('schedule', (e.target as HTMLSelectElement).value)}
-						class="mt-1 block w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-					>
-						{#each Object.entries(PIPE_SCHEDULE_LABELS) as [value, label]}
-							<option {value}>{label}</option>
-						{/each}
-					</select>
-				</div>
-			</div>
-
-			<div class="grid grid-cols-2 gap-3">
-				<div>
-					<label for="diameter" class="block text-xs font-medium text-gray-700">Diameter (in)</label>
-					<input
-						type="number"
-						id="diameter"
-						value={piping.pipe.nominal_diameter}
-						min="0"
-						step="0.5"
-						oninput={(e) => handleNumberInput((v) => updatePipeField('nominal_diameter', v), e)}
-						class="mt-1 block w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-					/>
-				</div>
-				<div>
-					<label for="length" class="block text-xs font-medium text-gray-700">Length (ft)</label>
-					<input
-						type="number"
-						id="length"
-						value={piping.pipe.length}
-						min="0"
-						oninput={(e) => handleNumberInput((v) => updatePipeField('length', v), e)}
-						class="mt-1 block w-full rounded-md border border-gray-300 px-2 py-1.5 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
-					/>
-				</div>
-			</div>
+			<PipeForm pipe={piping.pipe} onUpdate={updatePipeField} />
 		</div>
 
-		<!-- Fittings List -->
+		<!-- Fittings -->
 		<div class="border-t border-gray-200 pt-4">
-			<div class="flex items-center justify-between">
-				<h4 class="text-sm font-medium text-gray-900">Fittings</h4>
-				<div class="relative">
-					<button
-						type="button"
-						onclick={() => (showFittingSelector = !showFittingSelector)}
-						class="inline-flex items-center gap-1 text-sm text-blue-600 hover:text-blue-700"
-					>
-						<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
-						</svg>
-						Add
-					</button>
-
-					<!-- Fitting Selector Dropdown -->
-					{#if showFittingSelector}
-						<button
-							type="button"
-							class="fixed inset-0 z-40"
-							onclick={() => (showFittingSelector = false)}
-							aria-label="Close menu"
-						></button>
-						<div class="absolute right-0 z-50 mt-2 w-64 rounded-lg border border-gray-200 bg-white shadow-lg">
-							<div class="max-h-64 overflow-y-auto p-2">
-								{#each Object.entries(FITTING_CATEGORIES) as [category, types]}
-									<div class="py-1">
-										<p class="px-2 text-xs font-medium uppercase tracking-wide text-gray-500">
-											{category}
-										</p>
-										{#each types as type}
-											<button
-												type="button"
-												onclick={() => addFitting(type)}
-												class="block w-full px-2 py-1 text-left text-sm text-gray-700 hover:bg-gray-100"
-											>
-												{FITTING_TYPE_LABELS[type]}
-											</button>
-										{/each}
-									</div>
-								{/each}
-							</div>
-						</div>
-					{/if}
-				</div>
-			</div>
-
-			{#if piping.fittings.length === 0}
-				<p class="mt-2 text-sm text-gray-500">No fittings added</p>
-			{:else}
-				<ul class="mt-2 space-y-2">
-					{#each piping.fittings as fitting, index}
-						<li class="flex items-center gap-2 rounded-md border border-gray-200 p-2">
-							<div class="flex-1">
-								<p class="text-sm font-medium text-gray-900">
-									{FITTING_TYPE_LABELS[fitting.type]}
-								</p>
-								<div class="mt-1 flex items-center gap-2">
-									<label for="qty-{index}" class="text-xs text-gray-500">Qty:</label>
-									<input
-										type="number"
-										id="qty-{index}"
-										value={fitting.quantity}
-										min="1"
-										onchange={(e) =>
-											updateFitting(index, 'quantity', parseInt((e.target as HTMLInputElement).value))}
-										class="w-16 rounded border border-gray-300 px-2 py-0.5 text-sm"
-									/>
-									{#if fitting.k_factor_override !== undefined}
-										<span class="text-xs text-gray-500">K={fitting.k_factor_override}</span>
-									{/if}
-								</div>
-							</div>
-							<button
-								type="button"
-								onclick={() => removeFitting(index)}
-								class="text-gray-400 hover:text-red-500"
-								aria-label="Remove fitting"
-							>
-								<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-									<path
-										stroke-linecap="round"
-										stroke-linejoin="round"
-										stroke-width="2"
-										d="M6 18L18 6M6 6l12 12"
-									/>
-								</svg>
-							</button>
-						</li>
-					{/each}
-				</ul>
-			{/if}
+			<FittingsTable fittings={piping.fittings} onUpdate={updateFittings} />
 		</div>
 
 		<!-- Remove Piping Button -->


### PR DESCRIPTION
## Summary
- Add NumberInput component with validation (min/max, required, error display)
- Add dedicated forms for all component types:
  - ReservoirForm, TankForm, JunctionForm
  - PumpForm with pump curve entry/edit modal
  - ValveForm with type-specific setpoint fields
  - HeatExchangerForm, StrainerForm, OrificeForm, SprinklerForm
- Add PipeForm and FittingsTable for piping configuration
- Refactor ElementPanel and PipingPanel to use new form components

Closes #21

## Test plan
- [ ] Verify NumberInput shows validation errors for invalid inputs
- [ ] Test all component forms render with correct fields
- [ ] Test PumpForm curve editor (create, edit, save)
- [ ] Test FittingsTable add/remove/edit functionality
- [ ] Verify type checking passes (`pnpm exec svelte-check`)
- [ ] Verify all 73 tests pass (`pnpm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)