### PR TITLE
feat(ui): improve results panel tables and pump curve chart

### DIFF
--- a/apps/web/src/lib/components/results/PipingTable.svelte
+++ b/apps/web/src/lib/components/results/PipingTable.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import { components } from '$lib/stores';
-	import { FLOW_REGIME_LABELS, type SolvedState } from '$lib/models';
+	import { components, connections } from '$lib/stores';
+	import type { SolvedState } from '$lib/models';
 
 	interface Props {
 		/** The solved state containing results. */
@@ -16,34 +16,31 @@
 		result: typeof results.piping_results[string] | undefined;
 	}
 
-	// Get piping segments with their results
+	// Build a map of component IDs to names for display
+	let componentNames = $derived.by(() => {
+		const names: Record<string, string> = {};
+		$components.forEach((comp) => {
+			names[comp.id] = comp.name;
+		});
+		return names;
+	});
+
+	// Get piping segments with their results using connections
 	let pipingData = $derived.by(() => {
 		const data: PipingData[] = [];
 
-		// Add piping segments from components with upstream_piping
-		$components.forEach((comp) => {
-			if (comp.upstream_piping) {
-				const pipeId = `pipe_${comp.id}`;
+		// Use the connections array which has the proper IDs that match piping_results
+		$connections.forEach((conn) => {
+			if (conn.piping) {
+				const fromName = componentNames[conn.from_component_id] || conn.from_component_id;
+				const toName = componentNames[conn.to_component_id] || conn.to_component_id;
 				data.push({
-					id: pipeId,
-					name: `Pipe to ${comp.name}`,
+					id: conn.id,
+					name: `${fromName} → ${toName}`,
 					type: 'pipe',
-					result: results.piping_results[pipeId] || results.piping_results[comp.id]
+					result: results.piping_results[conn.id]
 				});
 			}
-
-			// Also check downstream connections for piping
-			comp.downstream_connections?.forEach((conn) => {
-				if (conn.piping) {
-					const pipeId = `pipe_${comp.id}_to_${conn.target_component_id}`;
-					data.push({
-						id: pipeId,
-						name: `Pipe from ${comp.name}`,
-						type: 'pipe',
-						result: results.piping_results[pipeId]
-					});
-				}
-			});
 		});
 
 		return data;
@@ -52,14 +49,6 @@
 	function formatNumber(value: number | undefined, decimals = 2): string {
 		if (value === undefined) return '-';
 		return value.toFixed(decimals);
-	}
-
-	function formatScientific(value: number | undefined): string {
-		if (value === undefined) return '-';
-		if (value >= 10000 || value < 0.01) {
-			return value.toExponential(2);
-		}
-		return value.toFixed(0);
 	}
 </script>
 
@@ -70,9 +59,6 @@
 				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
 					Piping
 				</th>
-				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-					Type
-				</th>
 				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
 					Flow (GPM)
 				</th>
@@ -82,12 +68,6 @@
 				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
 					Head Loss (ft)
 				</th>
-				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
-					Reynolds
-				</th>
-				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
-					Regime
-				</th>
 			</tr>
 		</thead>
 		<tbody class="divide-y divide-gray-200 bg-white">
@@ -95,9 +75,6 @@
 				<tr class="hover:bg-gray-50">
 					<td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
 						{piping.name}
-					</td>
-					<td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
-						Pipe
 					</td>
 					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
 						{formatNumber(piping.result?.flow)}
@@ -108,30 +85,11 @@
 					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
 						{formatNumber(piping.result?.head_loss)}
 					</td>
-					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
-						{formatScientific(piping.result?.reynolds_number)}
-					</td>
-					<td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
-						{#if piping.result?.regime}
-							<span
-								class="inline-flex rounded-full px-2 py-0.5 text-xs font-medium
-									{piping.result.regime === 'laminar'
-									? 'bg-green-100 text-green-800'
-									: piping.result.regime === 'transitional'
-										? 'bg-yellow-100 text-yellow-800'
-										: 'bg-blue-100 text-blue-800'}"
-							>
-								{FLOW_REGIME_LABELS[piping.result.regime]}
-							</span>
-						{:else}
-							-
-						{/if}
-					</td>
 				</tr>
 			{/each}
 			{#if pipingData.length === 0}
 				<tr>
-					<td colspan="7" class="px-4 py-8 text-center text-sm text-gray-500">
+					<td colspan="4" class="px-4 py-8 text-center text-sm text-gray-500">
 						No piping results available
 					</td>
 				</tr>

--- a/apps/web/src/lib/components/results/PumpCurveChart.svelte
+++ b/apps/web/src/lib/components/results/PumpCurveChart.svelte
@@ -39,19 +39,7 @@
 			// Build datasets
 			const datasets: Chart['data']['datasets'] = [];
 
-			// Pump curve
-			datasets.push({
-				label: 'Pump Curve',
-				data: curve.points.map((p) => ({ x: p.flow, y: p.head })),
-				borderColor: 'rgb(59, 130, 246)',
-				backgroundColor: 'rgba(59, 130, 246, 0.1)',
-				fill: false,
-				tension: 0.4,
-				pointRadius: 3,
-				pointHoverRadius: 5
-			});
-
-			// System curve
+			// System curve - smooth line only, no points (drawn first/behind)
 			if (result?.system_curve && result.system_curve.length > 0) {
 				datasets.push({
 					label: 'System Curve',
@@ -59,11 +47,40 @@
 					borderColor: 'rgb(239, 68, 68)',
 					backgroundColor: 'rgba(239, 68, 68, 0.1)',
 					fill: false,
+					showLine: true,
 					tension: 0.4,
 					pointRadius: 0,
-					borderDash: [5, 5]
+					pointHoverRadius: 0,
+					borderWidth: 2,
+					order: 3
 				});
 			}
+
+			// Pump curve line (drawn behind points)
+			datasets.push({
+				label: 'Pump Curve',
+				data: curve.points.map((p) => ({ x: p.flow, y: p.head })),
+				borderColor: 'rgb(59, 130, 246)',
+				backgroundColor: 'rgba(59, 130, 246, 0.1)',
+				fill: false,
+				showLine: true,
+				tension: 0.4,
+				pointRadius: 0,
+				borderWidth: 2,
+				order: 2
+			});
+
+			// Pump curve points (drawn on top of line)
+			datasets.push({
+				label: 'Pump Curve Points',
+				data: curve.points.map((p) => ({ x: p.flow, y: p.head })),
+				borderColor: 'rgb(59, 130, 246)',
+				backgroundColor: 'rgb(59, 130, 246)',
+				showLine: false,
+				pointRadius: 5,
+				pointHoverRadius: 7,
+				order: 1
+			});
 
 			// Operating point
 			if (result?.operating_flow !== undefined && result?.operating_head !== undefined) {
@@ -112,14 +129,16 @@
 							position: 'bottom',
 							labels: {
 								usePointStyle: true,
-								padding: 16
+								padding: 16,
+								filter: (item) => item.text !== 'Pump Curve Points'
 							}
 						},
 						tooltip: {
 							callbacks: {
 								label(context) {
 									const point = context.raw as { x: number; y: number };
-									return `${context.dataset.label}: ${point.x.toFixed(1)} GPM @ ${point.y.toFixed(1)} ft`;
+									const label = context.dataset.label === 'Pump Curve Points' ? 'Pump Curve' : context.dataset.label;
+									return `${label}: ${point.x.toFixed(1)} GPM @ ${point.y.toFixed(1)} ft`;
 								}
 							}
 						}

--- a/apps/web/src/lib/stores/index.ts
+++ b/apps/web/src/lib/stores/index.ts
@@ -8,6 +8,7 @@
 export {
 	projectStore,
 	components,
+	connections,
 	pumpLibrary,
 	fluid,
 	settings,


### PR DESCRIPTION
## Summary

- **ComponentTable**: Show results per port with rowspan grouping for multi-port components (pump suction/discharge, valve inlet/outlet)
- **PipingTable**: Fix results lookup using connections store, remove Reynolds and Regime columns for cleaner display
- **PumpCurveChart**: Add smooth spline lines connecting curve points, render line behind points, filter "Pump Curve Points" from legend
- Add `connections` export to stores/index.ts

## Changes

### ComponentTable.svelte
- Added `PortRow` interface to track port-specific data
- Uses `$derived.by()` to generate rows for each port on each component
- Uses `rowspan` to visually group ports belonging to the same component
- Added Port column showing port ID with direction (In/Out)

### PipingTable.svelte
- Fixed piping results lookup by using `connections` store with proper connection IDs
- Removed Reynolds Number and Flow Regime columns for cleaner display
- Now displays: Piping, Flow (GPM), Velocity (ft/s), Head Loss (ft)

### PumpCurveChart.svelte
- Split pump curve into two datasets: line (drawn first) and points (drawn on top)
- Added `order` property to control z-order rendering
- System curve shows smooth line only (no points) with `pointRadius: 0`
- Added legend filter to hide "Pump Curve Points" entry
- Updated tooltip to show "Pump Curve" for points dataset

## Test plan

- [ ] Load demo project and verify Pumps tab shows smooth curves
- [ ] Verify pump curve line appears behind data points
- [ ] Check Piping tab shows correct flow, velocity, head loss values
- [ ] Verify Components tab shows port information for multi-port components
- [ ] Confirm rowspan grouping works correctly for pumps and valves

🤖 Generated with [Claude Code](https://claude.com/claude-code)