### PR TITLE
feat(ui): add forms for branch components (tee, wye, cross)

### DIFF
--- a/apps/web/src/lib/components/forms/CrossBranchForm.svelte
+++ b/apps/web/src/lib/components/forms/CrossBranchForm.svelte
@@ -1,0 +1,144 @@
+<script lang="ts">
+	import type { CrossBranch } from '$lib/models';
+	import NumberInput from './NumberInput.svelte';
+
+	interface Props {
+		/** The cross branch component to edit. */
+		component: CrossBranch;
+		/** Callback when a field value changes. */
+		onUpdate: (field: string, value: unknown) => void;
+	}
+
+	let { component, onUpdate }: Props = $props();
+
+	// Get port sizes from component
+	const runInlet = $derived(component.ports.find((p) => p.id === 'run_inlet'));
+	const runOutlet = $derived(component.ports.find((p) => p.id === 'run_outlet'));
+	const branch1 = $derived(component.ports.find((p) => p.id === 'branch_1'));
+	const branch2 = $derived(component.ports.find((p) => p.id === 'branch_2'));
+
+	function updatePortSize(portId: string, size: number) {
+		const newPorts = component.ports.map((p) => (p.id === portId ? { ...p, nominal_size: size } : p));
+		onUpdate('ports', newPorts);
+	}
+
+	function updateAllRunPorts(size: number) {
+		const newPorts = component.ports.map((p) =>
+			p.id === 'run_inlet' || p.id === 'run_outlet' ? { ...p, nominal_size: size } : p
+		);
+		onUpdate('ports', newPorts);
+	}
+
+	function updateAllBranchPorts(size: number) {
+		const newPorts = component.ports.map((p) =>
+			p.id === 'branch_1' || p.id === 'branch_2' ? { ...p, nominal_size: size } : p
+		);
+		onUpdate('ports', newPorts);
+	}
+</script>
+
+<div class="space-y-4">
+	<div class="rounded-md bg-purple-50 p-3">
+		<p class="text-sm text-purple-800">
+			<strong>Cross Branch:</strong> Four-way fitting with perpendicular branches. Used for complex
+			flow distribution.
+		</p>
+	</div>
+
+	<!-- Visual diagram -->
+	<div class="rounded-md border border-gray-200 bg-gray-50 p-4">
+		<div class="flex items-center justify-center">
+			<svg viewBox="0 0 100 100" class="h-20 w-20">
+				<!-- Run line (horizontal) -->
+				<line x1="10" y1="50" x2="90" y2="50" stroke="currentColor" stroke-width="4" />
+				<!-- Branch lines (vertical) -->
+				<line x1="50" y1="10" x2="50" y2="90" stroke="currentColor" stroke-width="4" />
+				<!-- Port labels -->
+				<text x="10" y="45" class="fill-gray-600 text-[7px]">In</text>
+				<text x="80" y="45" class="fill-gray-600 text-[7px]">Out</text>
+				<text x="55" y="18" class="fill-gray-600 text-[7px]">Br 1</text>
+				<text x="55" y="92" class="fill-gray-600 text-[7px]">Br 2</text>
+				<!-- Flow arrows from center -->
+				<polygon points="30,47 20,50 30,53" fill="currentColor" />
+				<polygon points="70,47 80,50 70,53" fill="currentColor" />
+				<polygon points="47,30 50,20 53,30" fill="currentColor" />
+				<polygon points="47,70 50,80 53,70" fill="currentColor" />
+			</svg>
+		</div>
+		<p class="mt-2 text-center text-xs text-gray-500">Four-way flow distribution</p>
+	</div>
+
+	<NumberInput
+		id="elevation"
+		label="Elevation"
+		value={component.elevation}
+		unit="ft"
+		onchange={(value) => onUpdate('elevation', value)}
+	/>
+
+	<div class="border-t border-gray-200 pt-4">
+		<span class="block text-sm font-medium text-gray-700">Port Sizes</span>
+		<p class="mt-1 text-xs text-gray-500">Configure the nominal pipe size for each connection</p>
+	</div>
+
+	<NumberInput
+		id="run_size"
+		label="Run Size (Inlet & Outlet)"
+		value={runInlet?.nominal_size ?? 4}
+		unit="in"
+		min={0.5}
+		hint="Main line through the cross"
+		onchange={updateAllRunPorts}
+	/>
+
+	<NumberInput
+		id="branch_size"
+		label="Branch Size (Both Branches)"
+		value={branch1?.nominal_size ?? 4}
+		unit="in"
+		min={0.5}
+		hint="Perpendicular branches"
+		onchange={updateAllBranchPorts}
+	/>
+
+	<!-- Individual port override if needed -->
+	<details class="rounded-md border border-gray-200">
+		<summary class="cursor-pointer px-3 py-2 text-sm text-gray-600 hover:bg-gray-50">
+			Configure ports individually
+		</summary>
+		<div class="space-y-3 border-t border-gray-200 p-3">
+			<NumberInput
+				id="run_inlet_size"
+				label="Run Inlet"
+				value={runInlet?.nominal_size ?? 4}
+				unit="in"
+				min={0.5}
+				onchange={(value) => updatePortSize('run_inlet', value)}
+			/>
+			<NumberInput
+				id="run_outlet_size"
+				label="Run Outlet"
+				value={runOutlet?.nominal_size ?? 4}
+				unit="in"
+				min={0.5}
+				onchange={(value) => updatePortSize('run_outlet', value)}
+			/>
+			<NumberInput
+				id="branch_1_size"
+				label="Branch 1"
+				value={branch1?.nominal_size ?? 4}
+				unit="in"
+				min={0.5}
+				onchange={(value) => updatePortSize('branch_1', value)}
+			/>
+			<NumberInput
+				id="branch_2_size"
+				label="Branch 2"
+				value={branch2?.nominal_size ?? 4}
+				unit="in"
+				min={0.5}
+				onchange={(value) => updatePortSize('branch_2', value)}
+			/>
+		</div>
+	</details>
+</div>

