### PR TITLE
feat(models): add reference node and plug components

### DIFF
--- a/apps/api/src/opensolve_pipe/models/__init__.py
+++ b/apps/api/src/opensolve_pipe/models/__init__.py
@@ -51,6 +51,7 @@ from .piping import (
     PipeSchedule,
     PipingSegment,
 )
+from .plug import Plug, create_plug_port
 from .ports import (
     Port,
     PortDirection,
@@ -66,6 +67,15 @@ from .ports import (
 )
 from .project import Project, ProjectMetadata, ProjectSettings
 from .pump import FlowEfficiencyPoint, FlowHeadPoint, NPSHRPoint, PumpCurve
+from .reference_node import (
+    BaseReferenceNode,
+    FlowPressurePoint,
+    IdealReferenceNode,
+    NonIdealReferenceNode,
+    ReferenceNode,
+    ReferenceType,
+    create_reference_node_port,
+)
 from .results import (
     ComponentResult,
     FlowRegime,
@@ -80,6 +90,7 @@ from .units import SolverOptions, UnitPreferences, UnitSystem
 
 __all__ = [
     "BaseComponent",
+    "BaseReferenceNode",
     "Component",
     "ComponentResult",
     "ComponentType",
@@ -92,15 +103,18 @@ __all__ = [
     "Flow",
     "FlowEfficiencyPoint",
     "FlowHeadPoint",
+    "FlowPressurePoint",
     "FlowRegime",
     "FluidDefinition",
     "FluidProperties",
     "FluidType",
     "Head",
     "HeatExchanger",
+    "IdealReferenceNode",
     "Junction",
     "Length",
     "NPSHRPoint",
+    "NonIdealReferenceNode",
     "NonNegativeFloat",
     "NonNegativeInt",
     "OpenSolvePipeBaseModel",
@@ -111,6 +125,7 @@ __all__ = [
     "PipeSchedule",
     "PipingResult",
     "PipingSegment",
+    "Plug",
     "Port",
     "PortDirection",
     "PositiveFloat",
@@ -122,6 +137,8 @@ __all__ = [
     "PumpComponent",
     "PumpCurve",
     "PumpResult",
+    "ReferenceNode",
+    "ReferenceType",
     "Reservoir",
     "SolvedState",
     "SolverOptions",
@@ -140,7 +157,9 @@ __all__ = [
     "create_heat_exchanger_ports",
     "create_junction_ports",
     "create_orifice_ports",
+    "create_plug_port",
     "create_pump_ports",
+    "create_reference_node_port",
     "create_reservoir_ports",
     "create_sprinkler_ports",
     "create_strainer_ports",

--- a/apps/api/src/opensolve_pipe/models/components.py
+++ b/apps/api/src/opensolve_pipe/models/components.py
@@ -39,6 +39,9 @@ class ComponentType(str, Enum):
     STRAINER = "strainer"
     ORIFICE = "orifice"
     SPRINKLER = "sprinkler"
+    IDEAL_REFERENCE_NODE = "ideal_reference_node"
+    NON_IDEAL_REFERENCE_NODE = "non_ideal_reference_node"
+    PLUG = "plug"
 
 
 class ValveType(str, Enum):
@@ -300,6 +303,9 @@ class Sprinkler(BaseComponent):
         return self
 
 
+from .plug import Plug  # noqa: E402
+from .reference_node import IdealReferenceNode, NonIdealReferenceNode  # noqa: E402
+
 # Discriminated union for all component types
 Component = Annotated[
     Reservoir
@@ -310,6 +316,9 @@ Component = Annotated[
     | HeatExchanger
     | Strainer
     | Orifice
-    | Sprinkler,
+    | Sprinkler
+    | IdealReferenceNode
+    | NonIdealReferenceNode
+    | Plug,
     Field(discriminator="type"),
 ]

--- a/apps/api/src/opensolve_pipe/models/plug.py
+++ b/apps/api/src/opensolve_pipe/models/plug.py
@@ -1,0 +1,97 @@
+"""Plug/Cap model for dead-end boundary conditions."""
+
+from typing import Literal
+
+from pydantic import Field, model_validator
+
+from .base import Elevation, OpenSolvePipeBaseModel
+from .piping import PipingSegment
+from .ports import Port, PortDirection
+
+
+class Connection(OpenSolvePipeBaseModel):
+    """Connection to a downstream component (legacy, included for base compatibility)."""
+
+    target_component_id: str = Field(description="ID of the downstream component")
+    piping: PipingSegment | None = Field(
+        default=None, description="Piping segment to downstream component"
+    )
+
+
+def create_plug_port(nominal_size: float = 4.0) -> list[Port]:
+    """Create a single bidirectional port for a plug component.
+
+    Args:
+        nominal_size: Nominal port size in project units
+
+    Returns:
+        List containing single Port object
+    """
+    return [
+        Port(
+            id="port_1",
+            nominal_size=nominal_size,
+            direction=PortDirection.BIDIRECTIONAL,
+        )
+    ]
+
+
+class Plug(OpenSolvePipeBaseModel):
+    """Plug/Cap component for dead-end boundary conditions.
+
+    A plug represents a closed end in the piping system. At a plug:
+    - Flow is always zero (Q = 0)
+    - Pressure is determined by the connected pipe network
+
+    Use cases:
+    - Dead-end branches in distribution systems
+    - Future expansion points (valve + plug)
+    - Temporary closures during maintenance modeling
+    - Capped tee branches
+    - Closed valve representation (alternative to valve with position=0)
+
+    Hydraulic behavior:
+    - The plug enforces a zero-flow boundary condition
+    - Pressure at the plug is calculated from the network solution
+    - Head loss through the plug is undefined (no flow path)
+    """
+
+    id: str = Field(description="Unique component identifier")
+    type: Literal["plug"] = "plug"
+    name: str = Field(description="Display name")
+    elevation: Elevation = Field(description="Component elevation (can be negative)")
+    ports: list[Port] = Field(
+        default_factory=list,
+        description="Connection ports for this component (single port)",
+    )
+    upstream_piping: PipingSegment | None = Field(
+        default=None, description="Piping from upstream component (deprecated)"
+    )
+    downstream_connections: list[Connection] = Field(
+        default_factory=list,
+        description="Connections to downstream components (deprecated, always empty for plug)",
+    )
+
+    @model_validator(mode="after")
+    def set_default_ports(self) -> "Plug":
+        """Set default ports if not provided."""
+        if not self.ports:
+            self.ports = create_plug_port()
+        return self
+
+    @model_validator(mode="after")
+    def validate_no_downstream(self) -> "Plug":
+        """Validate that plug has no downstream connections."""
+        if self.downstream_connections:
+            raise ValueError(
+                "Plug components cannot have downstream connections "
+                "(they represent closed ends)"
+            )
+        return self
+
+    def get_port(self, port_id: str) -> Port | None:
+        """Get a port by ID."""
+        for port in self.ports:
+            if port.id == port_id:
+                return port
+        return None

--- a/apps/api/src/opensolve_pipe/models/reference_node.py
+++ b/apps/api/src/opensolve_pipe/models/reference_node.py
@@ -1,0 +1,215 @@
+"""Reference node models for pressure boundary conditions."""
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from .base import (
+    Elevation,
+    NonNegativeFloat,
+    OpenSolvePipeBaseModel,
+    PositiveFloat,
+)
+from .piping import PipingSegment
+from .ports import Port, PortDirection
+
+
+class ReferenceType(str, Enum):
+    """Type of reference node."""
+
+    IDEAL = "ideal"
+    NON_IDEAL = "non_ideal"
+
+
+class FlowPressurePoint(OpenSolvePipeBaseModel):
+    """A point on a pressure-flow curve for non-ideal reference nodes."""
+
+    flow: NonNegativeFloat = Field(description="Flow rate in project units")
+    pressure: float = Field(description="Pressure at this flow in project units")
+
+
+class Connection(OpenSolvePipeBaseModel):
+    """Connection to a downstream component (legacy, included for base compatibility)."""
+
+    target_component_id: str = Field(description="ID of the downstream component")
+    piping: PipingSegment | None = Field(
+        default=None, description="Piping segment to downstream component"
+    )
+
+
+def create_reference_node_port(nominal_size: float = 4.0) -> list[Port]:
+    """Create a single bidirectional port for a reference node.
+
+    Args:
+        nominal_size: Nominal port size in project units
+
+    Returns:
+        List containing single Port object
+    """
+    return [
+        Port(
+            id="port_1",
+            nominal_size=nominal_size,
+            direction=PortDirection.BIDIRECTIONAL,
+        )
+    ]
+
+
+class BaseReferenceNode(OpenSolvePipeBaseModel):
+    """Base class for reference node components.
+
+    Reference nodes define pressure boundary conditions in the network.
+    They can be ideal (constant pressure) or non-ideal (pressure varies with flow).
+    """
+
+    id: str = Field(description="Unique component identifier")
+    name: str = Field(description="Display name")
+    elevation: Elevation = Field(description="Component elevation (can be negative)")
+    ports: list[Port] = Field(
+        default_factory=list,
+        description="Connection ports for this component",
+    )
+    upstream_piping: PipingSegment | None = Field(
+        default=None, description="Piping from upstream component (deprecated)"
+    )
+    downstream_connections: list[Connection] = Field(
+        default_factory=list,
+        description="Connections to downstream components (deprecated)",
+    )
+
+    def get_port(self, port_id: str) -> Port | None:
+        """Get a port by ID."""
+        for port in self.ports:
+            if port.id == port_id:
+                return port
+        return None
+
+
+class IdealReferenceNode(BaseReferenceNode):
+    """Ideal reference node with constant pressure regardless of flow.
+
+    An ideal reference node acts like an infinite reservoir - it maintains
+    a constant pressure regardless of how much flow is drawn from or
+    supplied to it.
+
+    Use cases:
+    - Constant pressure water supply
+    - Infinite source/sink
+    - Pressure regulator at known setpoint
+    """
+
+    type: Literal["ideal_reference_node"] = "ideal_reference_node"
+    pressure: float = Field(description="Fixed pressure in project units")
+
+    @model_validator(mode="after")
+    def set_default_ports(self) -> "IdealReferenceNode":
+        """Set default ports if not provided."""
+        if not self.ports:
+            self.ports = create_reference_node_port()
+        return self
+
+
+class NonIdealReferenceNode(BaseReferenceNode):
+    """Non-ideal reference node with pressure that varies with flow.
+
+    A non-ideal reference node represents a source/sink where pressure
+    depends on the flow rate. This is useful for modeling:
+    - Pressure regulators with droop
+    - Wells with drawdown curves
+    - Distribution system connections
+    - Fire hydrant flows
+
+    The pressure-flow curve defines the relationship between flow and
+    pressure at this boundary.
+    """
+
+    type: Literal["non_ideal_reference_node"] = "non_ideal_reference_node"
+    pressure_flow_curve: list[FlowPressurePoint] = Field(
+        description="Pressure-flow curve defining boundary behavior"
+    )
+    max_flow: PositiveFloat | None = Field(
+        default=None,
+        description="Maximum flow capacity (optional, for validation)",
+    )
+
+    @field_validator("pressure_flow_curve")
+    @classmethod
+    def validate_curve_has_points(
+        cls, v: list[FlowPressurePoint]
+    ) -> list[FlowPressurePoint]:
+        """Validate that curve has at least 2 points."""
+        if len(v) < 2:
+            raise ValueError(
+                "Pressure-flow curve must have at least 2 points for interpolation"
+            )
+        return v
+
+    @field_validator("pressure_flow_curve")
+    @classmethod
+    def validate_curve_sorted(
+        cls, v: list[FlowPressurePoint]
+    ) -> list[FlowPressurePoint]:
+        """Validate that curve points are sorted by flow."""
+        flows = [p.flow for p in v]
+        if flows != sorted(flows):
+            raise ValueError("Pressure-flow curve points must be sorted by flow")
+        return v
+
+    @model_validator(mode="after")
+    def set_default_ports(self) -> "NonIdealReferenceNode":
+        """Set default ports if not provided."""
+        if not self.ports:
+            self.ports = create_reference_node_port()
+        return self
+
+    def interpolate_pressure(self, flow: float) -> float:
+        """Interpolate pressure from curve at given flow.
+
+        Uses linear interpolation between curve points.
+        Extrapolates linearly if flow is outside curve range.
+
+        Args:
+            flow: Flow rate to interpolate pressure for
+
+        Returns:
+            Interpolated pressure value
+        """
+        if len(self.pressure_flow_curve) < 2:
+            if self.pressure_flow_curve:
+                return self.pressure_flow_curve[0].pressure
+            return 0.0
+
+        # Find bracketing points
+        for i in range(len(self.pressure_flow_curve) - 1):
+            p1 = self.pressure_flow_curve[i]
+            p2 = self.pressure_flow_curve[i + 1]
+
+            if p1.flow <= flow <= p2.flow:
+                # Linear interpolation
+                if p2.flow == p1.flow:
+                    return p1.pressure
+                t = (flow - p1.flow) / (p2.flow - p1.flow)
+                return p1.pressure + t * (p2.pressure - p1.pressure)
+
+        # Extrapolate if outside range
+        if flow < self.pressure_flow_curve[0].flow:
+            # Extrapolate from first two points
+            p1 = self.pressure_flow_curve[0]
+            p2 = self.pressure_flow_curve[1]
+            if p2.flow == p1.flow:
+                return p1.pressure
+            slope = (p2.pressure - p1.pressure) / (p2.flow - p1.flow)
+            return p1.pressure + slope * (flow - p1.flow)
+        else:
+            # Extrapolate from last two points
+            p1 = self.pressure_flow_curve[-2]
+            p2 = self.pressure_flow_curve[-1]
+            if p2.flow == p1.flow:
+                return p2.pressure
+            slope = (p2.pressure - p1.pressure) / (p2.flow - p1.flow)
+            return p2.pressure + slope * (flow - p2.flow)
+
+
+# Type alias for reference node union
+ReferenceNode = IdealReferenceNode | NonIdealReferenceNode

--- a/apps/api/tests/models/test_plug.py
+++ b/apps/api/tests/models/test_plug.py
@@ -1,0 +1,202 @@
+"""Tests for plug/cap model."""
+
+import pytest
+from pydantic import ValidationError
+
+from opensolve_pipe.models import PortDirection
+from opensolve_pipe.models.plug import Connection, Plug, create_plug_port
+
+
+class TestCreatePlugPort:
+    """Tests for plug port factory function."""
+
+    def test_create_default_port(self) -> None:
+        """Test creating default plug port."""
+        ports = create_plug_port()
+        assert len(ports) == 1
+        assert ports[0].id == "port_1"
+        assert ports[0].nominal_size == 4.0
+        assert ports[0].direction == PortDirection.BIDIRECTIONAL
+
+    def test_create_port_with_custom_size(self) -> None:
+        """Test creating plug port with custom size."""
+        ports = create_plug_port(nominal_size=2.0)
+        assert len(ports) == 1
+        assert ports[0].nominal_size == 2.0
+
+
+class TestPlug:
+    """Tests for Plug model."""
+
+    def test_create_plug(self) -> None:
+        """Test creating a valid plug component."""
+        plug = Plug(
+            id="plug_1",
+            name="Dead End Cap",
+            elevation=10.0,
+        )
+        assert plug.id == "plug_1"
+        assert plug.name == "Dead End Cap"
+        assert plug.elevation == 10.0
+        assert plug.type == "plug"
+
+    def test_plug_default_ports(self) -> None:
+        """Test that plug gets default ports."""
+        plug = Plug(
+            id="plug_1",
+            name="Cap",
+            elevation=0.0,
+        )
+        assert len(plug.ports) == 1
+        assert plug.ports[0].id == "port_1"
+        assert plug.ports[0].direction == PortDirection.BIDIRECTIONAL
+
+    def test_plug_custom_ports(self) -> None:
+        """Test that custom ports are preserved."""
+        custom_ports = create_plug_port(nominal_size=6.0)
+        plug = Plug(
+            id="plug_1",
+            name="Cap",
+            elevation=0.0,
+            ports=custom_ports,
+        )
+        assert len(plug.ports) == 1
+        assert plug.ports[0].nominal_size == 6.0
+
+    def test_plug_negative_elevation(self) -> None:
+        """Test plug with negative elevation."""
+        plug = Plug(
+            id="plug_1",
+            name="Underground Cap",
+            elevation=-5.0,
+        )
+        assert plug.elevation == -5.0
+
+    def test_plug_no_downstream_connections(self) -> None:
+        """Test that plug rejects downstream connections."""
+        with pytest.raises(ValidationError) as exc_info:
+            Plug(
+                id="plug_1",
+                name="Invalid Plug",
+                elevation=0.0,
+                downstream_connections=[
+                    Connection(target_component_id="junction_1"),
+                ],
+            )
+        assert "cannot have downstream connections" in str(exc_info.value)
+
+    def test_plug_empty_downstream_connections_allowed(self) -> None:
+        """Test that empty downstream connections list is allowed."""
+        plug = Plug(
+            id="plug_1",
+            name="Valid Plug",
+            elevation=0.0,
+            downstream_connections=[],
+        )
+        assert plug.downstream_connections == []
+
+    def test_plug_get_port(self) -> None:
+        """Test get_port method."""
+        plug = Plug(
+            id="plug_1",
+            name="Cap",
+            elevation=0.0,
+        )
+        port = plug.get_port("port_1")
+        assert port is not None
+        assert port.id == "port_1"
+
+        # Non-existent port
+        assert plug.get_port("port_2") is None
+
+
+class TestPlugSerialization:
+    """Tests for plug serialization/deserialization."""
+
+    def test_plug_roundtrip(self) -> None:
+        """Test plug serializes and deserializes correctly."""
+        plug = Plug(
+            id="plug_1",
+            name="Dead End",
+            elevation=15.0,
+        )
+        data = plug.model_dump()
+        restored = Plug.model_validate(data)
+
+        assert restored.id == plug.id
+        assert restored.name == plug.name
+        assert restored.elevation == plug.elevation
+        assert restored.type == "plug"
+        assert len(restored.ports) == 1
+
+    def test_plug_json_roundtrip(self) -> None:
+        """Test plug JSON serialization."""
+        plug = Plug(
+            id="plug_1",
+            name="Cap",
+            elevation=0.0,
+        )
+        json_str = plug.model_dump_json()
+        restored = Plug.model_validate_json(json_str)
+
+        assert restored.id == plug.id
+        assert restored.type == "plug"
+
+    def test_plug_with_custom_ports_roundtrip(self) -> None:
+        """Test plug with custom ports serializes correctly."""
+        custom_ports = create_plug_port(nominal_size=8.0)
+        plug = Plug(
+            id="plug_1",
+            name="Large Cap",
+            elevation=0.0,
+            ports=custom_ports,
+        )
+        data = plug.model_dump()
+        restored = Plug.model_validate(data)
+
+        assert len(restored.ports) == 1
+        assert restored.ports[0].nominal_size == 8.0
+
+
+class TestPlugInComponentUnion:
+    """Tests for plug as part of Component discriminated union."""
+
+    def test_plug_in_component_list(self) -> None:
+        """Test plug can be used in a component list."""
+        from opensolve_pipe.models import Component, ComponentType, Junction
+
+        components: list[Component] = [
+            Junction(
+                id="junction_1",
+                name="Tee Branch",
+                elevation=10.0,
+            ),
+            Plug(
+                id="plug_1",
+                name="Capped Branch",
+                elevation=10.0,
+            ),
+        ]
+        assert len(components) == 2
+        assert components[0].type == ComponentType.JUNCTION
+        assert components[1].type == "plug"
+
+    def test_plug_discriminated_union_parsing(self) -> None:
+        """Test plug is correctly parsed from dict via discriminated union."""
+        from pydantic import TypeAdapter
+
+        from opensolve_pipe.models import Component
+
+        adapter: TypeAdapter[Component] = TypeAdapter(Component)
+
+        data = {
+            "id": "plug_1",
+            "type": "plug",
+            "name": "Dead End",
+            "elevation": 5.0,
+        }
+        component = adapter.validate_python(data)
+
+        assert isinstance(component, Plug)
+        assert component.id == "plug_1"
+        assert component.type == "plug"

--- a/apps/api/tests/models/test_reference_node.py
+++ b/apps/api/tests/models/test_reference_node.py
@@ -1,0 +1,357 @@
+"""Tests for reference node models."""
+
+import pytest
+from pydantic import ValidationError
+
+from opensolve_pipe.models import (
+    FlowPressurePoint,
+    IdealReferenceNode,
+    NonIdealReferenceNode,
+    PortDirection,
+    create_reference_node_port,
+)
+
+
+class TestFlowPressurePoint:
+    """Tests for FlowPressurePoint model."""
+
+    def test_create_flow_pressure_point(self) -> None:
+        """Test creating a valid flow-pressure point."""
+        point = FlowPressurePoint(flow=100.0, pressure=50.0)
+        assert point.flow == 100.0
+        assert point.pressure == 50.0
+
+    def test_flow_pressure_point_zero_flow(self) -> None:
+        """Test flow-pressure point with zero flow."""
+        point = FlowPressurePoint(flow=0.0, pressure=60.0)
+        assert point.flow == 0.0
+        assert point.pressure == 60.0
+
+    def test_flow_pressure_point_negative_pressure(self) -> None:
+        """Test flow-pressure point allows negative pressure (vacuum)."""
+        point = FlowPressurePoint(flow=50.0, pressure=-10.0)
+        assert point.pressure == -10.0
+
+    def test_flow_pressure_point_negative_flow_rejected(self) -> None:
+        """Test that negative flow is rejected."""
+        with pytest.raises(ValidationError):
+            FlowPressurePoint(flow=-10.0, pressure=50.0)
+
+
+class TestCreateReferenceNodePort:
+    """Tests for reference node port factory function."""
+
+    def test_create_default_port(self) -> None:
+        """Test creating default reference node port."""
+        ports = create_reference_node_port()
+        assert len(ports) == 1
+        assert ports[0].id == "port_1"
+        assert ports[0].nominal_size == 4.0
+        assert ports[0].direction == PortDirection.BIDIRECTIONAL
+
+    def test_create_port_with_custom_size(self) -> None:
+        """Test creating reference node port with custom size."""
+        ports = create_reference_node_port(nominal_size=6.0)
+        assert len(ports) == 1
+        assert ports[0].nominal_size == 6.0
+
+
+class TestIdealReferenceNode:
+    """Tests for IdealReferenceNode model."""
+
+    def test_create_ideal_reference_node(self) -> None:
+        """Test creating a valid ideal reference node."""
+        node = IdealReferenceNode(
+            id="ref_1",
+            name="City Water Supply",
+            elevation=100.0,
+            pressure=60.0,
+        )
+        assert node.id == "ref_1"
+        assert node.name == "City Water Supply"
+        assert node.elevation == 100.0
+        assert node.pressure == 60.0
+        assert node.type == "ideal_reference_node"
+
+    def test_ideal_reference_node_default_ports(self) -> None:
+        """Test that ideal reference node gets default ports."""
+        node = IdealReferenceNode(
+            id="ref_1",
+            name="Supply",
+            elevation=0.0,
+            pressure=50.0,
+        )
+        assert len(node.ports) == 1
+        assert node.ports[0].id == "port_1"
+        assert node.ports[0].direction == PortDirection.BIDIRECTIONAL
+
+    def test_ideal_reference_node_custom_ports(self) -> None:
+        """Test that custom ports are preserved."""
+        custom_ports = create_reference_node_port(nominal_size=8.0)
+        node = IdealReferenceNode(
+            id="ref_1",
+            name="Supply",
+            elevation=0.0,
+            pressure=50.0,
+            ports=custom_ports,
+        )
+        assert len(node.ports) == 1
+        assert node.ports[0].nominal_size == 8.0
+
+    def test_ideal_reference_node_negative_elevation(self) -> None:
+        """Test ideal reference node with negative elevation."""
+        node = IdealReferenceNode(
+            id="ref_1",
+            name="Underground Supply",
+            elevation=-10.0,
+            pressure=50.0,
+        )
+        assert node.elevation == -10.0
+
+    def test_ideal_reference_node_negative_pressure(self) -> None:
+        """Test ideal reference node allows negative pressure (vacuum)."""
+        node = IdealReferenceNode(
+            id="ref_1",
+            name="Vacuum Source",
+            elevation=0.0,
+            pressure=-5.0,
+        )
+        assert node.pressure == -5.0
+
+    def test_ideal_reference_node_get_port(self) -> None:
+        """Test get_port method."""
+        node = IdealReferenceNode(
+            id="ref_1",
+            name="Supply",
+            elevation=0.0,
+            pressure=50.0,
+        )
+        port = node.get_port("port_1")
+        assert port is not None
+        assert port.id == "port_1"
+
+        # Non-existent port
+        assert node.get_port("port_2") is None
+
+
+class TestNonIdealReferenceNode:
+    """Tests for NonIdealReferenceNode model."""
+
+    def test_create_non_ideal_reference_node(self) -> None:
+        """Test creating a valid non-ideal reference node."""
+        curve = [
+            FlowPressurePoint(flow=0.0, pressure=60.0),
+            FlowPressurePoint(flow=100.0, pressure=55.0),
+            FlowPressurePoint(flow=200.0, pressure=45.0),
+        ]
+        node = NonIdealReferenceNode(
+            id="ref_1",
+            name="City Main with Droop",
+            elevation=100.0,
+            pressure_flow_curve=curve,
+        )
+        assert node.id == "ref_1"
+        assert node.type == "non_ideal_reference_node"
+        assert len(node.pressure_flow_curve) == 3
+
+    def test_non_ideal_reference_node_default_ports(self) -> None:
+        """Test that non-ideal reference node gets default ports."""
+        curve = [
+            FlowPressurePoint(flow=0.0, pressure=60.0),
+            FlowPressurePoint(flow=100.0, pressure=50.0),
+        ]
+        node = NonIdealReferenceNode(
+            id="ref_1",
+            name="Supply",
+            elevation=0.0,
+            pressure_flow_curve=curve,
+        )
+        assert len(node.ports) == 1
+        assert node.ports[0].direction == PortDirection.BIDIRECTIONAL
+
+    def test_non_ideal_reference_node_with_max_flow(self) -> None:
+        """Test non-ideal reference node with max flow limit."""
+        curve = [
+            FlowPressurePoint(flow=0.0, pressure=60.0),
+            FlowPressurePoint(flow=100.0, pressure=50.0),
+        ]
+        node = NonIdealReferenceNode(
+            id="ref_1",
+            name="Limited Supply",
+            elevation=0.0,
+            pressure_flow_curve=curve,
+            max_flow=150.0,
+        )
+        assert node.max_flow == 150.0
+
+    def test_non_ideal_curve_requires_two_points(self) -> None:
+        """Test that curve requires at least 2 points."""
+        with pytest.raises(ValidationError) as exc_info:
+            NonIdealReferenceNode(
+                id="ref_1",
+                name="Invalid",
+                elevation=0.0,
+                pressure_flow_curve=[
+                    FlowPressurePoint(flow=0.0, pressure=60.0),
+                ],
+            )
+        assert "at least 2 points" in str(exc_info.value)
+
+    def test_non_ideal_curve_must_be_sorted(self) -> None:
+        """Test that curve points must be sorted by flow."""
+        with pytest.raises(ValidationError) as exc_info:
+            NonIdealReferenceNode(
+                id="ref_1",
+                name="Invalid",
+                elevation=0.0,
+                pressure_flow_curve=[
+                    FlowPressurePoint(flow=100.0, pressure=50.0),
+                    FlowPressurePoint(flow=0.0, pressure=60.0),  # Out of order
+                ],
+            )
+        assert "sorted by flow" in str(exc_info.value)
+
+
+class TestNonIdealReferenceNodeInterpolation:
+    """Tests for pressure interpolation on non-ideal reference nodes."""
+
+    @pytest.fixture
+    def linear_curve_node(self) -> NonIdealReferenceNode:
+        """Create a node with a linear pressure-flow curve."""
+        curve = [
+            FlowPressurePoint(flow=0.0, pressure=60.0),
+            FlowPressurePoint(flow=100.0, pressure=50.0),
+            FlowPressurePoint(flow=200.0, pressure=40.0),
+        ]
+        return NonIdealReferenceNode(
+            id="ref_1",
+            name="Linear Droop",
+            elevation=0.0,
+            pressure_flow_curve=curve,
+        )
+
+    def test_interpolate_at_curve_points(
+        self, linear_curve_node: NonIdealReferenceNode
+    ) -> None:
+        """Test interpolation exactly at curve points."""
+        assert linear_curve_node.interpolate_pressure(0.0) == 60.0
+        assert linear_curve_node.interpolate_pressure(100.0) == 50.0
+        assert linear_curve_node.interpolate_pressure(200.0) == 40.0
+
+    def test_interpolate_between_points(
+        self, linear_curve_node: NonIdealReferenceNode
+    ) -> None:
+        """Test linear interpolation between curve points."""
+        # Midpoint between first two points
+        assert linear_curve_node.interpolate_pressure(50.0) == pytest.approx(55.0)
+        # Midpoint between last two points
+        assert linear_curve_node.interpolate_pressure(150.0) == pytest.approx(45.0)
+
+    def test_extrapolate_below_range(
+        self, linear_curve_node: NonIdealReferenceNode
+    ) -> None:
+        """Test extrapolation below curve range."""
+        # Linear extrapolation from first two points
+        # slope = (50 - 60) / (100 - 0) = -0.1
+        # pressure = 60 + (-0.1) * (-50) = 65
+        assert linear_curve_node.interpolate_pressure(-50.0) == pytest.approx(65.0)
+
+    def test_extrapolate_above_range(
+        self, linear_curve_node: NonIdealReferenceNode
+    ) -> None:
+        """Test extrapolation above curve range."""
+        # Linear extrapolation from last two points
+        # slope = (40 - 50) / (200 - 100) = -0.1
+        # pressure = 40 + (-0.1) * (50) = 35
+        assert linear_curve_node.interpolate_pressure(250.0) == pytest.approx(35.0)
+
+    def test_interpolate_with_two_point_curve(self) -> None:
+        """Test interpolation with minimum valid curve (2 points)."""
+        node = NonIdealReferenceNode(
+            id="ref_1",
+            name="Two Point",
+            elevation=0.0,
+            pressure_flow_curve=[
+                FlowPressurePoint(flow=0.0, pressure=100.0),
+                FlowPressurePoint(flow=100.0, pressure=80.0),
+            ],
+        )
+        assert node.interpolate_pressure(50.0) == pytest.approx(90.0)
+
+    def test_interpolate_non_linear_curve(self) -> None:
+        """Test interpolation with non-linear curve."""
+        node = NonIdealReferenceNode(
+            id="ref_1",
+            name="Non-linear",
+            elevation=0.0,
+            pressure_flow_curve=[
+                FlowPressurePoint(flow=0.0, pressure=60.0),
+                FlowPressurePoint(flow=50.0, pressure=58.0),
+                FlowPressurePoint(flow=100.0, pressure=50.0),
+            ],
+        )
+        # Between first two points (0, 60) and (50, 58)
+        # slope = -2/50 = -0.04
+        # at flow=25: pressure = 60 + (-0.04) * 25 = 59
+        assert node.interpolate_pressure(25.0) == pytest.approx(59.0)
+
+        # Between last two points (50, 58) and (100, 50)
+        # slope = -8/50 = -0.16
+        # at flow=75: pressure = 58 + (-0.16) * 25 = 54
+        assert node.interpolate_pressure(75.0) == pytest.approx(54.0)
+
+
+class TestReferenceNodeSerialization:
+    """Tests for reference node serialization/deserialization."""
+
+    def test_ideal_reference_node_roundtrip(self) -> None:
+        """Test ideal reference node serializes and deserializes correctly."""
+        node = IdealReferenceNode(
+            id="ref_1",
+            name="Supply",
+            elevation=100.0,
+            pressure=60.0,
+        )
+        data = node.model_dump()
+        restored = IdealReferenceNode.model_validate(data)
+
+        assert restored.id == node.id
+        assert restored.name == node.name
+        assert restored.elevation == node.elevation
+        assert restored.pressure == node.pressure
+        assert restored.type == "ideal_reference_node"
+
+    def test_non_ideal_reference_node_roundtrip(self) -> None:
+        """Test non-ideal reference node serializes and deserializes correctly."""
+        node = NonIdealReferenceNode(
+            id="ref_1",
+            name="City Main",
+            elevation=50.0,
+            pressure_flow_curve=[
+                FlowPressurePoint(flow=0.0, pressure=60.0),
+                FlowPressurePoint(flow=100.0, pressure=50.0),
+            ],
+            max_flow=200.0,
+        )
+        data = node.model_dump()
+        restored = NonIdealReferenceNode.model_validate(data)
+
+        assert restored.id == node.id
+        assert restored.name == node.name
+        assert len(restored.pressure_flow_curve) == 2
+        assert restored.max_flow == 200.0
+        assert restored.type == "non_ideal_reference_node"
+
+    def test_ideal_reference_node_json_roundtrip(self) -> None:
+        """Test ideal reference node JSON serialization."""
+        node = IdealReferenceNode(
+            id="ref_1",
+            name="Supply",
+            elevation=100.0,
+            pressure=60.0,
+        )
+        json_str = node.model_dump_json()
+        restored = IdealReferenceNode.model_validate_json(json_str)
+
+        assert restored.id == node.id
+        assert restored.pressure == node.pressure

--- a/docs/plans/issue-59-plan.md
+++ b/docs/plans/issue-59-plan.md
@@ -1,0 +1,47 @@
+# Implementation Plan: Issue #59 - Backend Reference Node and Plug Components
+
+## Summary
+
+Implement Reference Node and Plug/Cap components for defining boundary conditions in the network.
+
+## Tasks
+
+### 1. Reference Node Models (`apps/api/src/opensolve_pipe/models/reference_node.py`)
+
+- [x] Define `FlowPressurePoint` model for curve data
+- [x] Define `ReferenceNode` base model with single port
+- [x] Define `IdealReferenceNode` model (fixed pressure boundary)
+- [x] Define `NonIdealReferenceNode` model (pressure-flow curve)
+- [x] Add `ReferenceType` enum (IDEAL, NON_IDEAL)
+- [x] Add port factory function for reference nodes
+
+### 2. Plug Model (`apps/api/src/opensolve_pipe/models/plug.py`)
+
+- [x] Define `Plug` model with single port (zero flow boundary)
+- [x] Add port factory function for plug
+
+### 3. Update Component Types
+
+- [x] Add IDEAL_REFERENCE_NODE and NON_IDEAL_REFERENCE_NODE to ComponentType enum
+- [x] Add PLUG to ComponentType enum
+- [x] Add to discriminated union in components.py
+- [x] Update __init__.py exports
+
+### 4. Write Unit Tests
+
+- [x] Test reference node model creation and validation
+- [x] Test plug model creation and validation
+- [x] Test port configurations for both components
+- [x] Test pressure-flow curve validation for non-ideal nodes
+
+## Dependencies
+
+- Issue #58 (Port-Based Architecture) - REQUIRED
+
+## Acceptance Criteria
+
+- [x] Reference nodes have single bidirectional port
+- [x] Ideal reference node can specify fixed pressure
+- [x] Non-ideal reference node can specify pressure-flow curve
+- [x] Plug enforces zero flow at connected port
+- [x] All models serialize/deserialize correctly


### PR DESCRIPTION
## Summary

Implements Issue #59 - Backend Reference Node and Plug Components for defining boundary conditions in the network.

## Changes

### Reference Nodes
- **IdealReferenceNode**: Constant pressure boundary condition (like an infinite reservoir)
- **NonIdealReferenceNode**: Pressure varies with flow via a pressure-flow curve with linear interpolation
- **FlowPressurePoint** model for curve data points
- Curve validation: requires ≥2 points, sorted by flow

### Plug
- Dead-end boundary condition (zero flow)
- Validates that downstream connections are not allowed
- Single bidirectional port

### Component Integration
- Added `IDEAL_REFERENCE_NODE`, `NON_IDEAL_REFERENCE_NODE`, and `PLUG` to ComponentType enum
- Added to Component discriminated union
- Exported all new models from __init__.py

## Test Plan
- [x] 40 new unit tests covering:
  - Model creation and validation
  - Port configurations
  - Pressure-flow curve validation
  - Interpolation/extrapolation
  - Serialization roundtrips
  - Discriminated union parsing
- [x] All 542 tests pass
- [x] Linting passes (ruff check/format)
- [x] Type checking passes (mypy)

## Dependencies
- Depends on PR #64 (Port-Based Architecture)

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)