### PR TITLE
fix: Disable Previous button when on first component

### DIFF
--- a/apps/web/src/lib/components/panel/NavigationControls.svelte
+++ b/apps/web/src/lib/components/panel/NavigationControls.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { navigationStore, canGoBack, canGoForward, components } from '$lib/stores';
+	import { navigationStore, components } from '$lib/stores';
 	import { COMPONENT_TYPE_LABELS } from '$lib/models';
 
 	interface Props {
@@ -20,31 +20,27 @@
 	let totalComponents = $derived($components.length);
 
 	function handlePrev() {
-		// Navigate to previous component in the chain
+		// Navigate to previous component in the chain (linear navigation)
 		if (currentIndex > 0) {
 			const prevComponent = $components[currentIndex - 1];
 			navigationStore.navigateTo(prevComponent.id);
-			onNavigate?.('prev');
-		} else if ($canGoBack) {
-			navigationStore.goBack();
 			onNavigate?.('prev');
 		}
 	}
 
 	function handleNext() {
-		// Navigate to next component in the chain
+		// Navigate to next component in the chain (linear navigation)
 		if (currentIndex < totalComponents - 1) {
 			const nextComponent = $components[currentIndex + 1];
 			navigationStore.navigateTo(nextComponent.id);
 			onNavigate?.('next');
-		} else if ($canGoForward) {
-			navigationStore.goForward();
-			onNavigate?.('next');
 		}
 	}
 
-	let canNavigatePrev = $derived(currentIndex > 0 || $canGoBack);
-	let canNavigateNext = $derived(currentIndex < totalComponents - 1 || $canGoForward);
+	// Previous/Next are purely linear through component chain
+	// (not affected by visit history)
+	let canNavigatePrev = $derived(currentIndex > 0);
+	let canNavigateNext = $derived(currentIndex < totalComponents - 1);
 </script>
 
 <div class="flex items-center justify-between border-t border-gray-200 bg-gray-50 px-4 py-3">


### PR DESCRIPTION
## Summary

Fix navigation bug where Previous button was enabled on component 1 and incorrectly navigated to component 2.

## Problem

The Previous/Next buttons were conflating two navigation concepts:
1. **Linear navigation** through the component chain (1 → 2 → 3)
2. **History navigation** (back/forward through visited components)

When on component 1, if the user had previously visited component 2, `$canGoBack` was true (because of visit history), which enabled the Previous button. Clicking it would call `goBack()` and navigate to component 2 instead of being disabled.

## Solution

Make Previous/Next buttons purely linear through the component chain:
- **Previous:** Disabled when `currentIndex <= 0` (on first component)
- **Next:** Disabled when `currentIndex >= totalComponents - 1` (on last component)

Visit history (`canGoBack`/`canGoForward`) is no longer factored into these buttons.

## Test plan

- [ ] Navigate to component 1 of 3
- [ ] Verify Previous button is greyed out and disabled
- [ ] Navigate to component 2 of 3
- [ ] Verify Previous button is enabled and goes to component 1
- [ ] Navigate to component 3 of 3
- [ ] Verify Next button is greyed out and disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)