### PR TITLE
feat: #89 - Add port-level elevation support for components

### DIFF
--- a/apps/api/src/opensolve_pipe/models/components.py
+++ b/apps/api/src/opensolve_pipe/models/components.py
@@ -98,6 +98,32 @@ class BaseComponent(OpenSolvePipeBaseModel):
                 return port
         return None
 
+    def get_port_elevation(self, port_id: str) -> float:
+        """Get the effective elevation for a port.
+
+        If the port has a specific elevation set, that value is returned.
+        Otherwise, the component's elevation is returned (inheritance).
+
+        This is useful for modeling:
+        - Tanks/Reservoirs with ports at different heights (bottom drain, side fill, top overflow)
+        - Pumps with suction and discharge nozzles at different elevations
+        - Heat exchangers with shell/tube connections at different heights
+        - Vertical equipment where connection points span multiple elevations
+
+        Args:
+            port_id: The ID of the port to get elevation for
+
+        Returns:
+            The effective elevation of the port
+
+        Raises:
+            ValueError: If the port_id is not found on this component
+        """
+        port = self.get_port(port_id)
+        if port is None:
+            raise ValueError(f"Port '{port_id}' not found on component '{self.id}'")
+        return port.elevation if port.elevation is not None else self.elevation
+
     def get_inlet_ports(self) -> list[Port]:
         """Get all inlet ports."""
         return [

--- a/apps/api/src/opensolve_pipe/models/ports.py
+++ b/apps/api/src/opensolve_pipe/models/ports.py
@@ -4,7 +4,7 @@ from enum import Enum
 
 from pydantic import Field
 
-from .base import OpenSolvePipeBaseModel, PositiveFloat
+from .base import Elevation, OpenSolvePipeBaseModel, PositiveFloat
 
 
 class PortDirection(str, Enum):
@@ -22,6 +22,12 @@ class Port(OpenSolvePipeBaseModel):
     - A unique ID within the component (e.g., "suction", "discharge")
     - A nominal size for pipe size matching
     - A direction indicating flow constraints
+    - An optional elevation override for port-specific height
+
+    If elevation is not specified (None), the port inherits the parent
+    component's elevation. This is useful for most equipment. For tall
+    equipment like tanks, reservoirs, or vertical pumps, port-specific
+    elevations can be set to model connection points at different heights.
     """
 
     id: str = Field(description="Unique port identifier within the component")
@@ -31,6 +37,10 @@ class Port(OpenSolvePipeBaseModel):
     direction: PortDirection = Field(
         default=PortDirection.BIDIRECTIONAL,
         description="Flow direction constraint for this port",
+    )
+    elevation: Elevation | None = Field(
+        default=None,
+        description="Optional port-specific elevation. If None, inherits from parent component.",
     )
 
 

--- a/apps/api/tests/test_models/test_ports.py
+++ b/apps/api/tests/test_models/test_ports.py
@@ -226,3 +226,74 @@ class TestSprinklerPorts:
         ports = create_sprinkler_ports(inlet_size=0.5)
 
         assert ports[0].nominal_size == 0.5
+
+
+class TestPortElevation:
+    """Tests for port elevation functionality."""
+
+    def test_port_elevation_default_none(self):
+        """Test that port elevation defaults to None."""
+        port = Port(id="port_1", nominal_size=4.0)
+
+        assert port.elevation is None
+
+    def test_port_elevation_can_be_set(self):
+        """Test that port elevation can be explicitly set."""
+        port = Port(id="port_1", nominal_size=4.0, elevation=10.0)
+
+        assert port.elevation == 10.0
+
+    def test_port_elevation_can_be_negative(self):
+        """Test that port elevation can be negative (below reference)."""
+        port = Port(id="port_1", nominal_size=4.0, elevation=-5.0)
+
+        assert port.elevation == -5.0
+
+    def test_port_elevation_can_be_zero(self):
+        """Test that port elevation can be zero."""
+        port = Port(id="port_1", nominal_size=4.0, elevation=0.0)
+
+        assert port.elevation == 0.0
+
+    def test_port_serialization_with_elevation(self):
+        """Test port with elevation serializes correctly."""
+        port = Port(id="outlet", nominal_size=6.0, elevation=15.5)
+        data = port.model_dump()
+
+        assert data["id"] == "outlet"
+        assert data["nominal_size"] == 6.0
+        assert data["elevation"] == 15.5
+
+    def test_port_serialization_without_elevation(self):
+        """Test port without elevation serializes with None."""
+        port = Port(id="outlet", nominal_size=6.0)
+        data = port.model_dump()
+
+        assert data["elevation"] is None
+
+    def test_port_deserialization_with_elevation(self):
+        """Test port with elevation deserializes correctly."""
+        data = {
+            "id": "drain",
+            "nominal_size": 2.0,
+            "direction": "outlet",
+            "elevation": -2.5,
+        }
+        port = Port.model_validate(data)
+
+        assert port.id == "drain"
+        assert port.elevation == -2.5
+
+    def test_port_deserialization_without_elevation(self):
+        """Test port without elevation field deserializes to None."""
+        data = {"id": "inlet", "nominal_size": 4.0, "direction": "inlet"}
+        port = Port.model_validate(data)
+
+        assert port.elevation is None
+
+    def test_port_deserialization_with_null_elevation(self):
+        """Test port with explicit null elevation deserializes to None."""
+        data = {"id": "inlet", "nominal_size": 4.0, "elevation": None}
+        port = Port.model_validate(data)
+
+        assert port.elevation is None

--- a/apps/web/src/lib/models/__tests__/components.test.ts
+++ b/apps/web/src/lib/models/__tests__/components.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for component model utility functions.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+	getPortElevation,
+	createReservoirPorts,
+	createPumpPorts,
+	createTankPorts,
+	type Component,
+	type Port
+} from '../components';
+
+describe('getPortElevation', () => {
+	it('returns component elevation when port has no elevation', () => {
+		const component: Component = {
+			id: 'R1',
+			type: 'reservoir',
+			name: 'Test Reservoir',
+			elevation: 100,
+			water_level: 10,
+			ports: createReservoirPorts(4.0),
+			downstream_connections: []
+		};
+
+		expect(getPortElevation(component, 'outlet_1')).toBe(100);
+	});
+
+	it('returns port elevation when explicitly set', () => {
+		const ports: Port[] = [
+			{ id: 'bottom_drain', nominal_size: 4.0, direction: 'bidirectional', elevation: 95 },
+			{ id: 'side_fill', nominal_size: 6.0, direction: 'bidirectional', elevation: 105 },
+			{ id: 'top_overflow', nominal_size: 4.0, direction: 'bidirectional', elevation: 120 }
+		];
+
+		const component: Component = {
+			id: 'T1',
+			type: 'tank',
+			name: 'Test Tank',
+			elevation: 100,
+			diameter: 10,
+			min_level: 0,
+			max_level: 20,
+			initial_level: 10,
+			ports,
+			downstream_connections: []
+		};
+
+		expect(getPortElevation(component, 'bottom_drain')).toBe(95);
+		expect(getPortElevation(component, 'side_fill')).toBe(105);
+		expect(getPortElevation(component, 'top_overflow')).toBe(120);
+	});
+
+	it('returns 0 when port elevation is explicitly set to 0', () => {
+		const ports: Port[] = [
+			{ id: 'outlet_1', nominal_size: 4.0, direction: 'bidirectional', elevation: 0 }
+		];
+
+		const component: Component = {
+			id: 'R1',
+			type: 'reservoir',
+			name: 'Test Reservoir',
+			elevation: 50, // Component at 50 ft
+			water_level: 10,
+			ports,
+			downstream_connections: []
+		};
+
+		// Port elevation is explicitly 0, should not inherit 50
+		expect(getPortElevation(component, 'outlet_1')).toBe(0);
+	});
+
+	it('supports negative port elevations', () => {
+		const ports: Port[] = [
+			{ id: 'bottom', nominal_size: 4.0, direction: 'bidirectional', elevation: -25 }
+		];
+
+		const component: Component = {
+			id: 'T1',
+			type: 'tank',
+			name: 'Underground Tank',
+			elevation: -10, // Tank top at -10 ft
+			diameter: 10,
+			min_level: 0,
+			max_level: 20,
+			initial_level: 10,
+			ports,
+			downstream_connections: []
+		};
+
+		expect(getPortElevation(component, 'bottom')).toBe(-25);
+	});
+
+	it('handles mixed ports - some with elevation, some without', () => {
+		const ports: Port[] = [
+			{ id: 'suction', nominal_size: 6.0, direction: 'inlet', elevation: 5 }, // Explicit elevation
+			{ id: 'discharge', nominal_size: 4.0, direction: 'outlet' } // No elevation, inherits
+		];
+
+		const component: Component = {
+			id: 'P1',
+			type: 'pump',
+			name: 'Vertical Pump',
+			elevation: 10, // Pump body at 10 ft
+			curve_id: 'PC1',
+			speed: 1.0,
+			status: 'on',
+			ports,
+			downstream_connections: []
+		};
+
+		expect(getPortElevation(component, 'suction')).toBe(5); // Uses explicit elevation
+		expect(getPortElevation(component, 'discharge')).toBe(10); // Inherits component elevation
+	});
+
+	it('throws error for non-existent port', () => {
+		const component: Component = {
+			id: 'R1',
+			type: 'reservoir',
+			name: 'Test Reservoir',
+			elevation: 100,
+			water_level: 10,
+			ports: createReservoirPorts(4.0),
+			downstream_connections: []
+		};
+
+		expect(() => getPortElevation(component, 'nonexistent_port')).toThrow(
+			"Port 'nonexistent_port' not found on component 'R1'"
+		);
+	});
+});
+
+describe('Port interface', () => {
+	it('allows port creation without elevation (undefined)', () => {
+		const port: Port = {
+			id: 'port_1',
+			nominal_size: 4.0,
+			direction: 'bidirectional'
+		};
+
+		expect(port.elevation).toBeUndefined();
+	});
+
+	it('allows port creation with explicit elevation', () => {
+		const port: Port = {
+			id: 'port_1',
+			nominal_size: 4.0,
+			direction: 'bidirectional',
+			elevation: 15.5
+		};
+
+		expect(port.elevation).toBe(15.5);
+	});
+
+	it('allows port creation with zero elevation', () => {
+		const port: Port = {
+			id: 'port_1',
+			nominal_size: 4.0,
+			direction: 'bidirectional',
+			elevation: 0
+		};
+
+		expect(port.elevation).toBe(0);
+	});
+
+	it('allows port creation with negative elevation', () => {
+		const port: Port = {
+			id: 'port_1',
+			nominal_size: 4.0,
+			direction: 'bidirectional',
+			elevation: -10
+		};
+
+		expect(port.elevation).toBe(-10);
+	});
+});
+
+describe('Port factory functions', () => {
+	it('createReservoirPorts returns ports without elevation (undefined)', () => {
+		const ports = createReservoirPorts(4.0);
+		expect(ports[0].elevation).toBeUndefined();
+	});
+
+	it('createTankPorts returns ports without elevation (undefined)', () => {
+		const ports = createTankPorts(4.0);
+		expect(ports[0].elevation).toBeUndefined();
+	});
+
+	it('createPumpPorts returns ports without elevation (undefined)', () => {
+		const ports = createPumpPorts(6.0, 4.0);
+		expect(ports[0].elevation).toBeUndefined();
+		expect(ports[1].elevation).toBeUndefined();
+	});
+});

--- a/docs/plans/issue-89-plan.md
+++ b/docs/plans/issue-89-plan.md
@@ -1,0 +1,72 @@
+# Implementation Plan: Port-Level Elevation Support (Issue #89)
+
+## Overview
+
+Add optional elevation field to the Port model to allow port-specific elevations on components. This enables accurate modeling of:
+
+- Tanks/Reservoirs with ports at different heights (bottom drain, side fill, top overflow)
+- Pumps with suction and discharge nozzles at different elevations
+- Heat exchangers with shell/tube connections at different heights
+- Vertical equipment where connection points span multiple elevations
+
+## Implementation Summary
+
+### 1. Backend Changes
+
+#### 1.1 Port Model (`apps/api/src/opensolve_pipe/models/ports.py`)
+
+- Added optional `elevation: Elevation | None = None` field to `Port` class
+- Updated docstring to explain the inheritance behavior
+
+#### 1.2 BaseComponent (`apps/api/src/opensolve_pipe/models/components.py`)
+
+- Added `get_port_elevation(port_id: str) -> float` method
+- Returns port-specific elevation if set, otherwise inherits component elevation
+- Raises `ValueError` if port_id not found
+
+### 2. Frontend Changes
+
+#### 2.1 Port Interface (`apps/web/src/lib/models/components.ts`)
+
+- Added optional `elevation?: number` field to `Port` interface
+- Updated interface documentation
+
+#### 2.2 Helper Function
+
+- Added `getPortElevation(component: Component, portId: string): number`
+- Mirrors Python implementation behavior
+
+### 3. Tests Added
+
+#### Backend Tests (`apps/api/tests/test_models/`)
+
+- `test_ports.py::TestPortElevation` - 9 tests for Port elevation field
+- `test_components.py::TestGetPortElevation` - 7 tests for get_port_elevation method
+
+#### Frontend Tests (`apps/web/src/lib/models/__tests__/`)
+
+- `components.test.ts` - 13 tests for getPortElevation and Port interface
+
+### 4. Acceptance Criteria Status
+
+- [x] Add optional `elevation` field to Port model
+- [x] Add `get_port_elevation()` method to BaseComponent
+- [ ] Update solver service to use port-level elevations (deferred - requires careful analysis)
+- [ ] Update frontend forms to allow port elevation input (deferred - separate PR)
+- [x] Add unit tests for elevation inheritance logic
+- [ ] Update documentation (minimal updates in code, full docs separate PR)
+
+### 5. Notes
+
+The solver service changes were intentionally deferred to a follow-up PR because:
+
+1. The current implementation establishes the foundation (data model + methods)
+2. Solver changes require careful analysis of all elevation usage points
+3. Frontend form changes should come with the solver update for a complete feature
+
+## Test Results
+
+- Backend: 629 tests passed
+- Frontend: 86 tests passed
+- Linting: All checks passed
+- Type checking: No errors or warnings


### PR DESCRIPTION
## Summary

Implements #89 - adds optional elevation field to Port model to support port-specific elevations on components.

This enables accurate modeling of:
- **Tanks/Reservoirs** - Ports at different heights (bottom drain, side fill, top overflow)
- **Pumps** - Suction and discharge nozzles at different elevations
- **Heat Exchangers** - Shell/tube connections at different heights
- **Vertical equipment** - Any equipment where connection points span multiple elevations

## Changes

### Backend (`apps/api/`)
- Added `elevation: Elevation | None = None` field to `Port` model
- Added `get_port_elevation(port_id: str) -> float` method to `BaseComponent`
- Added 16 unit tests for port elevation functionality

### Frontend (`apps/web/`)
- Added `elevation?: number` field to `Port` interface
- Added `getPortElevation(component, portId)` helper function
- Added 13 unit tests for TypeScript implementation

### Documentation
- Implementation plan at `docs/plans/issue-89-plan.md`

## Behavior

- If `port.elevation` is `None`/`undefined` (default): Inherit elevation from parent component
- If `port.elevation` is specified: Use the port's explicit elevation value
- This maintains backward compatibility - existing projects work unchanged

## Plan
See `docs/plans/issue-89-plan.md`

## Test Results
- Backend: 629 tests passed
- Frontend: 86 tests passed
- Linting: All checks passed
- Type checking: No errors or warnings

## Future Work
- Update solver service to use port-level elevations in calculations (separate PR)
- Add frontend forms for port elevation input (separate PR)

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)