### PR TITLE
feat(web): add results display components with pump curve chart

### DIFF
--- a/apps/web/src/lib/components/results/LinkTable.svelte
+++ b/apps/web/src/lib/components/results/LinkTable.svelte
@@ -1,0 +1,142 @@
+<script lang="ts">
+	import { components } from '$lib/stores';
+	import { COMPONENT_TYPE_LABELS, FLOW_REGIME_LABELS, type SolvedState, type ComponentType } from '$lib/models';
+
+	interface Props {
+		/** The solved state containing results. */
+		results: SolvedState;
+	}
+
+	let { results }: Props = $props();
+
+	interface LinkData {
+		id: string;
+		name: string;
+		type: string;
+		result: typeof results.link_results[string] | undefined;
+	}
+
+	// Get links with their results
+	let linkData = $derived.by(() => {
+		const data: LinkData[] = [];
+
+		// Add component links (pumps, valves, etc.)
+		const linkComponents = $components.filter((c) =>
+			['pump', 'valve', 'heat_exchanger', 'strainer'].includes(c.type)
+		);
+
+		linkComponents.forEach((comp) => {
+			data.push({
+				id: comp.id,
+				name: comp.name,
+				type: comp.type,
+				result: results.link_results[comp.id]
+			});
+		});
+
+		// Add piping segments from components with upstream_piping
+		$components.forEach((comp) => {
+			if (comp.upstream_piping) {
+				const pipeId = `pipe_${comp.id}`;
+				data.push({
+					id: pipeId,
+					name: `Pipe to ${comp.name}`,
+					type: 'pipe',
+					result: results.link_results[pipeId] || results.link_results[comp.id]
+				});
+			}
+		});
+
+		return data;
+	});
+
+	function formatNumber(value: number | undefined, decimals = 2): string {
+		if (value === undefined) return '-';
+		return value.toFixed(decimals);
+	}
+
+	function formatScientific(value: number | undefined): string {
+		if (value === undefined) return '-';
+		if (value >= 10000 || value < 0.01) {
+			return value.toExponential(2);
+		}
+		return value.toFixed(0);
+	}
+</script>
+
+<div class="overflow-x-auto">
+	<table class="min-w-full divide-y divide-gray-200">
+		<thead class="bg-gray-50">
+			<tr>
+				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+					Link
+				</th>
+				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+					Type
+				</th>
+				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+					Flow (GPM)
+				</th>
+				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+					Velocity (ft/s)
+				</th>
+				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+					Head Loss (ft)
+				</th>
+				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+					Reynolds
+				</th>
+				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+					Regime
+				</th>
+			</tr>
+		</thead>
+		<tbody class="divide-y divide-gray-200 bg-white">
+			{#each linkData as link}
+				<tr class="hover:bg-gray-50">
+					<td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
+						{link.name}
+					</td>
+					<td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+						{link.type === 'pipe' ? 'Pipe' : COMPONENT_TYPE_LABELS[link.type as ComponentType] ?? link.type}
+					</td>
+					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
+						{formatNumber(link.result?.flow)}
+					</td>
+					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
+						{formatNumber(link.result?.velocity)}
+					</td>
+					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
+						{formatNumber(link.result?.head_loss)}
+					</td>
+					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
+						{formatScientific(link.result?.reynolds_number)}
+					</td>
+					<td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+						{#if link.result?.regime}
+							<span
+								class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium
+									{link.result.regime === 'laminar'
+									? 'bg-green-100 text-green-800'
+									: link.result.regime === 'transitional'
+										? 'bg-yellow-100 text-yellow-800'
+										: 'bg-blue-100 text-blue-800'}"
+							>
+								{FLOW_REGIME_LABELS[link.result.regime]}
+							</span>
+						{:else}
+							-
+						{/if}
+					</td>
+				</tr>
+			{/each}
+			{#if linkData.length === 0}
+				<tr>
+					<td colspan="7" class="px-4 py-8 text-center text-sm text-gray-500">
+						No link results available
+					</td>
+				</tr>
+			{/if}
+		</tbody>
+	</table>
+</div>

--- a/apps/web/src/lib/components/results/NodeTable.svelte
+++ b/apps/web/src/lib/components/results/NodeTable.svelte
@@ -1,0 +1,86 @@
+<script lang="ts">
+	import { components } from '$lib/stores';
+	import { COMPONENT_TYPE_LABELS, type SolvedState } from '$lib/models';
+
+	interface Props {
+		/** The solved state containing results. */
+		results: SolvedState;
+	}
+
+	let { results }: Props = $props();
+
+	// Get nodes with their results
+	let nodeData = $derived.by(() => {
+		const nodes = $components.filter((c) =>
+			['reservoir', 'tank', 'junction', 'sprinkler', 'orifice'].includes(c.type)
+		);
+
+		return nodes.map((node) => {
+			const result = results.node_results[node.id];
+			return {
+				id: node.id,
+				name: node.name,
+				type: node.type,
+				elevation: node.elevation,
+				result
+			};
+		});
+	});
+
+	function formatNumber(value: number | undefined, decimals = 2): string {
+		if (value === undefined) return '-';
+		return value.toFixed(decimals);
+	}
+</script>
+
+<div class="overflow-x-auto">
+	<table class="min-w-full divide-y divide-gray-200">
+		<thead class="bg-gray-50">
+			<tr>
+				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+					Node
+				</th>
+				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+					Type
+				</th>
+				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+					Pressure (psi)
+				</th>
+				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+					HGL (ft)
+				</th>
+				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+					EGL (ft)
+				</th>
+			</tr>
+		</thead>
+		<tbody class="divide-y divide-gray-200 bg-white">
+			{#each nodeData as node}
+				<tr class="hover:bg-gray-50">
+					<td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
+						{node.name}
+					</td>
+					<td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+						{COMPONENT_TYPE_LABELS[node.type]}
+					</td>
+					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
+						{formatNumber(node.result?.pressure)}
+					</td>
+					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
+						{formatNumber(node.result?.hgl)}
+					</td>
+					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
+						{formatNumber(node.result?.egl)}
+					</td>
+				</tr>
+			{/each}
+			{#if nodeData.length === 0}
+				<tr>
+					<td colspan="5" class="px-4 py-8 text-center text-sm text-gray-500">
+						No node results available
+					</td>
+				</tr>
+			{/if}
+		</tbody>
+	</table>
+</div>

--- a/apps/web/src/lib/components/results/PumpCurveChart.svelte
+++ b/apps/web/src/lib/components/results/PumpCurveChart.svelte
@@ -1,0 +1,213 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { Chart, registerables } from 'chart.js';
+	import type { PumpCurve, PumpResult } from '$lib/models';
+
+	// Register Chart.js components
+	Chart.register(...registerables);
+
+	interface Props {
+		/** The pump curve data. */
+		curve: PumpCurve;
+		/** The pump result with operating point and system curve. */
+		result?: PumpResult;
+	}
+
+	let { curve, result }: Props = $props();
+
+	let canvas: HTMLCanvasElement;
+	let chart: Chart | null = null;
+
+	// Reactive chart data
+	let chartData = $derived.by(() => {
+		const datasets: Chart['data']['datasets'] = [];
+
+		// Pump curve
+		datasets.push({
+			label: 'Pump Curve',
+			data: curve.points.map((p) => ({ x: p.flow, y: p.head })),
+			borderColor: 'rgb(59, 130, 246)',
+			backgroundColor: 'rgba(59, 130, 246, 0.1)',
+			fill: false,
+			tension: 0.4,
+			pointRadius: 3,
+			pointHoverRadius: 5
+		});
+
+		// System curve
+		if (result?.system_curve && result.system_curve.length > 0) {
+			datasets.push({
+				label: 'System Curve',
+				data: result.system_curve.map((p) => ({ x: p.flow, y: p.head })),
+				borderColor: 'rgb(239, 68, 68)',
+				backgroundColor: 'rgba(239, 68, 68, 0.1)',
+				fill: false,
+				tension: 0.4,
+				pointRadius: 0,
+				borderDash: [5, 5]
+			});
+		}
+
+		// Operating point
+		if (result) {
+			datasets.push({
+				label: 'Operating Point',
+				data: [{ x: result.operating_flow, y: result.operating_head }],
+				borderColor: 'rgb(34, 197, 94)',
+				backgroundColor: 'rgb(34, 197, 94)',
+				pointRadius: 8,
+				pointHoverRadius: 10,
+				showLine: false
+			});
+		}
+
+		return { datasets };
+	});
+
+	function createChart() {
+		if (!canvas) return;
+
+		// Destroy existing chart
+		if (chart) {
+			chart.destroy();
+			chart = null;
+		}
+
+		// Calculate axis ranges
+		const allFlows = curve.points.map((p) => p.flow);
+		const allHeads = curve.points.map((p) => p.head);
+
+		if (result?.system_curve) {
+			allFlows.push(...result.system_curve.map((p) => p.flow));
+			allHeads.push(...result.system_curve.map((p) => p.head));
+		}
+
+		if (result) {
+			allFlows.push(result.operating_flow);
+			allHeads.push(result.operating_head);
+		}
+
+		const maxFlow = Math.max(...allFlows) * 1.1;
+		const maxHead = Math.max(...allHeads) * 1.1;
+
+		chart = new Chart(canvas, {
+			type: 'scatter',
+			data: chartData,
+			options: {
+				responsive: true,
+				maintainAspectRatio: false,
+				interaction: {
+					intersect: false,
+					mode: 'index'
+				},
+				plugins: {
+					legend: {
+						position: 'bottom',
+						labels: {
+							usePointStyle: true,
+							padding: 16
+						}
+					},
+					tooltip: {
+						callbacks: {
+							label(context) {
+								const point = context.raw as { x: number; y: number };
+								return `${context.dataset.label}: ${point.x.toFixed(1)} GPM @ ${point.y.toFixed(1)} ft`;
+							}
+						}
+					}
+				},
+				scales: {
+					x: {
+						type: 'linear',
+						min: 0,
+						max: maxFlow,
+						title: {
+							display: true,
+							text: 'Flow (GPM)',
+							font: { weight: 'bold' }
+						},
+						grid: {
+							color: 'rgba(0, 0, 0, 0.05)'
+						}
+					},
+					y: {
+						type: 'linear',
+						min: 0,
+						max: maxHead,
+						title: {
+							display: true,
+							text: 'Head (ft)',
+							font: { weight: 'bold' }
+						},
+						grid: {
+							color: 'rgba(0, 0, 0, 0.05)'
+						}
+					}
+				}
+			}
+		});
+	}
+
+	// Update chart when data changes
+	$effect(() => {
+		// Access reactive dependencies to trigger effect
+		void chartData;
+		void curve;
+		void result;
+
+		// Recreate chart
+		if (canvas) {
+			createChart();
+		}
+	});
+
+	onMount(() => {
+		createChart();
+	});
+
+	onDestroy(() => {
+		if (chart) {
+			chart.destroy();
+		}
+	});
+</script>
+
+<div class="relative h-64 w-full sm:h-80">
+	<canvas bind:this={canvas}></canvas>
+</div>
+
+{#if result}
+	<div class="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-4">
+		<div class="rounded-lg bg-gray-50 p-3">
+			<p class="text-xs font-medium uppercase tracking-wide text-gray-500">Flow</p>
+			<p class="mt-1 text-lg font-semibold text-gray-900">{result.operating_flow.toFixed(1)} GPM</p>
+		</div>
+		<div class="rounded-lg bg-gray-50 p-3">
+			<p class="text-xs font-medium uppercase tracking-wide text-gray-500">Head</p>
+			<p class="mt-1 text-lg font-semibold text-gray-900">{result.operating_head.toFixed(1)} ft</p>
+		</div>
+		<div class="rounded-lg bg-gray-50 p-3">
+			<p class="text-xs font-medium uppercase tracking-wide text-gray-500">NPSH Available</p>
+			<p class="mt-1 text-lg font-semibold text-gray-900">{result.npsh_available.toFixed(1)} ft</p>
+		</div>
+		{#if result.efficiency !== undefined}
+			<div class="rounded-lg bg-gray-50 p-3">
+				<p class="text-xs font-medium uppercase tracking-wide text-gray-500">Efficiency</p>
+				<p class="mt-1 text-lg font-semibold text-gray-900">{(result.efficiency * 100).toFixed(1)}%</p>
+			</div>
+		{:else if result.power !== undefined}
+			<div class="rounded-lg bg-gray-50 p-3">
+				<p class="text-xs font-medium uppercase tracking-wide text-gray-500">Power</p>
+				<p class="mt-1 text-lg font-semibold text-gray-900">{result.power.toFixed(2)} kW</p>
+			</div>
+		{:else}
+			<div class="rounded-lg bg-gray-50 p-3">
+				<p class="text-xs font-medium uppercase tracking-wide text-gray-500">NPSH Margin</p>
+				<p class="mt-1 text-lg font-semibold text-gray-900">
+					{result.npsh_margin !== undefined ? `${result.npsh_margin.toFixed(1)} ft` : '-'}
+				</p>
+			</div>
+		{/if}
+	</div>
+{/if}

--- a/apps/web/src/lib/components/results/ResultsPanel.svelte
+++ b/apps/web/src/lib/components/results/ResultsPanel.svelte
@@ -1,0 +1,248 @@
+<script lang="ts">
+	import { solvedState, components, pumpLibrary } from '$lib/stores';
+	import { isPump, WARNING_CATEGORY_LABELS, type Warning } from '$lib/models';
+	import NodeTable from './NodeTable.svelte';
+	import LinkTable from './LinkTable.svelte';
+	import PumpCurveChart from './PumpCurveChart.svelte';
+
+	interface Props {
+		/** Whether a solve is currently in progress. */
+		isLoading?: boolean;
+	}
+
+	let { isLoading = false }: Props = $props();
+
+	type TabId = 'summary' | 'nodes' | 'links' | 'pumps';
+	let activeTab: TabId = $state('summary');
+
+	// Get pumps with their curves and results
+	let pumpData = $derived.by(() => {
+		const pumps = $components.filter(isPump);
+		return pumps.map((pump) => {
+			const curve = $pumpLibrary.find((c) => c.id === pump.curve_id);
+			const result = $solvedState?.pump_results[pump.id];
+			return { pump, curve, result };
+		});
+	});
+
+	// Group warnings by severity
+	let errorWarnings = $derived(
+		$solvedState?.warnings.filter((w) => w.severity === 'error') ?? []
+	);
+	let warningWarnings = $derived(
+		$solvedState?.warnings.filter((w) => w.severity === 'warning') ?? []
+	);
+	let infoWarnings = $derived(
+		$solvedState?.warnings.filter((w) => w.severity === 'info') ?? []
+	);
+
+	const tabs: { id: TabId; label: string }[] = [
+		{ id: 'summary', label: 'Summary' },
+		{ id: 'nodes', label: 'Nodes' },
+		{ id: 'links', label: 'Links' },
+		{ id: 'pumps', label: 'Pumps' }
+	];
+
+	function formatDuration(seconds: number | undefined): string {
+		if (seconds === undefined) return '-';
+		if (seconds < 1) return `${(seconds * 1000).toFixed(0)} ms`;
+		return `${seconds.toFixed(2)} s`;
+	}
+
+	function getWarningIcon(severity: Warning['severity']): string {
+		switch (severity) {
+			case 'error':
+				return 'M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z';
+			case 'warning':
+				return 'M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z';
+			default:
+				return 'M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z';
+		}
+	}
+</script>
+
+<div class="flex h-full flex-col">
+	{#if isLoading}
+		<!-- Loading State -->
+		<div class="flex flex-1 flex-col items-center justify-center p-8">
+			<div class="h-12 w-12 animate-spin rounded-full border-4 border-blue-500 border-t-transparent"></div>
+			<p class="mt-4 text-sm text-gray-600">Solving network...</p>
+		</div>
+	{:else if !$solvedState}
+		<!-- No Results State -->
+		<div class="flex flex-1 flex-col items-center justify-center p-8 text-center">
+			<svg class="h-16 w-16 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
+				/>
+			</svg>
+			<h3 class="mt-4 text-lg font-medium text-gray-900">No results yet</h3>
+			<p class="mt-2 text-sm text-gray-500">
+				Click "Solve" to calculate pressures and flows in your network.
+			</p>
+		</div>
+	{:else}
+		<!-- Tab Navigation -->
+		<div class="border-b border-gray-200 bg-gray-50">
+			<nav class="flex -mb-px" aria-label="Tabs">
+				{#each tabs as tab}
+					<button
+						type="button"
+						onclick={() => (activeTab = tab.id)}
+						class="flex-1 border-b-2 py-3 text-center text-sm font-medium transition-colors
+							{activeTab === tab.id
+							? 'border-blue-500 text-blue-600'
+							: 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'}"
+					>
+						{tab.label}
+					</button>
+				{/each}
+			</nav>
+		</div>
+
+		<!-- Tab Content -->
+		<div class="flex-1 overflow-y-auto p-4">
+			{#if activeTab === 'summary'}
+				<!-- Convergence Status -->
+				<div
+					class="rounded-lg border p-4
+						{$solvedState.converged ? 'border-green-200 bg-green-50' : 'border-red-200 bg-red-50'}"
+				>
+					<div class="flex items-center gap-3">
+						{#if $solvedState.converged}
+							<svg class="h-6 w-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+							</svg>
+							<div>
+								<p class="font-medium text-green-800">Solution Converged</p>
+								<p class="text-sm text-green-600">
+									{$solvedState.iterations} iterations in {formatDuration($solvedState.solve_time_seconds)}
+								</p>
+							</div>
+						{:else}
+							<svg class="h-6 w-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
+							</svg>
+							<div>
+								<p class="font-medium text-red-800">Solution Failed</p>
+								<p class="text-sm text-red-600">
+									{$solvedState.error || 'Unknown error'}
+								</p>
+							</div>
+						{/if}
+					</div>
+				</div>
+
+				<!-- Warnings -->
+				{#if $solvedState.warnings.length > 0}
+					<div class="mt-4 space-y-3">
+						<h4 class="text-sm font-medium text-gray-900">Warnings & Messages</h4>
+
+						{#each errorWarnings as warning}
+							<div class="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 p-3">
+								<svg class="h-5 w-5 flex-shrink-0 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={getWarningIcon('error')} />
+								</svg>
+								<div>
+									<p class="text-sm font-medium text-red-800">{warning.message}</p>
+									<p class="text-xs text-red-600">{WARNING_CATEGORY_LABELS[warning.category]}</p>
+								</div>
+							</div>
+						{/each}
+
+						{#each warningWarnings as warning}
+							<div class="flex items-start gap-3 rounded-lg border border-yellow-200 bg-yellow-50 p-3">
+								<svg class="h-5 w-5 flex-shrink-0 text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={getWarningIcon('warning')} />
+								</svg>
+								<div>
+									<p class="text-sm font-medium text-yellow-800">{warning.message}</p>
+									<p class="text-xs text-yellow-600">{WARNING_CATEGORY_LABELS[warning.category]}</p>
+								</div>
+							</div>
+						{/each}
+
+						{#each infoWarnings as warning}
+							<div class="flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 p-3">
+								<svg class="h-5 w-5 flex-shrink-0 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={getWarningIcon('info')} />
+								</svg>
+								<div>
+									<p class="text-sm font-medium text-blue-800">{warning.message}</p>
+									<p class="text-xs text-blue-600">{WARNING_CATEGORY_LABELS[warning.category]}</p>
+								</div>
+							</div>
+						{/each}
+					</div>
+				{/if}
+
+				<!-- Quick Stats -->
+				{#if $solvedState.converged}
+					<div class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
+						<div class="rounded-lg bg-gray-50 p-3">
+							<p class="text-xs font-medium uppercase tracking-wide text-gray-500">Nodes</p>
+							<p class="mt-1 text-2xl font-semibold text-gray-900">
+								{Object.keys($solvedState.node_results).length}
+							</p>
+						</div>
+						<div class="rounded-lg bg-gray-50 p-3">
+							<p class="text-xs font-medium uppercase tracking-wide text-gray-500">Links</p>
+							<p class="mt-1 text-2xl font-semibold text-gray-900">
+								{Object.keys($solvedState.link_results).length}
+							</p>
+						</div>
+						<div class="rounded-lg bg-gray-50 p-3">
+							<p class="text-xs font-medium uppercase tracking-wide text-gray-500">Pumps</p>
+							<p class="mt-1 text-2xl font-semibold text-gray-900">
+								{Object.keys($solvedState.pump_results).length}
+							</p>
+						</div>
+						<div class="rounded-lg bg-gray-50 p-3">
+							<p class="text-xs font-medium uppercase tracking-wide text-gray-500">Warnings</p>
+							<p class="mt-1 text-2xl font-semibold text-gray-900">
+								{$solvedState.warnings.length}
+							</p>
+						</div>
+					</div>
+				{/if}
+			{:else if activeTab === 'nodes'}
+				<NodeTable results={$solvedState} />
+			{:else if activeTab === 'links'}
+				<LinkTable results={$solvedState} />
+			{:else if activeTab === 'pumps'}
+				{#if pumpData.length === 0}
+					<div class="flex flex-col items-center justify-center py-12 text-center">
+						<svg class="h-12 w-12 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+							/>
+						</svg>
+						<p class="mt-4 text-sm text-gray-500">No pumps in this network</p>
+					</div>
+				{:else}
+					<div class="space-y-6">
+						{#each pumpData as { pump, curve, result }}
+							<div class="rounded-lg border border-gray-200 p-4">
+								<h4 class="text-sm font-medium text-gray-900">{pump.name}</h4>
+								{#if curve}
+									<p class="text-xs text-gray-500">{curve.name}</p>
+									<div class="mt-4">
+										<PumpCurveChart {curve} {result} />
+									</div>
+								{:else}
+									<p class="mt-2 text-sm text-yellow-600">No pump curve assigned</p>
+								{/if}
+							</div>
+						{/each}
+					</div>
+				{/if}
+			{/if}
+		</div>
+	{/if}
+</div>

--- a/apps/web/src/lib/components/results/index.ts
+++ b/apps/web/src/lib/components/results/index.ts
@@ -1,0 +1,11 @@
+/**
+ * Results Display Components
+ *
+ * Components for displaying solved network results including
+ * tables, pump curves, and summary views.
+ */
+
+export { default as ResultsPanel } from './ResultsPanel.svelte';
+export { default as NodeTable } from './NodeTable.svelte';
+export { default as LinkTable } from './LinkTable.svelte';
+export { default as PumpCurveChart } from './PumpCurveChart.svelte';


### PR DESCRIPTION
## Summary
- Add ResultsPanel with tabbed interface (Summary, Nodes, Links, Pumps)
- Add NodeTable showing pressure, HGL, EGL for all nodes
- Add LinkTable showing flow, velocity, head loss, Reynolds, flow regime
- Add PumpCurveChart using Chart.js with pump curve, system curve, and operating point visualization
- Display convergence status with success/failure styling
- Show warnings grouped by severity (error, warning, info)
- Add loading state and empty state handling

Closes #22

## Test plan
- [ ] Verify ResultsPanel renders with no results (empty state)
- [ ] Verify loading state shows spinner
- [ ] Verify NodeTable displays node data with units
- [ ] Verify LinkTable displays link data with flow regime badges
- [ ] Verify PumpCurveChart renders pump curve with Chart.js
- [ ] Verify warnings display correctly by severity
- [ ] Test mobile responsiveness of tables

🤖 Generated with [Claude Code](https://claude.com/claude-code)