### PR TITLE
fix(web): fix garbled component menu and rename Panel to Build

### DIFF
--- a/apps/web/src/lib/components/Header.svelte
+++ b/apps/web/src/lib/components/Header.svelte
@@ -108,7 +108,7 @@
 								: 'text-gray-600 hover:text-gray-900'}"
 							onclick={() => handleViewModeChange('panel')}
 						>
-							Panel
+							Build
 						</button>
 						<button
 							type="button"

--- a/apps/web/src/lib/components/panel/ElementTypeSelector.svelte
+++ b/apps/web/src/lib/components/panel/ElementTypeSelector.svelte
@@ -51,9 +51,9 @@
 								<button
 									type="button"
 									onclick={() => handleSelect(type)}
-									class="rounded-md border border-gray-200 px-3 py-2 text-left text-sm leading-normal transition-colors hover:border-blue-500 hover:bg-blue-50"
+									class="rounded-md border border-gray-200 bg-white px-3 py-2 text-left text-sm leading-normal text-gray-900 transition-colors hover:border-blue-500 hover:bg-blue-50"
 								>
-									<span class="block truncate">{COMPONENT_TYPE_LABELS[type]}</span>
+									{COMPONENT_TYPE_LABELS[type]}
 								</button>
 							{/each}
 						</div>


### PR DESCRIPTION
## Summary

- Fix garbled/invisible text in the "Add Component" dropdown menu
- Rename "Panel" button to "Build" in the view switcher

### Changes

**ElementTypeSelector.svelte:**
- Added explicit `bg-white` and `text-gray-900` classes to component type buttons
- Ensures text is visible regardless of any inherited or conflicting styles

**Header.svelte:**
- Changed "Panel" → "Build" for the view mode toggle button

## Screenshots

Before: Component buttons showed as empty white boxes with no visible text
After: Component names (Reservoir, Tank, Junction, etc.) are now visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)