### PR TITLE
feat(ui): make build panel flex to available screen height

### DIFF
--- a/apps/web/src/lib/components/panel/PanelNavigator.svelte
+++ b/apps/web/src/lib/components/panel/PanelNavigator.svelte
@@ -163,8 +163,8 @@
 			</nav>
 		</div>
 
-		<!-- Tab Content - fixed height container with scroll for consistent navigation button position -->
-		<div class="h-[400px] overflow-y-auto p-4">
+		<!-- Tab Content - flex container that grows to fill available space -->
+		<div class="min-h-0 flex-1 overflow-y-auto p-4">
 			{#if activeTab === 'element'}
 				<ElementPanel component={currentComponent} />
 			{:else if activeTab === 'upstream'}

--- a/apps/web/src/routes/p/[...encoded]/+page.svelte
+++ b/apps/web/src/routes/p/[...encoded]/+page.svelte
@@ -210,11 +210,11 @@
 		</div>
 	{/if}
 
-	<main id="main-content" class="flex-1">
+	<main id="main-content" class="flex min-h-0 flex-1 flex-col">
 		{#if viewMode === 'panel'}
 			<!-- Panel Navigator View -->
-			<div class="mx-auto max-w-4xl p-4">
-				<div class="mb-4">
+			<div class="mx-auto flex min-h-0 w-full max-w-4xl flex-1 flex-col p-4">
+				<div class="mb-4 flex-shrink-0">
 					{#if isEditingName}
 						<!-- svelte-ignore a11y_autofocus -->
 						<input
@@ -249,7 +249,9 @@
 						</button>
 					{/if}
 				</div>
-				<PanelNavigator />
+				<div class="min-h-0 flex-1">
+					<PanelNavigator />
+				</div>
 			</div>
 		{:else}
 			<!-- Results View -->


### PR DESCRIPTION
## Summary

Updates the build panel layout to flex to available screen height instead of using a fixed 400px height. This makes better use of screen real estate and reduces unnecessary vertical scrolling.

### Changes

**`src/routes/p/[...encoded]/+page.svelte`:**
- Main content (`#main-content`) now uses `flex min-h-0 flex-1 flex-col` 
- Panel wrapper uses `flex min-h-0 w-full max-w-4xl flex-1 flex-col`
- Project name header uses `flex-shrink-0` to maintain fixed size
- PanelNavigator wrapped in `min-h-0 flex-1` container

**`src/lib/components/panel/PanelNavigator.svelte`:**
- Tab content uses `min-h-0 flex-1 overflow-y-auto` instead of `h-[400px]`

### Technical Details

The key fix is using `min-h-0` on flex children to allow proper shrinking in flex containers. Without this, flex items won't shrink below their content size, causing layout issues.

### Test Plan

- [x] Lint passes
- [x] Svelte check passes  
- [x] All 73 unit tests pass
- [x] Pre-commit hooks pass
- [ ] Manual testing on different viewport sizes

Closes #74

🤖 Generated with [Claude Code](https://claude.com/claude-code)