### PR TITLE
feat(models): add branch components (tee, wye, cross)

### DIFF
--- a/apps/api/src/opensolve_pipe/models/__init__.py
+++ b/apps/api/src/opensolve_pipe/models/__init__.py
@@ -19,6 +19,17 @@ from .base import (
     Temperature,
     Velocity,
 )
+from .branch import (
+    BaseBranch,
+    Branch,
+    BranchType,
+    CrossBranch,
+    TeeBranch,
+    WyeBranch,
+    create_cross_ports,
+    create_tee_ports,
+    create_wye_ports,
+)
 from .components import (
     BaseComponent,
     Component,
@@ -89,13 +100,17 @@ from .results import (
 from .units import SolverOptions, UnitPreferences, UnitSystem
 
 __all__ = [
+    "BaseBranch",
     "BaseComponent",
     "BaseReferenceNode",
+    "Branch",
+    "BranchType",
     "Component",
     "ComponentResult",
     "ComponentType",
     "Connection",
     "ConnectionBuilder",
+    "CrossBranch",
     "Diameter",
     "Elevation",
     "Fitting",
@@ -145,6 +160,7 @@ __all__ = [
     "Sprinkler",
     "Strainer",
     "Tank",
+    "TeeBranch",
     "Temperature",
     "UnitPreferences",
     "UnitSystem",
@@ -154,6 +170,8 @@ __all__ = [
     "Warning",
     "WarningCategory",
     "WarningSeverity",
+    "WyeBranch",
+    "create_cross_ports",
     "create_heat_exchanger_ports",
     "create_junction_ports",
     "create_orifice_ports",
@@ -164,7 +182,9 @@ __all__ = [
     "create_sprinkler_ports",
     "create_strainer_ports",
     "create_tank_ports",
+    "create_tee_ports",
     "create_valve_ports",
+    "create_wye_ports",
     "validate_connection",
     "validate_port_direction_compatibility",
     "validate_port_size_compatibility",

--- a/apps/api/src/opensolve_pipe/models/branch.py
+++ b/apps/api/src/opensolve_pipe/models/branch.py
@@ -1,0 +1,331 @@
+"""Branch models for flow splitting/combining components.
+
+Branch components (tees, wyes, crosses) allow flow to split or combine
+at specific points in the network. They have multiple ports and handle
+the hydraulic relationships between the connected flows.
+"""
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import Field, field_validator, model_validator
+
+from .base import (
+    Elevation,
+    OpenSolvePipeBaseModel,
+    PositiveFloat,
+)
+from .piping import PipingSegment
+from .ports import Port, PortDirection
+
+
+class BranchType(str, Enum):
+    """Type of branch fitting."""
+
+    TEE = "tee"
+    WYE = "wye"
+    CROSS = "cross"
+
+
+class Connection(OpenSolvePipeBaseModel):
+    """Connection to a downstream component (legacy, for base compatibility)."""
+
+    target_component_id: str = Field(description="ID of the downstream component")
+    piping: PipingSegment | None = Field(
+        default=None, description="Piping segment to downstream component"
+    )
+
+
+def create_tee_ports(
+    run_size: float = 4.0,
+    branch_size: float | None = None,
+) -> list[Port]:
+    """Create ports for a tee branch component.
+
+    Tees have three ports:
+    - run_inlet: Main line inlet (bidirectional for flow reversals)
+    - run_outlet: Main line outlet (bidirectional for flow reversals)
+    - branch: Branch connection (bidirectional)
+
+    The branch can be the same size as the run (standard tee) or
+    smaller (reducing tee).
+
+    Args:
+        run_size: Nominal size of the run (main line) ports
+        branch_size: Nominal size of the branch port (defaults to run_size)
+
+    Returns:
+        List of three Port objects
+    """
+    if branch_size is None:
+        branch_size = run_size
+
+    return [
+        Port(
+            id="run_inlet",
+            nominal_size=run_size,
+            direction=PortDirection.BIDIRECTIONAL,
+        ),
+        Port(
+            id="run_outlet",
+            nominal_size=run_size,
+            direction=PortDirection.BIDIRECTIONAL,
+        ),
+        Port(
+            id="branch",
+            nominal_size=branch_size,
+            direction=PortDirection.BIDIRECTIONAL,
+        ),
+    ]
+
+
+def create_wye_ports(
+    run_size: float = 4.0,
+    branch_size: float | None = None,
+) -> list[Port]:
+    """Create ports for a wye branch component.
+
+    Wyes have three ports:
+    - run_inlet: Main line inlet
+    - run_outlet: Main line outlet
+    - branch: Branch at an angle (typically 45°)
+
+    Args:
+        run_size: Nominal size of the run ports
+        branch_size: Nominal size of the branch port (defaults to run_size)
+
+    Returns:
+        List of three Port objects
+    """
+    if branch_size is None:
+        branch_size = run_size
+
+    return [
+        Port(
+            id="run_inlet",
+            nominal_size=run_size,
+            direction=PortDirection.BIDIRECTIONAL,
+        ),
+        Port(
+            id="run_outlet",
+            nominal_size=run_size,
+            direction=PortDirection.BIDIRECTIONAL,
+        ),
+        Port(
+            id="branch",
+            nominal_size=branch_size,
+            direction=PortDirection.BIDIRECTIONAL,
+        ),
+    ]
+
+
+def create_cross_ports(
+    main_size: float = 4.0,
+    branch_size: float | None = None,
+) -> list[Port]:
+    """Create ports for a cross branch component.
+
+    Crosses have four ports arranged in two perpendicular lines:
+    - run_inlet: Main line inlet
+    - run_outlet: Main line outlet
+    - branch_1: First branch (perpendicular to run)
+    - branch_2: Second branch (opposite to branch_1)
+
+    Args:
+        main_size: Nominal size of the main run ports
+        branch_size: Nominal size of branch ports (defaults to main_size)
+
+    Returns:
+        List of four Port objects
+    """
+    if branch_size is None:
+        branch_size = main_size
+
+    return [
+        Port(
+            id="run_inlet",
+            nominal_size=main_size,
+            direction=PortDirection.BIDIRECTIONAL,
+        ),
+        Port(
+            id="run_outlet",
+            nominal_size=main_size,
+            direction=PortDirection.BIDIRECTIONAL,
+        ),
+        Port(
+            id="branch_1",
+            nominal_size=branch_size,
+            direction=PortDirection.BIDIRECTIONAL,
+        ),
+        Port(
+            id="branch_2",
+            nominal_size=branch_size,
+            direction=PortDirection.BIDIRECTIONAL,
+        ),
+    ]
+
+
+class BaseBranch(OpenSolvePipeBaseModel):
+    """Base class for branch components.
+
+    Branch components allow flow to split or combine at specific points
+    in the network. They have multiple ports and the flow direction
+    determines whether flow is diverging or converging.
+    """
+
+    id: str = Field(description="Unique component identifier")
+    name: str = Field(description="Display name")
+    elevation: Elevation = Field(description="Component elevation (can be negative)")
+    ports: list[Port] = Field(
+        default_factory=list,
+        description="Connection ports for this component",
+    )
+    upstream_piping: PipingSegment | None = Field(
+        default=None, description="Piping from upstream component (deprecated)"
+    )
+    downstream_connections: list[Connection] = Field(
+        default_factory=list,
+        description="Connections to downstream components (deprecated)",
+    )
+
+    def get_port(self, port_id: str) -> Port | None:
+        """Get a port by ID."""
+        for port in self.ports:
+            if port.id == port_id:
+                return port
+        return None
+
+    def get_run_ports(self) -> list[Port]:
+        """Get the main run ports."""
+        return [p for p in self.ports if p.id.startswith("run_")]
+
+    def get_branch_ports(self) -> list[Port]:
+        """Get the branch ports."""
+        return [p for p in self.ports if p.id.startswith("branch")]
+
+
+class TeeBranch(BaseBranch):
+    """Tee branch for 90° flow splitting/combining.
+
+    A tee has three ports:
+    - run_inlet: Main line inlet
+    - run_outlet: Main line outlet (straight through)
+    - branch: 90° branch connection
+
+    Flow can either:
+    - Diverge: Flow enters run_inlet, splits to run_outlet and branch
+    - Converge: Flow enters run_inlet and branch, combines to run_outlet
+    - Through: Flow passes through run_inlet to run_outlet, branch blocked
+
+    K-factors are calculated based on Crane TP-410:
+    - Branch flow (diverging): K = 60 * f_T
+    - Run flow (through): K = 20 * f_T
+    - Converging flow: K varies with flow ratio
+
+    Hydraulic properties:
+    - Reduced branch size increases K by factor (D_run/D_branch)^4
+    - Screwed fittings use Equation 2-7 K values
+    - Flanged/welded fittings use Equation 2-8 K values
+    """
+
+    type: Literal["tee_branch"] = "tee_branch"
+    branch_angle: float = Field(
+        default=90.0,
+        ge=45.0,
+        le=90.0,
+        description="Branch angle in degrees (standard tee is 90°)",
+    )
+
+    @model_validator(mode="after")
+    def set_default_ports(self) -> "TeeBranch":
+        """Set default ports if not provided."""
+        if not self.ports:
+            self.ports = create_tee_ports()
+        return self
+
+    @field_validator("ports")
+    @classmethod
+    def validate_port_count(cls, v: list[Port]) -> list[Port]:
+        """Validate tee has exactly 3 ports."""
+        if v and len(v) != 3:
+            raise ValueError("TeeBranch must have exactly 3 ports")
+        return v
+
+
+class WyeBranch(BaseBranch):
+    """Wye branch for angled flow splitting/combining.
+
+    A wye has three ports like a tee, but the branch is at an angle
+    (typically 45°) rather than 90°. This results in lower head loss
+    for branch flow compared to a standard tee.
+
+    Flow patterns are similar to a tee but with different K-factors
+    due to the smoother flow transition.
+
+    Hydraulic properties:
+    - Lower K-factors than tee due to gradual angle change
+    - Commonly used in drainage systems
+    - Available in various angles: 45°, 60°, etc.
+    """
+
+    type: Literal["wye_branch"] = "wye_branch"
+    branch_angle: PositiveFloat = Field(
+        default=45.0,
+        ge=22.5,
+        le=60.0,
+        description="Branch angle in degrees (common values: 45°, 60°)",
+    )
+
+    @model_validator(mode="after")
+    def set_default_ports(self) -> "WyeBranch":
+        """Set default ports if not provided."""
+        if not self.ports:
+            self.ports = create_wye_ports()
+        return self
+
+    @field_validator("ports")
+    @classmethod
+    def validate_port_count(cls, v: list[Port]) -> list[Port]:
+        """Validate wye has exactly 3 ports."""
+        if v and len(v) != 3:
+            raise ValueError("WyeBranch must have exactly 3 ports")
+        return v
+
+
+class CrossBranch(BaseBranch):
+    """Cross fitting for four-way flow distribution.
+
+    A cross has four ports arranged in two perpendicular lines:
+    - run_inlet/run_outlet: Main line (straight through)
+    - branch_1/branch_2: Perpendicular branches
+
+    Flow can split from one inlet to multiple outlets, or combine
+    from multiple inlets to one outlet. The hydraulic analysis
+    depends on the specific flow configuration.
+
+    Hydraulic properties:
+    - More complex than tee due to additional flow paths
+    - K-factors depend on flow split ratios
+    - Less common in pressure piping, more common in distribution
+    """
+
+    type: Literal["cross_branch"] = "cross_branch"
+
+    @model_validator(mode="after")
+    def set_default_ports(self) -> "CrossBranch":
+        """Set default ports if not provided."""
+        if not self.ports:
+            self.ports = create_cross_ports()
+        return self
+
+    @field_validator("ports")
+    @classmethod
+    def validate_port_count(cls, v: list[Port]) -> list[Port]:
+        """Validate cross has exactly 4 ports."""
+        if v and len(v) != 4:
+            raise ValueError("CrossBranch must have exactly 4 ports")
+        return v
+
+
+# Type alias for branch union
+Branch = TeeBranch | WyeBranch | CrossBranch

--- a/apps/api/src/opensolve_pipe/models/components.py
+++ b/apps/api/src/opensolve_pipe/models/components.py
@@ -42,6 +42,9 @@ class ComponentType(str, Enum):
     IDEAL_REFERENCE_NODE = "ideal_reference_node"
     NON_IDEAL_REFERENCE_NODE = "non_ideal_reference_node"
     PLUG = "plug"
+    TEE_BRANCH = "tee_branch"
+    WYE_BRANCH = "wye_branch"
+    CROSS_BRANCH = "cross_branch"
 
 
 class ValveType(str, Enum):
@@ -303,6 +306,7 @@ class Sprinkler(BaseComponent):
         return self
 
 
+from .branch import CrossBranch, TeeBranch, WyeBranch  # noqa: E402
 from .plug import Plug  # noqa: E402
 from .reference_node import IdealReferenceNode, NonIdealReferenceNode  # noqa: E402
 
@@ -319,6 +323,9 @@ Component = Annotated[
     | Sprinkler
     | IdealReferenceNode
     | NonIdealReferenceNode
-    | Plug,
+    | Plug
+    | TeeBranch
+    | WyeBranch
+    | CrossBranch,
     Field(discriminator="type"),
 ]

--- a/apps/api/tests/models/test_branch.py
+++ b/apps/api/tests/models/test_branch.py
@@ -1,0 +1,446 @@
+"""Tests for branch models."""
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from opensolve_pipe.models import (
+    BranchType,
+    Component,
+    CrossBranch,
+    PortDirection,
+    TeeBranch,
+    WyeBranch,
+    create_cross_ports,
+    create_tee_ports,
+    create_wye_ports,
+)
+
+
+class TestCreateTeePorts:
+    """Tests for tee port factory function."""
+
+    def test_create_default_ports(self) -> None:
+        """Test creating default tee ports."""
+        ports = create_tee_ports()
+        assert len(ports) == 3
+        assert ports[0].id == "run_inlet"
+        assert ports[1].id == "run_outlet"
+        assert ports[2].id == "branch"
+        assert all(p.nominal_size == 4.0 for p in ports)
+        assert all(p.direction == PortDirection.BIDIRECTIONAL for p in ports)
+
+    def test_create_ports_with_custom_run_size(self) -> None:
+        """Test creating tee ports with custom run size."""
+        ports = create_tee_ports(run_size=6.0)
+        assert ports[0].nominal_size == 6.0
+        assert ports[1].nominal_size == 6.0
+        assert ports[2].nominal_size == 6.0  # Branch defaults to run size
+
+    def test_create_reducing_tee(self) -> None:
+        """Test creating reducing tee ports."""
+        ports = create_tee_ports(run_size=6.0, branch_size=4.0)
+        assert ports[0].nominal_size == 6.0  # run_inlet
+        assert ports[1].nominal_size == 6.0  # run_outlet
+        assert ports[2].nominal_size == 4.0  # branch (smaller)
+
+
+class TestCreateWyePorts:
+    """Tests for wye port factory function."""
+
+    def test_create_default_ports(self) -> None:
+        """Test creating default wye ports."""
+        ports = create_wye_ports()
+        assert len(ports) == 3
+        assert ports[0].id == "run_inlet"
+        assert ports[1].id == "run_outlet"
+        assert ports[2].id == "branch"
+
+    def test_create_reducing_wye(self) -> None:
+        """Test creating reducing wye ports."""
+        ports = create_wye_ports(run_size=8.0, branch_size=4.0)
+        assert ports[0].nominal_size == 8.0
+        assert ports[2].nominal_size == 4.0
+
+
+class TestCreateCrossPorts:
+    """Tests for cross port factory function."""
+
+    def test_create_default_ports(self) -> None:
+        """Test creating default cross ports."""
+        ports = create_cross_ports()
+        assert len(ports) == 4
+        assert ports[0].id == "run_inlet"
+        assert ports[1].id == "run_outlet"
+        assert ports[2].id == "branch_1"
+        assert ports[3].id == "branch_2"
+
+    def test_create_reducing_cross(self) -> None:
+        """Test creating reducing cross ports."""
+        ports = create_cross_ports(main_size=6.0, branch_size=4.0)
+        assert ports[0].nominal_size == 6.0  # run_inlet
+        assert ports[1].nominal_size == 6.0  # run_outlet
+        assert ports[2].nominal_size == 4.0  # branch_1
+        assert ports[3].nominal_size == 4.0  # branch_2
+
+
+class TestTeeBranch:
+    """Tests for TeeBranch model."""
+
+    def test_create_tee_branch(self) -> None:
+        """Test creating a valid tee branch."""
+        tee = TeeBranch(
+            id="tee_1",
+            name="Main Tee",
+            elevation=10.0,
+        )
+        assert tee.id == "tee_1"
+        assert tee.name == "Main Tee"
+        assert tee.elevation == 10.0
+        assert tee.type == "tee_branch"
+        assert tee.branch_angle == 90.0  # Default
+
+    def test_tee_branch_default_ports(self) -> None:
+        """Test that tee branch gets default ports."""
+        tee = TeeBranch(
+            id="tee_1",
+            name="Tee",
+            elevation=0.0,
+        )
+        assert len(tee.ports) == 3
+        assert tee.ports[0].id == "run_inlet"
+        assert tee.ports[1].id == "run_outlet"
+        assert tee.ports[2].id == "branch"
+
+    def test_tee_branch_custom_ports(self) -> None:
+        """Test that custom ports are preserved."""
+        custom_ports = create_tee_ports(run_size=6.0, branch_size=4.0)
+        tee = TeeBranch(
+            id="tee_1",
+            name="Reducing Tee",
+            elevation=0.0,
+            ports=custom_ports,
+        )
+        assert len(tee.ports) == 3
+        assert tee.ports[0].nominal_size == 6.0
+        assert tee.ports[2].nominal_size == 4.0
+
+    def test_tee_branch_custom_angle(self) -> None:
+        """Test tee branch with custom angle."""
+        tee = TeeBranch(
+            id="tee_1",
+            name="Lateral Tee",
+            elevation=0.0,
+            branch_angle=45.0,
+        )
+        assert tee.branch_angle == 45.0
+
+    def test_tee_branch_invalid_angle(self) -> None:
+        """Test tee branch rejects invalid angles."""
+        with pytest.raises(ValidationError):
+            TeeBranch(
+                id="tee_1",
+                name="Invalid",
+                elevation=0.0,
+                branch_angle=30.0,  # Too small
+            )
+
+    def test_tee_branch_invalid_port_count(self) -> None:
+        """Test tee branch rejects wrong number of ports."""
+        from opensolve_pipe.models import Port
+
+        with pytest.raises(ValidationError) as exc_info:
+            TeeBranch(
+                id="tee_1",
+                name="Invalid",
+                elevation=0.0,
+                ports=[Port(id="single", nominal_size=4.0)],
+            )
+        assert "exactly 3 ports" in str(exc_info.value)
+
+    def test_tee_branch_get_port(self) -> None:
+        """Test get_port method."""
+        tee = TeeBranch(
+            id="tee_1",
+            name="Tee",
+            elevation=0.0,
+        )
+        port = tee.get_port("branch")
+        assert port is not None
+        assert port.id == "branch"
+        assert tee.get_port("nonexistent") is None
+
+    def test_tee_branch_get_run_ports(self) -> None:
+        """Test get_run_ports method."""
+        tee = TeeBranch(
+            id="tee_1",
+            name="Tee",
+            elevation=0.0,
+        )
+        run_ports = tee.get_run_ports()
+        assert len(run_ports) == 2
+        assert run_ports[0].id == "run_inlet"
+        assert run_ports[1].id == "run_outlet"
+
+    def test_tee_branch_get_branch_ports(self) -> None:
+        """Test get_branch_ports method."""
+        tee = TeeBranch(
+            id="tee_1",
+            name="Tee",
+            elevation=0.0,
+        )
+        branch_ports = tee.get_branch_ports()
+        assert len(branch_ports) == 1
+        assert branch_ports[0].id == "branch"
+
+
+class TestWyeBranch:
+    """Tests for WyeBranch model."""
+
+    def test_create_wye_branch(self) -> None:
+        """Test creating a valid wye branch."""
+        wye = WyeBranch(
+            id="wye_1",
+            name="45° Wye",
+            elevation=10.0,
+        )
+        assert wye.id == "wye_1"
+        assert wye.type == "wye_branch"
+        assert wye.branch_angle == 45.0  # Default
+
+    def test_wye_branch_default_ports(self) -> None:
+        """Test that wye branch gets default ports."""
+        wye = WyeBranch(
+            id="wye_1",
+            name="Wye",
+            elevation=0.0,
+        )
+        assert len(wye.ports) == 3
+
+    def test_wye_branch_custom_angle(self) -> None:
+        """Test wye branch with custom angle."""
+        wye = WyeBranch(
+            id="wye_1",
+            name="60° Wye",
+            elevation=0.0,
+            branch_angle=60.0,
+        )
+        assert wye.branch_angle == 60.0
+
+    def test_wye_branch_invalid_angle(self) -> None:
+        """Test wye branch rejects invalid angles."""
+        with pytest.raises(ValidationError):
+            WyeBranch(
+                id="wye_1",
+                name="Invalid",
+                elevation=0.0,
+                branch_angle=70.0,  # Too large
+            )
+
+    def test_wye_branch_invalid_port_count(self) -> None:
+        """Test wye branch rejects wrong number of ports."""
+        from opensolve_pipe.models import Port
+
+        with pytest.raises(ValidationError) as exc_info:
+            WyeBranch(
+                id="wye_1",
+                name="Invalid",
+                elevation=0.0,
+                ports=[
+                    Port(id="p1", nominal_size=4.0),
+                    Port(id="p2", nominal_size=4.0),
+                ],
+            )
+        assert "exactly 3 ports" in str(exc_info.value)
+
+
+class TestCrossBranch:
+    """Tests for CrossBranch model."""
+
+    def test_create_cross_branch(self) -> None:
+        """Test creating a valid cross branch."""
+        cross = CrossBranch(
+            id="cross_1",
+            name="4-Way Cross",
+            elevation=10.0,
+        )
+        assert cross.id == "cross_1"
+        assert cross.type == "cross_branch"
+
+    def test_cross_branch_default_ports(self) -> None:
+        """Test that cross branch gets default ports."""
+        cross = CrossBranch(
+            id="cross_1",
+            name="Cross",
+            elevation=0.0,
+        )
+        assert len(cross.ports) == 4
+        assert cross.ports[0].id == "run_inlet"
+        assert cross.ports[1].id == "run_outlet"
+        assert cross.ports[2].id == "branch_1"
+        assert cross.ports[3].id == "branch_2"
+
+    def test_cross_branch_invalid_port_count(self) -> None:
+        """Test cross branch rejects wrong number of ports."""
+        from opensolve_pipe.models import Port
+
+        with pytest.raises(ValidationError) as exc_info:
+            CrossBranch(
+                id="cross_1",
+                name="Invalid",
+                elevation=0.0,
+                ports=[Port(id="p1", nominal_size=4.0)],
+            )
+        assert "exactly 4 ports" in str(exc_info.value)
+
+    def test_cross_branch_get_branch_ports(self) -> None:
+        """Test get_branch_ports method."""
+        cross = CrossBranch(
+            id="cross_1",
+            name="Cross",
+            elevation=0.0,
+        )
+        branch_ports = cross.get_branch_ports()
+        assert len(branch_ports) == 2
+        assert branch_ports[0].id == "branch_1"
+        assert branch_ports[1].id == "branch_2"
+
+
+class TestBranchSerialization:
+    """Tests for branch serialization/deserialization."""
+
+    def test_tee_branch_roundtrip(self) -> None:
+        """Test tee branch serializes and deserializes correctly."""
+        tee = TeeBranch(
+            id="tee_1",
+            name="Main Tee",
+            elevation=10.0,
+            branch_angle=60.0,
+        )
+        data = tee.model_dump()
+        restored = TeeBranch.model_validate(data)
+
+        assert restored.id == tee.id
+        assert restored.name == tee.name
+        assert restored.elevation == tee.elevation
+        assert restored.branch_angle == tee.branch_angle
+        assert len(restored.ports) == 3
+
+    def test_wye_branch_roundtrip(self) -> None:
+        """Test wye branch serializes and deserializes correctly."""
+        wye = WyeBranch(
+            id="wye_1",
+            name="Wye",
+            elevation=5.0,
+            branch_angle=45.0,
+        )
+        data = wye.model_dump()
+        restored = WyeBranch.model_validate(data)
+
+        assert restored.id == wye.id
+        assert restored.branch_angle == wye.branch_angle
+
+    def test_cross_branch_roundtrip(self) -> None:
+        """Test cross branch serializes and deserializes correctly."""
+        cross = CrossBranch(
+            id="cross_1",
+            name="Cross",
+            elevation=0.0,
+        )
+        data = cross.model_dump()
+        restored = CrossBranch.model_validate(data)
+
+        assert restored.id == cross.id
+        assert len(restored.ports) == 4
+
+    def test_tee_branch_json_roundtrip(self) -> None:
+        """Test tee branch JSON serialization."""
+        tee = TeeBranch(
+            id="tee_1",
+            name="Tee",
+            elevation=0.0,
+        )
+        json_str = tee.model_dump_json()
+        restored = TeeBranch.model_validate_json(json_str)
+
+        assert restored.id == tee.id
+        assert restored.type == "tee_branch"
+
+
+class TestBranchInComponentUnion:
+    """Tests for branch types in Component discriminated union."""
+
+    def test_tee_branch_in_component_list(self) -> None:
+        """Test tee branch can be used in a component list."""
+        from opensolve_pipe.models import ComponentType, Junction
+
+        components: list[Component] = [
+            Junction(
+                id="junction_1",
+                name="Before Tee",
+                elevation=10.0,
+            ),
+            TeeBranch(
+                id="tee_1",
+                name="Main Tee",
+                elevation=10.0,
+            ),
+        ]
+        assert len(components) == 2
+        assert components[0].type == ComponentType.JUNCTION
+        assert components[1].type == "tee_branch"
+
+    def test_tee_branch_discriminated_union_parsing(self) -> None:
+        """Test tee is correctly parsed from dict via discriminated union."""
+        adapter: TypeAdapter[Component] = TypeAdapter(Component)
+
+        data = {
+            "id": "tee_1",
+            "type": "tee_branch",
+            "name": "Tee",
+            "elevation": 5.0,
+        }
+        component = adapter.validate_python(data)
+
+        assert isinstance(component, TeeBranch)
+        assert component.id == "tee_1"
+
+    def test_wye_branch_discriminated_union_parsing(self) -> None:
+        """Test wye is correctly parsed from dict via discriminated union."""
+        adapter: TypeAdapter[Component] = TypeAdapter(Component)
+
+        data = {
+            "id": "wye_1",
+            "type": "wye_branch",
+            "name": "Wye",
+            "elevation": 5.0,
+            "branch_angle": 45.0,
+        }
+        component = adapter.validate_python(data)
+
+        assert isinstance(component, WyeBranch)
+        assert component.branch_angle == 45.0
+
+    def test_cross_branch_discriminated_union_parsing(self) -> None:
+        """Test cross is correctly parsed from dict via discriminated union."""
+        adapter: TypeAdapter[Component] = TypeAdapter(Component)
+
+        data = {
+            "id": "cross_1",
+            "type": "cross_branch",
+            "name": "Cross",
+            "elevation": 5.0,
+        }
+        component = adapter.validate_python(data)
+
+        assert isinstance(component, CrossBranch)
+        assert len(component.ports) == 4
+
+
+class TestBranchType:
+    """Tests for BranchType enum."""
+
+    def test_branch_type_values(self) -> None:
+        """Test BranchType enum values."""
+        assert BranchType.TEE.value == "tee"
+        assert BranchType.WYE.value == "wye"
+        assert BranchType.CROSS.value == "cross"

--- a/docs/plans/issue-60-plan.md
+++ b/docs/plans/issue-60-plan.md
@@ -1,0 +1,47 @@
+# Implementation Plan: Issue #60 - Backend Branch Component (Tee/Wye/Cross)
+
+## Summary
+
+Implement Branch components for flow splitting/combining with proper K-factor calculations based on Crane TP-410.
+
+## Tasks
+
+### 1. Branch Models (`apps/api/src/opensolve_pipe/models/branch.py`)
+
+- [x] Define `BranchType` enum (TEE, WYE, CROSS)
+- [x] Define `BaseBranch` base model with variable ports
+- [x] Define `TeeBranch` model (3 ports: run_inlet, run_outlet, branch)
+- [x] Define `WyeBranch` model (3 ports with configurable angle)
+- [x] Define `CrossBranch` model (4 ports)
+- [x] Add port factory functions for each branch type
+- [x] Validate port configurations
+
+### 2. Update Component Types
+
+- [x] Add TEE_BRANCH, WYE_BRANCH, CROSS_BRANCH to ComponentType enum
+- [x] Add to discriminated union in components.py
+- [x] Update __init__.py exports
+
+### 3. Write Unit Tests
+
+- [x] Test branch model creation and validation
+- [x] Test port configurations for each branch type
+- [x] Test serialization roundtrips
+- [x] Test discriminated union parsing
+
+## Notes
+
+K-factor calculations and solver integration will be handled in a separate issue as they require more complex hydraulic logic. This issue focuses on the data models only.
+
+## Dependencies
+
+- Issue #58 (Port-Based Architecture) - REQUIRED
+- Issue #59 (Reference Node and Plug) - builds on same branch
+
+## Acceptance Criteria
+
+- [x] TeeBranch has 3 ports (run_inlet, run_outlet, branch)
+- [x] WyeBranch has 3 ports with configurable branch angle
+- [x] CrossBranch has 4 ports
+- [x] All models serialize/deserialize correctly
+- [x] All models work in Component discriminated union


### PR DESCRIPTION
## Summary

Implements Issue #60 - Backend Branch Component (Tee/Wye/Cross) for flow splitting/combining in hydraulic networks.

## Changes

### Branch Models
- **TeeBranch**: 3 ports (run_inlet, run_outlet, branch) with configurable 45-90° angle
- **WyeBranch**: 3 ports with configurable 22.5-60° branch angle (default 45°)
- **CrossBranch**: 4 ports for four-way distribution (run_inlet, run_outlet, branch_1, branch_2)

### Features
- Port factory functions: `create_tee_ports()`, `create_wye_ports()`, `create_cross_ports()`
- Support for reducing branches (smaller branch port size)
- Port count validation (3 for tee/wye, 4 for cross)
- Helper methods: `get_run_ports()`, `get_branch_ports()`
- All ports bidirectional to support flow reversals

### Component Integration
- Added `TEE_BRANCH`, `WYE_BRANCH`, `CROSS_BRANCH` to ComponentType enum
- Added to Component discriminated union
- Exported all new models from __init__.py

## Test Plan
- [x] 34 new unit tests covering:
  - Model creation and validation
  - Port configurations (default and custom)
  - Branch angle validation
  - Port count validation
  - Serialization roundtrips
  - Discriminated union parsing
- [x] All 576 tests pass
- [x] Linting passes (ruff check/format)
- [x] Type checking passes (mypy)

## Dependencies
- Depends on PR #65 (Reference Node and Plug Components)
- Depends on PR #64 (Port-Based Architecture)

## Notes
K-factor calculations and solver integration will be implemented in a follow-up issue. This PR focuses on the data models.

Closes #60

🤖 Generated with [Claude Code](https://claude.com/claude-code)