### PR TITLE
fix(a11y): improve accessibility for navigation and form controls

### DIFF
--- a/apps/web/src/lib/components/forms/FittingsTable.svelte
+++ b/apps/web/src/lib/components/forms/FittingsTable.svelte
@@ -116,6 +116,7 @@
 									min={1}
 									max={99}
 									onchange={(e) => updateFitting(index, 'quantity', parseInt((e.target as HTMLInputElement).value) || 1)}
+									aria-label="Quantity for {FITTING_TYPE_LABELS[fitting.type]}"
 									class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
 								/>
 							</td>
@@ -130,6 +131,7 @@
 										const val = (e.target as HTMLInputElement).value;
 										updateFitting(index, 'k_factor_override', val ? parseFloat(val) : undefined);
 									}}
+									aria-label="K-factor for {FITTING_TYPE_LABELS[fitting.type]}"
 									class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
 								/>
 							</td>

--- a/apps/web/src/lib/components/panel/Breadcrumbs.svelte
+++ b/apps/web/src/lib/components/panel/Breadcrumbs.svelte
@@ -49,7 +49,7 @@
 					{/if}
 
 					{#if crumb.type === 'ellipsis'}
-						<span class="px-2 text-gray-400">...</span>
+						<span class="px-2 text-gray-400" aria-label="More components">...</span>
 					{:else if crumb.isLast}
 						<span class="px-2 font-medium text-gray-900">
 							{crumb.name || COMPONENT_TYPE_LABELS[crumb.type]}

--- a/apps/web/src/lib/components/panel/NavigationControls.svelte
+++ b/apps/web/src/lib/components/panel/NavigationControls.svelte
@@ -53,6 +53,7 @@
 		type="button"
 		onclick={handlePrev}
 		disabled={!canNavigatePrev}
+		aria-label="Previous component"
 		class="inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors
 			{canNavigatePrev
 			? 'bg-white text-gray-700 shadow-sm hover:bg-gray-50 border border-gray-300'
@@ -85,6 +86,7 @@
 		type="button"
 		onclick={handleNext}
 		disabled={!canNavigateNext}
+		aria-label="Next component"
 		class="inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors
 			{canNavigateNext
 			? 'bg-white text-gray-700 shadow-sm hover:bg-gray-50 border border-gray-300'

--- a/apps/web/src/lib/components/panel/PanelNavigator.svelte
+++ b/apps/web/src/lib/components/panel/PanelNavigator.svelte
@@ -82,6 +82,7 @@
 				<button
 					type="button"
 					onclick={() => (showAddSelector = !showAddSelector)}
+					aria-label="Add component"
 					class="inline-flex items-center gap-1 rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-blue-700"
 				>
 					<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/apps/web/src/routes/p/[...encoded]/+page.svelte
+++ b/apps/web/src/routes/p/[...encoded]/+page.svelte
@@ -161,7 +161,7 @@
 
 	<!-- Toast Messages -->
 	{#if solveError}
-		<div class="fixed right-4 top-20 z-50 max-w-md transition-all duration-150 ease-out">
+		<div class="fixed right-4 top-20 z-50 max-w-md transition-all duration-150 ease-out" role="alert" aria-live="assertive">
 			<div class="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 p-4 shadow-lg">
 				<svg class="h-5 w-5 flex-shrink-0 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
@@ -185,7 +185,7 @@
 	{/if}
 
 	{#if solveSuccess}
-		<div class="fixed right-4 top-20 z-50 max-w-md transition-all duration-150 ease-out">
+		<div class="fixed right-4 top-20 z-50 max-w-md transition-all duration-150 ease-out" role="status" aria-live="polite">
 			<div class="flex items-start gap-3 rounded-lg border border-green-200 bg-green-50 p-4 shadow-lg">
 				<svg class="h-5 w-5 flex-shrink-0 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />


### PR DESCRIPTION
## Summary

- Add aria-labels to navigation controls (Previous/Next buttons)
- Add aria-label to Add component button in panel navigator
- Add ARIA live regions to error toast (`role="alert"`, `aria-live="assertive"`) and success toast (`role="status"`, `aria-live="polite"`)
- Add aria-label to breadcrumb ellipsis for truncated paths
- Add aria-labels to quantity and k-factor inputs in fittings table (dynamic based on fitting type)

## Test Plan

- [x] Svelte type checking passes (`pnpm run check`)
- [x] ESLint passes (`pnpm run lint`)
- [x] All E2E tests pass (11/11)
- [ ] Manual screen reader testing

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)