### PR TITLE
fix(ui): resolve Chart.js lifecycle issue in PumpCurveChart for Svelte 5

### DIFF
--- a/apps/web/src/lib/components/results/PumpCurveChart.svelte
+++ b/apps/web/src/lib/components/results/PumpCurveChart.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-	import { onMount, onDestroy } from 'svelte';
 	import { Chart, registerables } from 'chart.js';
 	import type { PumpCurve, PumpResult } from '$lib/models';
 
@@ -15,166 +14,180 @@
 
 	let { curve, result }: Props = $props();
 
-	let canvas: HTMLCanvasElement;
+	let canvas: HTMLCanvasElement | null = $state(null);
 	let chart: Chart | null = null;
 
-	// Reactive chart data
-	let chartData = $derived.by(() => {
-		const datasets: Chart['data']['datasets'] = [];
-
-		// Pump curve
-		datasets.push({
-			label: 'Pump Curve',
-			data: curve.points.map((p) => ({ x: p.flow, y: p.head })),
-			borderColor: 'rgb(59, 130, 246)',
-			backgroundColor: 'rgba(59, 130, 246, 0.1)',
-			fill: false,
-			tension: 0.4,
-			pointRadius: 3,
-			pointHoverRadius: 5
-		});
-
-		// System curve
-		if (result?.system_curve && result.system_curve.length > 0) {
-			datasets.push({
-				label: 'System Curve',
-				data: result.system_curve.map((p) => ({ x: p.flow, y: p.head })),
-				borderColor: 'rgb(239, 68, 68)',
-				backgroundColor: 'rgba(239, 68, 68, 0.1)',
-				fill: false,
-				tension: 0.4,
-				pointRadius: 0,
-				borderDash: [5, 5]
-			});
-		}
-
-		// Operating point
-		if (result) {
-			datasets.push({
-				label: 'Operating Point',
-				data: [{ x: result.operating_flow, y: result.operating_head }],
-				borderColor: 'rgb(34, 197, 94)',
-				backgroundColor: 'rgb(34, 197, 94)',
-				pointRadius: 8,
-				pointHoverRadius: 10,
-				showLine: false
-			});
-		}
-
-		return { datasets };
-	});
-
-	function createChart() {
-		if (!canvas) return;
-
-		// Destroy existing chart
+	function destroyChart() {
 		if (chart) {
-			chart.destroy();
+			try {
+				chart.destroy();
+			} catch {
+				// Ignore errors during cleanup
+			}
 			chart = null;
 		}
+	}
 
-		// Calculate axis ranges
-		const allFlows = curve.points.map((p) => p.flow);
-		const allHeads = curve.points.map((p) => p.head);
+	function createChart(canvasEl: HTMLCanvasElement) {
+		try {
+			// Destroy existing chart first
+			destroyChart();
 
-		if (result?.system_curve) {
-			allFlows.push(...result.system_curve.map((p) => p.flow));
-			allHeads.push(...result.system_curve.map((p) => p.head));
-		}
+			// Ensure curve has points
+			if (!curve?.points || curve.points.length === 0) return;
 
-		if (result) {
-			allFlows.push(result.operating_flow);
-			allHeads.push(result.operating_head);
-		}
+			// Build datasets
+			const datasets: Chart['data']['datasets'] = [];
 
-		const maxFlow = Math.max(...allFlows) * 1.1;
-		const maxHead = Math.max(...allHeads) * 1.1;
+			// Pump curve
+			datasets.push({
+				label: 'Pump Curve',
+				data: curve.points.map((p) => ({ x: p.flow, y: p.head })),
+				borderColor: 'rgb(59, 130, 246)',
+				backgroundColor: 'rgba(59, 130, 246, 0.1)',
+				fill: false,
+				tension: 0.4,
+				pointRadius: 3,
+				pointHoverRadius: 5
+			});
 
-		chart = new Chart(canvas, {
-			type: 'scatter',
-			data: chartData,
-			options: {
-				responsive: true,
-				maintainAspectRatio: false,
-				interaction: {
-					intersect: false,
-					mode: 'index'
-				},
-				plugins: {
-					legend: {
-						position: 'bottom',
-						labels: {
-							usePointStyle: true,
-							padding: 16
+			// System curve
+			if (result?.system_curve && result.system_curve.length > 0) {
+				datasets.push({
+					label: 'System Curve',
+					data: result.system_curve.map((p) => ({ x: p.flow, y: p.head })),
+					borderColor: 'rgb(239, 68, 68)',
+					backgroundColor: 'rgba(239, 68, 68, 0.1)',
+					fill: false,
+					tension: 0.4,
+					pointRadius: 0,
+					borderDash: [5, 5]
+				});
+			}
+
+			// Operating point
+			if (result?.operating_flow !== undefined && result?.operating_head !== undefined) {
+				datasets.push({
+					label: 'Operating Point',
+					data: [{ x: result.operating_flow, y: result.operating_head }],
+					borderColor: 'rgb(34, 197, 94)',
+					backgroundColor: 'rgb(34, 197, 94)',
+					pointRadius: 8,
+					pointHoverRadius: 10,
+					showLine: false
+				});
+			}
+
+			// Calculate axis ranges
+			const allFlows = curve.points.map((p) => p.flow);
+			const allHeads = curve.points.map((p) => p.head);
+
+			if (result?.system_curve) {
+				allFlows.push(...result.system_curve.map((p) => p.flow));
+				allHeads.push(...result.system_curve.map((p) => p.head));
+			}
+
+			if (result?.operating_flow !== undefined) {
+				allFlows.push(result.operating_flow);
+			}
+			if (result?.operating_head !== undefined) {
+				allHeads.push(result.operating_head);
+			}
+
+			const maxFlow = Math.max(...allFlows) * 1.1 || 100;
+			const maxHead = Math.max(...allHeads) * 1.1 || 100;
+
+			chart = new Chart(canvasEl, {
+				type: 'scatter',
+				data: { datasets },
+				options: {
+					responsive: true,
+					maintainAspectRatio: false,
+					interaction: {
+						intersect: false,
+						mode: 'index'
+					},
+					plugins: {
+						legend: {
+							position: 'bottom',
+							labels: {
+								usePointStyle: true,
+								padding: 16
+							}
+						},
+						tooltip: {
+							callbacks: {
+								label(context) {
+									const point = context.raw as { x: number; y: number };
+									return `${context.dataset.label}: ${point.x.toFixed(1)} GPM @ ${point.y.toFixed(1)} ft`;
+								}
+							}
 						}
 					},
-					tooltip: {
-						callbacks: {
-							label(context) {
-								const point = context.raw as { x: number; y: number };
-								return `${context.dataset.label}: ${point.x.toFixed(1)} GPM @ ${point.y.toFixed(1)} ft`;
+					scales: {
+						x: {
+							type: 'linear',
+							min: 0,
+							max: maxFlow,
+							title: {
+								display: true,
+								text: 'Flow (GPM)',
+								font: { weight: 'bold' }
+							},
+							grid: {
+								color: 'rgba(0, 0, 0, 0.05)'
+							}
+						},
+						y: {
+							type: 'linear',
+							min: 0,
+							max: maxHead,
+							title: {
+								display: true,
+								text: 'Head (ft)',
+								font: { weight: 'bold' }
+							},
+							grid: {
+								color: 'rgba(0, 0, 0, 0.05)'
 							}
 						}
 					}
-				},
-				scales: {
-					x: {
-						type: 'linear',
-						min: 0,
-						max: maxFlow,
-						title: {
-							display: true,
-							text: 'Flow (GPM)',
-							font: { weight: 'bold' }
-						},
-						grid: {
-							color: 'rgba(0, 0, 0, 0.05)'
-						}
-					},
-					y: {
-						type: 'linear',
-						min: 0,
-						max: maxHead,
-						title: {
-							display: true,
-							text: 'Head (ft)',
-							font: { weight: 'bold' }
-						},
-						grid: {
-							color: 'rgba(0, 0, 0, 0.05)'
-						}
-					}
 				}
-			}
-		});
+			});
+		} catch (error) {
+			console.error('Error creating pump curve chart:', error);
+		}
 	}
 
-	// Update chart when data changes
+	// Effect for chart lifecycle - creates chart when canvas is available, destroys on cleanup
 	$effect(() => {
-		// Access reactive dependencies to trigger effect
-		void chartData;
-		void curve;
-		void result;
+		// Track dependencies
+		const currentCanvas = canvas;
+		const currentCurve = curve;
+		const currentResult = result;
 
-		// Recreate chart
-		if (canvas) {
-			createChart();
+		if (currentCanvas && currentCurve?.points?.length > 0) {
+			// Use setTimeout to ensure we're not in the middle of a render
+			const timeoutId = setTimeout(() => {
+				createChart(currentCanvas);
+			}, 0);
+
+			// Cleanup function
+			return () => {
+				clearTimeout(timeoutId);
+				destroyChart();
+			};
 		}
-	});
 
-	onMount(() => {
-		createChart();
-	});
-
-	onDestroy(() => {
-		if (chart) {
-			chart.destroy();
-		}
+		// Return cleanup if no canvas
+		return () => {
+			destroyChart();
+		};
 	});
 </script>
 
 <div class="relative h-64 w-full sm:h-80">
-	<canvas bind:this={canvas}></canvas>
+	<canvas bind:this={canvas} class="w-full h-full"></canvas>
 </div>
 
 {#if result}


### PR DESCRIPTION
## Summary
- Fix TypeError when clicking the Pumps tab in Results view and being unable to navigate away
- Replace `onMount`/`onDestroy` lifecycle hooks with Svelte 5 `$effect` cleanup pattern
- Chart.js instances are now properly created and destroyed during conditional rendering

## Test plan
- [ ] Navigate to a project with a pump (e.g., Reservoir → Valve → Pump → Valve → Tank)
- [ ] Click Solve to generate results
- [ ] Click the Pumps tab in Results view
- [ ] Verify pump data displays (flow, head, NPSH, efficiency)
- [ ] Click away to another tab (Summary, Components, Piping)
- [ ] Verify navigation works without freezing

🤖 Generated with [Claude Code](https://claude.com/claude-code)