### PR TITLE
feat(frontend): add port-based connection models and store

### DIFF
--- a/apps/web/src/lib/data/exampleProject.ts
+++ b/apps/web/src/lib/data/exampleProject.ts
@@ -51,6 +51,7 @@ export const EXAMPLE_PROJECT: Project = {
 			name: 'Supply Tank',
 			elevation: 0,
 			water_level: 10,
+			ports: [{ id: 'outlet_1', nominal_size: 4, direction: 'bidirectional' }],
 			downstream_connections: [
 				{
 					target_component_id: 'pump_1',
@@ -74,6 +75,10 @@ export const EXAMPLE_PROJECT: Project = {
 			curve_id: 'curve_1',
 			speed: 1.0,
 			status: 'on',
+			ports: [
+				{ id: 'suction', nominal_size: 4, direction: 'inlet' },
+				{ id: 'discharge', nominal_size: 4, direction: 'outlet' }
+			],
 			downstream_connections: [
 				{
 					target_component_id: 'junction_1',
@@ -98,7 +103,45 @@ export const EXAMPLE_PROJECT: Project = {
 			name: 'Discharge Point',
 			elevation: 50,
 			demand: 200,
+			ports: [{ id: 'port_1', nominal_size: 4, direction: 'bidirectional' }],
 			downstream_connections: []
+		}
+	],
+	connections: [
+		{
+			id: 'conn_1',
+			from_component_id: 'reservoir_1',
+			from_port_id: 'outlet_1',
+			to_component_id: 'pump_1',
+			to_port_id: 'suction',
+			piping: {
+				pipe: {
+					material: 'carbon_steel',
+					schedule: '40',
+					nominal_diameter: 4,
+					length: 20
+				},
+				fittings: [{ type: 'elbow_90_lr', quantity: 2 }]
+			}
+		},
+		{
+			id: 'conn_2',
+			from_component_id: 'pump_1',
+			from_port_id: 'discharge',
+			to_component_id: 'junction_1',
+			to_port_id: 'port_1',
+			piping: {
+				pipe: {
+					material: 'carbon_steel',
+					schedule: '40',
+					nominal_diameter: 4,
+					length: 100
+				},
+				fittings: [
+					{ type: 'elbow_90_lr', quantity: 3 },
+					{ type: 'gate_valve', quantity: 1 }
+				]
+			}
 		}
 	],
 	pump_library: [

--- a/apps/web/src/lib/models/index.ts
+++ b/apps/web/src/lib/models/index.ts
@@ -59,6 +59,9 @@ export {
 
 // Components
 export type {
+	PortDirection,
+	Port,
+	PipeConnection,
 	ComponentType,
 	ValveType,
 	Connection,
@@ -71,6 +74,13 @@ export type {
 	Strainer,
 	Orifice,
 	Sprinkler,
+	FlowPressurePoint,
+	IdealReferenceNode,
+	NonIdealReferenceNode,
+	Plug,
+	TeeBranch,
+	WyeBranch,
+	CrossBranch,
 	Component
 } from './components';
 export {
@@ -87,10 +97,31 @@ export {
 	isStrainer,
 	isOrifice,
 	isSprinkler,
+	isIdealReferenceNode,
+	isNonIdealReferenceNode,
+	isPlug,
+	isTeeBranch,
+	isWyeBranch,
+	isCrossBranch,
 	isNodeComponent,
 	isLinkComponent,
 	getReservoirTotalHead,
 	generateComponentId,
+	getDefaultPorts,
+	createReservoirPorts,
+	createTankPorts,
+	createJunctionPorts,
+	createPumpPorts,
+	createValvePorts,
+	createHeatExchangerPorts,
+	createStrainerPorts,
+	createOrificePorts,
+	createSprinklerPorts,
+	createReferenceNodePorts,
+	createPlugPorts,
+	createTeePorts,
+	createWyePorts,
+	createCrossPorts,
 	createDefaultComponent
 } from './components';
 
@@ -121,15 +152,22 @@ export {
 export type { ProjectMetadata, ProjectSettings, Project } from './project';
 export {
 	generateProjectId,
+	generateConnectionId,
 	createDefaultMetadata,
 	createDefaultSettings,
 	createNewProject,
 	getComponentById,
 	getPumpCurveById,
+	getConnectionById,
+	getConnectionsFromComponent,
+	getConnectionsToComponent,
+	getConnectionsForPort,
 	validateComponentIds,
 	validateConnectionReferences,
 	validatePumpCurveIds,
 	validatePumpCurveReferences,
+	validatePipeConnectionIds,
+	validatePipeConnectionReferences,
 	validateProject,
 	touchProject,
 	branchProject

--- a/docs/plans/issue-61-plan.md
+++ b/docs/plans/issue-61-plan.md
@@ -1,0 +1,74 @@
+# Implementation Plan: Issue #61 - Frontend Port Connection Editor
+
+## Summary
+
+Create UI for managing port-based connections between components.
+
+## Tasks
+
+### 1. Update Frontend Models (COMPLETED)
+
+- [x] Add Port and PortDirection types to components.ts
+- [x] Add PipeConnection type for port-based connections
+- [x] Update component interfaces to include ports field
+- [x] Add new component types (IdealReferenceNode, NonIdealReferenceNode, Plug, branches)
+- [x] Add port factory functions for each component type
+- [x] Add type guards for new components
+- [x] Update createDefaultComponent to include ports
+
+### 2. Update Project Model (COMPLETED)
+
+- [x] Add connections list to Project interface
+- [x] Update createNewProject to include empty connections array
+- [x] Add connection validation functions
+- [x] Add connection helper functions (getConnectionById, getConnectionsFromComponent, etc.)
+- [x] Update example project with ports and connections
+
+### 3. Update Project Store (COMPLETED)
+
+- [x] Add PipeConnection import and generateConnectionId
+- [x] Add addPipeConnection function
+- [x] Add removePipeConnection function
+- [x] Add updatePipeConnectionPiping function
+- [x] Add getConnectionsForComponent function
+- [x] Add connections derived store
+
+### 4. Create Port and Connection UI Components (TODO)
+
+- [ ] Create `PortSelector.svelte` - dropdown to select a port from a component
+- [ ] Create `PortConnectionEditor.svelte` - manage connection between two ports
+- [ ] Add port display in component forms (showing available ports)
+
+### 5. Update Existing UI (TODO)
+
+- [ ] Update PipingPanel to work with port-based connections
+- [ ] Show visual indicators for connected vs unconnected ports
+- [ ] Display validation errors for invalid connections
+
+### 6. Write Tests (TODO)
+
+- [ ] Test PortSelector component
+- [ ] Test PortConnectionEditor component
+- [ ] Test project store connection functions
+
+## Dependencies
+
+- Issue #58 (Backend Port-Based Architecture) - REQUIRED
+- Issue #59 (Reference Node and Plug) - for new component types
+- Issue #60 (Branch Components) - for branch types
+
+## Acceptance Criteria
+
+- [x] Port and PipeConnection types defined
+- [x] Project store can manage connections
+- [x] All existing tests pass
+- [ ] Users can select source and target ports for connections (UI TODO)
+- [ ] Invalid connections show clear errors (UI TODO)
+- [ ] All available ports are visible in the selector (UI TODO)
+- [ ] Connection state updates correctly in the store (DONE)
+
+## Notes
+
+This PR completes the model and store updates for port-based connections.
+The UI components (PortSelector, PortConnectionEditor) will be implemented
+in a follow-up PR as they require more design consideration.


### PR DESCRIPTION
## Summary

Implements Issue #61 - Frontend Port Connection Editor (models and store layer).

This PR adds the TypeScript models and Svelte store functions for port-based connections, mirroring the backend port architecture from Issues #58-60.

## Changes

### Frontend Models (`apps/web/src/lib/models/components.ts`)
- **Port types**: `Port`, `PortDirection` interfaces
- **PipeConnection**: Connection type linking ports between components
- **New component types**: 
  - `IdealReferenceNode`, `NonIdealReferenceNode` (reference nodes)
  - `Plug` (dead-end boundary)
  - `TeeBranch`, `WyeBranch`, `CrossBranch` (branch fittings)
- **Port factory functions**: 14 functions for creating default ports per component type
- **Type guards**: Added for all new component types
- **Updated categories**: Components grouped into Sources, Connections, Equipment

### Project Model (`apps/web/src/lib/models/project.ts`)
- Added `connections: PipeConnection[]` to Project interface
- Added `generateConnectionId()` function
- Added connection helper functions:
  - `getConnectionById()`
  - `getConnectionsFromComponent()`
  - `getConnectionsToComponent()`
  - `getConnectionsForPort()`
- Added connection validation functions

### Project Store (`apps/web/src/lib/stores/project.ts`)
- Added `addPipeConnection()` - create new port-based connection
- Added `removePipeConnection()` - remove connection by ID
- Added `updatePipeConnectionPiping()` - update piping for connection
- Added `getConnectionsForComponent()` - get all connections for a component
- Added `connections` derived store

### Example Project
- Updated with ports on all components
- Added example PipeConnections

## Test Plan
- [x] All 73 existing frontend tests pass
- [x] Svelte type checking passes
- [x] ESLint passes
- [x] Prettier formatting passes

## Dependencies
- Depends on PR #66 (Branch Components)
- Depends on PR #65 (Reference Node and Plug)
- Depends on PR #64 (Port-Based Architecture)

## Notes
The UI components (PortSelector, PortConnectionEditor) will be implemented in a follow-up PR as they require more design consideration.

Closes #61 (partial - models and store complete, UI components to follow)

🤖 Generated with [Claude Code](https://claude.com/claude-code)