--- a/apps/web/src/lib/components/forms/TeeBranchForm.svelte
+++ b/apps/web/src/lib/components/forms/TeeBranchForm.svelte
@@ -1,0 +1,111 @@
+<script lang="ts">
+	import type { TeeBranch } from '$lib/models';
+	import NumberInput from './NumberInput.svelte';
+
+	interface Props {
+		/** The tee branch component to edit. */
+		component: TeeBranch;
+		/** Callback when a field value changes. */
+		onUpdate: (field: string, value: unknown) => void;
+	}
+
+	let { component, onUpdate }: Props = $props();
+
+	// Get port sizes from component
+	const runInlet = $derived(component.ports.find((p) => p.id === 'run_inlet'));
+	const branch = $derived(component.ports.find((p) => p.id === 'branch'));
+
+	function updatePortSize(portId: string, size: number) {
+		const newPorts = component.ports.map((p) => (p.id === portId ? { ...p, nominal_size: size } : p));
+		onUpdate('ports', newPorts);
+	}
+
+	function updateAllRunPorts(size: number) {
+		const newPorts = component.ports.map((p) =>
+			p.id === 'run_inlet' || p.id === 'run_outlet' ? { ...p, nominal_size: size } : p
+		);
+		onUpdate('ports', newPorts);
+	}
+</script>
+
+<div class="space-y-4">
+	<div class="rounded-md bg-blue-50 p-3">
+		<p class="text-sm text-blue-800">
+			<strong>Tee Branch:</strong> 90° fitting for flow splitting or combining. Run ports are the main
+			flow path, branch port is perpendicular.
+		</p>
+	</div>
+
+	<!-- Visual diagram -->
+	<div class="rounded-md border border-gray-200 bg-gray-50 p-4">
+		<div class="flex items-center justify-center">
+			<svg viewBox="0 0 120 80" class="h-16 w-24">
+				<!-- Run line (horizontal) -->
+				<line x1="10" y1="40" x2="110" y2="40" stroke="currentColor" stroke-width="4" />
+				<!-- Branch line (vertical up) -->
+				<line x1="60" y1="40" x2="60" y2="10" stroke="currentColor" stroke-width="4" />
+				<!-- Port labels -->
+				<text x="15" y="55" class="fill-gray-600 text-[8px]">Run In</text>
+				<text x="85" y="55" class="fill-gray-600 text-[8px]">Run Out</text>
+				<text x="65" y="20" class="fill-gray-600 text-[8px]">Branch</text>
+				<!-- Flow arrows -->
+				<polygon points="30,37 40,40 30,43" fill="currentColor" />
+				<polygon points="90,37 100,40 90,43" fill="currentColor" />
+				<polygon points="57,25 60,15 63,25" fill="currentColor" />
+			</svg>
+		</div>
+		<p class="mt-2 text-center text-xs text-gray-500">Flow direction shown for diverging flow</p>
+	</div>
+
+	<NumberInput
+		id="elevation"
+		label="Elevation"
+		value={component.elevation}
+		unit="ft"
+		onchange={(value) => onUpdate('elevation', value)}
+	/>
+
+	<NumberInput
+		id="branch_angle"
+		label="Branch Angle"
+		value={component.branch_angle}
+		unit="deg"
+		min={45}
+		max={90}
+		step={5}
+		hint="Standard tee is 90°"
+		onchange={(value) => onUpdate('branch_angle', value)}
+	/>
+
+	<div class="border-t border-gray-200 pt-4">
+		<span class="block text-sm font-medium text-gray-700">Port Sizes</span>
+		<p class="mt-1 text-xs text-gray-500">Configure the nominal pipe size for each connection</p>
+	</div>
+
+	<NumberInput
+		id="run_size"
+		label="Run Size (Inlet & Outlet)"
+		value={runInlet?.nominal_size ?? 4}
+		unit="in"
+		min={0.5}
+		onchange={updateAllRunPorts}
+	/>
+
+	<NumberInput
+		id="branch_size"
+		label="Branch Size"
+		value={branch?.nominal_size ?? 4}
+		unit="in"
+		min={0.5}
+		hint="Can be same size or smaller than run (reducing tee)"
+		onchange={(value) => updatePortSize('branch', value)}
+	/>
+
+	{#if branch && runInlet && branch.nominal_size > runInlet.nominal_size}
+		<div class="rounded-md border border-amber-200 bg-amber-50 p-2">
+			<p class="text-xs text-amber-800">
+				Branch size larger than run is unusual. Typically branch is same size or smaller.
+			</p>
+		</div>
+	{/if}
+</div>

--- a/apps/web/src/lib/components/forms/WyeBranchForm.svelte
+++ b/apps/web/src/lib/components/forms/WyeBranchForm.svelte
@@ -1,0 +1,110 @@
+<script lang="ts">
+	import type { WyeBranch } from '$lib/models';
+	import NumberInput from './NumberInput.svelte';
+
+	interface Props {
+		/** The wye branch component to edit. */
+		component: WyeBranch;
+		/** Callback when a field value changes. */
+		onUpdate: (field: string, value: unknown) => void;
+	}
+
+	let { component, onUpdate }: Props = $props();
+
+	// Get port sizes from component
+	const runInlet = $derived(component.ports.find((p) => p.id === 'run_inlet'));
+	const branch = $derived(component.ports.find((p) => p.id === 'branch'));
+
+	function updatePortSize(portId: string, size: number) {
+		const newPorts = component.ports.map((p) => (p.id === portId ? { ...p, nominal_size: size } : p));
+		onUpdate('ports', newPorts);
+	}
+
+	function updateAllRunPorts(size: number) {
+		const newPorts = component.ports.map((p) =>
+			p.id === 'run_inlet' || p.id === 'run_outlet' ? { ...p, nominal_size: size } : p
+		);
+		onUpdate('ports', newPorts);
+	}
+</script>
+
+<div class="space-y-4">
+	<div class="rounded-md bg-green-50 p-3">
+		<p class="text-sm text-green-800">
+			<strong>Wye Branch:</strong> Angled fitting (typically 45°) for smoother flow transitions.
+			Lower head loss than standard tee.
+		</p>
+	</div>
+
+	<!-- Visual diagram -->
+	<div class="rounded-md border border-gray-200 bg-gray-50 p-4">
+		<div class="flex items-center justify-center">
+			<svg viewBox="0 0 120 80" class="h-16 w-24">
+				<!-- Run line (horizontal) -->
+				<line x1="10" y1="50" x2="110" y2="50" stroke="currentColor" stroke-width="4" />
+				<!-- Branch line (angled up at 45°) -->
+				<line x1="60" y1="50" x2="85" y2="15" stroke="currentColor" stroke-width="4" />
+				<!-- Port labels -->
+				<text x="15" y="65" class="fill-gray-600 text-[8px]">Run In</text>
+				<text x="85" y="65" class="fill-gray-600 text-[8px]">Run Out</text>
+				<text x="75" y="20" class="fill-gray-600 text-[8px]">Branch</text>
+				<!-- Angle indicator -->
+				<path d="M 60,50 L 70,50 A 10,10 0 0,0 67,40" fill="none" stroke="gray" stroke-width="1" />
+				<text x="68" y="48" class="fill-gray-500 text-[6px]">45°</text>
+			</svg>
+		</div>
+		<p class="mt-2 text-center text-xs text-gray-500">Lower pressure drop than 90° tee</p>
+	</div>
+
+	<NumberInput
+		id="elevation"
+		label="Elevation"
+		value={component.elevation}
+		unit="ft"
+		onchange={(value) => onUpdate('elevation', value)}
+	/>
+
+	<NumberInput
+		id="branch_angle"
+		label="Branch Angle"
+		value={component.branch_angle}
+		unit="deg"
+		min={22.5}
+		max={60}
+		step={5}
+		hint="Common values: 45°, 60°"
+		onchange={(value) => onUpdate('branch_angle', value)}
+	/>
+
+	<div class="border-t border-gray-200 pt-4">
+		<span class="block text-sm font-medium text-gray-700">Port Sizes</span>
+		<p class="mt-1 text-xs text-gray-500">Configure the nominal pipe size for each connection</p>
+	</div>
+
+	<NumberInput
+		id="run_size"
+		label="Run Size (Inlet & Outlet)"
+		value={runInlet?.nominal_size ?? 4}
+		unit="in"
+		min={0.5}
+		onchange={updateAllRunPorts}
+	/>
+
+	<NumberInput
+		id="branch_size"
+		label="Branch Size"
+		value={branch?.nominal_size ?? 4}
+		unit="in"
+		min={0.5}
+		hint="Can be same size or smaller than run"
+		onchange={(value) => updatePortSize('branch', value)}
+	/>
+
+	{#if branch && runInlet && branch.nominal_size > runInlet.nominal_size}
+		<div class="rounded-md border border-amber-200 bg-amber-50 p-2">
+			<p class="text-xs text-amber-800">
+				Branch size larger than run is unusual. Typically branch is same size or smaller.
+			</p>
+		</div>
+	{/if}
+</div>

--- a/apps/web/src/lib/components/forms/index.ts
+++ b/apps/web/src/lib/components/forms/index.ts
@@ -25,6 +25,11 @@ export { default as StrainerForm } from './StrainerForm.svelte';
 export { default as ReferenceNodeForm } from './ReferenceNodeForm.svelte';
 export { default as PlugForm } from './PlugForm.svelte';
 
+// Branch components
+export { default as TeeBranchForm } from './TeeBranchForm.svelte';
+export { default as WyeBranchForm } from './WyeBranchForm.svelte';
+export { default as CrossBranchForm } from './CrossBranchForm.svelte';
+
 // Piping components
 export { default as PipeForm } from './PipeForm.svelte';
 export { default as FittingsTable } from './FittingsTable.svelte';

--- a/apps/web/src/lib/components/panel/ElementPanel.svelte
+++ b/apps/web/src/lib/components/panel/ElementPanel.svelte
@@ -14,6 +14,9 @@
 		isIdealReferenceNode,
 		isNonIdealReferenceNode,
 		isPlug,
+		isTeeBranch,
+		isWyeBranch,
+		isCrossBranch,
 		type Component
 	} from '$lib/models';
 	import {
@@ -27,7 +30,10 @@
 		OrificeForm,
 		SprinklerForm,
 		ReferenceNodeForm,
-		PlugForm
+		PlugForm,
+		TeeBranchForm,
+		WyeBranchForm,
+		CrossBranchForm
 	} from '$lib/components/forms';
 
 	interface Props {
@@ -107,6 +113,12 @@
 			<ReferenceNodeForm {component} onUpdate={updateField} />
 		{:else if isPlug(component)}
 			<PlugForm {component} onUpdate={updateField} />
+		{:else if isTeeBranch(component)}
+			<TeeBranchForm {component} onUpdate={updateField} />
+		{:else if isWyeBranch(component)}
+			<WyeBranchForm {component} onUpdate={updateField} />
+		{:else if isCrossBranch(component)}
+			<CrossBranchForm {component} onUpdate={updateField} />
 		{/if}
 	</div>
 


### PR DESCRIPTION
## Summary

- Create TeeBranchForm.svelte with:
  - Branch angle configuration (45-90 degrees)
  - Run and branch port size configuration
  - Visual SVG diagram showing port arrangement
  - Warning for unusual branch sizes larger than run

- Create WyeBranchForm.svelte with:
  - Branch angle configuration (22.5-60 degrees)
  - Port size configuration
  - Visual diagram showing angled branch

- Create CrossBranchForm.svelte with:
  - Main run and perpendicular branch port sizes
  - Collapsible individual port override
  - Four-way flow diagram

- Export new forms from forms/index.ts
- Update ElementPanel.svelte to render branch forms for tee/wye/cross components

## Test plan

- [x] pnpm check passes (Svelte type checking)
- [x] pnpm lint passes (ESLint)
- [x] pnpm test passes (73 tests)
- [ ] Manual testing: verify forms render when selecting branch components

## Dependencies

- Issue #62 (Reference Node Forms) - merged
- Issue #61 (Frontend Port Connections) - merged

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)