### PR TITLE
docs: update CHANGELOG with ADR-006 terminology changes

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -56,6 +56,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING:** Renamed "Nodes/Links" terminology to "Components/Piping" per ADR-006
+  - `NodeResult` → `ComponentResult`
+  - `LinkResult` → `PipingResult`
+  - `node_results` → `component_results`
+  - `link_results` → `piping_results`
+  - UI tabs renamed from "Nodes"/"Links" to "Components"/"Piping"
+
 ### Planned Features
 
 - Branching network support


### PR DESCRIPTION
## Summary

Document the breaking API changes from the Nodes/Links to Components/Piping terminology refactoring in the CHANGELOG.

## Test plan

- [x] No code changes, documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)