### PR TITLE
feat(ui): consolidate Reference Node menu and reorder component groups

### DIFF
--- a/apps/web/src/lib/components/forms/ReferenceNodeForm.svelte
+++ b/apps/web/src/lib/components/forms/ReferenceNodeForm.svelte
@@ -7,12 +7,22 @@
 		component: IdealReferenceNode | NonIdealReferenceNode;
 		/** Callback when a field value changes. */
 		onUpdate: (field: string, value: unknown) => void;
+		/** Callback to change the component type (for switching between ideal/non-ideal). */
+		onTypeChange?: (newType: 'ideal_reference_node' | 'non_ideal_reference_node') => void;
 	}
 
-	let { component, onUpdate }: Props = $props();
+	let { component, onUpdate, onTypeChange }: Props = $props();
 
 	// Check if this is an ideal or non-ideal reference node
 	const isIdeal = $derived(component.type === 'ideal_reference_node');
+
+	// Handle type switch
+	function handleTypeSwitch(newIsIdeal: boolean) {
+		const newType = newIsIdeal ? 'ideal_reference_node' : 'non_ideal_reference_node';
+		if (newType !== component.type && onTypeChange) {
+			onTypeChange(newType);
+		}
+	}
 
 	// For non-ideal nodes, get the curve data
 	const curvePoints = $derived(
@@ -66,6 +76,38 @@
 </script>
 
 <div class="space-y-4">
+	<!-- Type Selector -->
+	<fieldset>
+		<legend class="block text-sm font-medium text-gray-700 mb-2">Reference Node Type</legend>
+		<div class="flex gap-2" role="group" aria-label="Reference Node Type">
+			<button
+				type="button"
+				onclick={() => handleTypeSwitch(true)}
+				aria-pressed={isIdeal}
+				class="flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors
+					{isIdeal
+					? 'bg-blue-600 text-white'
+					: 'bg-gray-100 text-gray-700 hover:bg-gray-200'}"
+			>
+				Ideal
+			</button>
+			<button
+				type="button"
+				onclick={() => handleTypeSwitch(false)}
+				aria-pressed={!isIdeal}
+				class="flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors
+					{!isIdeal
+					? 'bg-amber-600 text-white'
+					: 'bg-gray-100 text-gray-700 hover:bg-gray-200'}"
+			>
+				Non-Ideal
+			</button>
+		</div>
+		<p class="mt-1 text-xs text-gray-500">
+			{isIdeal ? 'Constant pressure boundary' : 'Pressure varies with flow'}
+		</p>
+	</fieldset>
+
 	<NumberInput
 		id="elevation"
 		label="Elevation"

--- a/apps/web/src/lib/models/components.ts
+++ b/apps/web/src/lib/models/components.ts
@@ -71,8 +71,8 @@ export const COMPONENT_TYPE_LABELS: Record<ComponentType, string> = {
 	strainer: 'Strainer',
 	orifice: 'Orifice',
 	sprinkler: 'Sprinkler',
-	ideal_reference_node: 'Reference Node (Ideal)',
-	non_ideal_reference_node: 'Reference Node (Non-Ideal)',
+	ideal_reference_node: 'Reference Node',
+	non_ideal_reference_node: 'Reference Node',
 	plug: 'Plug/Cap',
 	tee_branch: 'Tee Branch',
 	wye_branch: 'Wye Branch',
@@ -83,11 +83,14 @@ export const COMPONENT_TYPE_LABELS: Record<ComponentType, string> = {
  * Component categories for UI grouping.
  * All equipment is grouped together - "links" (piping/fittings) connect components.
  * See ADR-006 in docs/DECISIONS.md for rationale.
+ *
+ * Note: 'ideal_reference_node' is used as the menu entry for Reference Node.
+ * Users can switch to non-ideal within the component form.
  */
 export const COMPONENT_CATEGORIES = {
-	Sources: ['reservoir', 'tank', 'ideal_reference_node', 'non_ideal_reference_node'] as ComponentType[],
-	Connections: ['junction', 'tee_branch', 'wye_branch', 'cross_branch', 'plug'] as ComponentType[],
-	Equipment: ['pump', 'valve', 'heat_exchanger', 'strainer', 'orifice', 'sprinkler'] as ComponentType[]
+	Sources: ['reservoir', 'tank', 'ideal_reference_node'] as ComponentType[],
+	Equipment: ['pump', 'valve', 'heat_exchanger', 'strainer', 'orifice', 'sprinkler'] as ComponentType[],
+	Connections: ['junction', 'tee_branch', 'wye_branch', 'cross_branch', 'plug'] as ComponentType[]
 };
 
 /** Types of control valves. */


### PR DESCRIPTION
## Summary

- Merge "Reference Node (Ideal)" and "Reference Node (Non-Ideal)" into single "Reference Node" menu item
- Add type selector (Ideal/Non-Ideal toggle) within the Reference Node form in the element panel
- Reorder component groups in Add Component menu: Sources → Equipment → Connections
- Implement type conversion logic to preserve data when switching between ideal and non-ideal

## Changes

### `apps/web/src/lib/models/components.ts`
- Updated `COMPONENT_TYPE_LABELS` to show "Reference Node" for both types
- Reordered `COMPONENT_CATEGORIES` with Equipment second
- Removed `non_ideal_reference_node` from Sources category (only ideal in menu)

### `apps/web/src/lib/components/forms/ReferenceNodeForm.svelte`
- Added `onTypeChange` prop for type switching callback
- Added Ideal/Non-Ideal toggle button group with accessible fieldset/legend pattern
- Uses `aria-pressed` for accessibility

### `apps/web/src/lib/components/panel/ElementPanel.svelte`
- Added `handleReferenceNodeTypeChange` function to convert between ideal/non-ideal
- Preserves relevant data during conversion (e.g., first curve pressure → fixed pressure)

## Test plan

- [ ] Add a Reference Node from the menu (should add ideal by default)
- [ ] Toggle to Non-Ideal and verify form changes to show pressure-flow curve
- [ ] Toggle back to Ideal and verify pressure is preserved from first curve point
- [ ] Verify Equipment group appears second in Add Component menu
- [ ] Verify accessibility: button group has proper ARIA attributes

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)