### PR TITLE
feat(models): add name field to Port model and standardize port IDs (#92)

### DIFF
--- a/apps/api/src/opensolve_pipe/models/branch.py
+++ b/apps/api/src/opensolve_pipe/models/branch.py
@@ -43,9 +43,9 @@ def create_tee_ports(
     """Create ports for a tee branch component.
 
     Tees have three ports:
-    - run_inlet: Main line inlet (bidirectional for flow reversals)
-    - run_outlet: Main line outlet (bidirectional for flow reversals)
-    - branch: Branch connection (bidirectional)
+    - P1: Run Inlet (main line inlet, bidirectional for flow reversals)
+    - P2: Run Outlet (main line outlet, bidirectional for flow reversals)
+    - P3: Branch (branch connection, bidirectional)
 
     The branch can be the same size as the run (standard tee) or
     smaller (reducing tee).
@@ -62,17 +62,20 @@ def create_tee_ports(
 
     return [
         Port(
-            id="run_inlet",
+            id="P1",
+            name="Run Inlet",
             nominal_size=run_size,
             direction=PortDirection.BIDIRECTIONAL,
         ),
         Port(
-            id="run_outlet",
+            id="P2",
+            name="Run Outlet",
             nominal_size=run_size,
             direction=PortDirection.BIDIRECTIONAL,
         ),
         Port(
-            id="branch",
+            id="P3",
+            name="Branch",
             nominal_size=branch_size,
             direction=PortDirection.BIDIRECTIONAL,
         ),
@@ -86,9 +89,9 @@ def create_wye_ports(
     """Create ports for a wye branch component.
 
     Wyes have three ports:
-    - run_inlet: Main line inlet
-    - run_outlet: Main line outlet
-    - branch: Branch at an angle (typically 45°)
+    - P1: Run Inlet (main line inlet)
+    - P2: Run Outlet (main line outlet)
+    - P3: Branch (branch at an angle, typically 45°)
 
     Args:
         run_size: Nominal size of the run ports
@@ -102,17 +105,20 @@ def create_wye_ports(
 
     return [
         Port(
-            id="run_inlet",
+            id="P1",
+            name="Run Inlet",
             nominal_size=run_size,
             direction=PortDirection.BIDIRECTIONAL,
         ),
         Port(
-            id="run_outlet",
+            id="P2",
+            name="Run Outlet",
             nominal_size=run_size,
             direction=PortDirection.BIDIRECTIONAL,
         ),
         Port(
-            id="branch",
+            id="P3",
+            name="Branch",
             nominal_size=branch_size,
             direction=PortDirection.BIDIRECTIONAL,
         ),
@@ -126,10 +132,10 @@ def create_cross_ports(
     """Create ports for a cross branch component.
 
     Crosses have four ports arranged in two perpendicular lines:
-    - run_inlet: Main line inlet
-    - run_outlet: Main line outlet
-    - branch_1: First branch (perpendicular to run)
-    - branch_2: Second branch (opposite to branch_1)
+    - P1: Run Inlet (main line inlet)
+    - P2: Run Outlet (main line outlet)
+    - P3: Branch 1 (first branch, perpendicular to run)
+    - P4: Branch 2 (second branch, opposite to branch_1)
 
     Args:
         main_size: Nominal size of the main run ports
@@ -143,22 +149,26 @@ def create_cross_ports(
 
     return [
         Port(
-            id="run_inlet",
+            id="P1",
+            name="Run Inlet",
             nominal_size=main_size,
             direction=PortDirection.BIDIRECTIONAL,
         ),
         Port(
-            id="run_outlet",
+            id="P2",
+            name="Run Outlet",
             nominal_size=main_size,
             direction=PortDirection.BIDIRECTIONAL,
         ),
         Port(
-            id="branch_1",
+            id="P3",
+            name="Branch 1",
             nominal_size=branch_size,
             direction=PortDirection.BIDIRECTIONAL,
         ),
         Port(
-            id="branch_2",
+            id="P4",
+            name="Branch 2",
             nominal_size=branch_size,
             direction=PortDirection.BIDIRECTIONAL,
         ),
@@ -196,12 +206,12 @@ class BaseBranch(OpenSolvePipeBaseModel):
         return None
 
     def get_run_ports(self) -> list[Port]:
-        """Get the main run ports."""
-        return [p for p in self.ports if p.id.startswith("run_")]
+        """Get the main run ports (P1: Run Inlet, P2: Run Outlet)."""
+        return [p for p in self.ports if p.name.lower().startswith("run")]
 
     def get_branch_ports(self) -> list[Port]:
-        """Get the branch ports."""
-        return [p for p in self.ports if p.id.startswith("branch")]
+        """Get the branch ports (P3, P4, etc.)."""
+        return [p for p in self.ports if p.name.lower().startswith("branch")]
 
 
 class TeeBranch(BaseBranch):

--- a/apps/api/src/opensolve_pipe/models/plug.py
+++ b/apps/api/src/opensolve_pipe/models/plug.py
@@ -29,7 +29,8 @@ def create_plug_port(nominal_size: float = 4.0) -> list[Port]:
     """
     return [
         Port(
-            id="port_1",
+            id="P1",
+            name="Port",
             nominal_size=nominal_size,
             direction=PortDirection.BIDIRECTIONAL,
         )

--- a/apps/api/src/opensolve_pipe/models/reference_node.py
+++ b/apps/api/src/opensolve_pipe/models/reference_node.py
@@ -49,7 +49,8 @@ def create_reference_node_port(nominal_size: float = 4.0) -> list[Port]:
     """
     return [
         Port(
-            id="port_1",
+            id="P1",
+            name="Port",
             nominal_size=nominal_size,
             direction=PortDirection.BIDIRECTIONAL,
         )

--- a/apps/api/tests/models/test_branch.py
+++ b/apps/api/tests/models/test_branch.py
@@ -23,9 +23,9 @@ class TestCreateTeePorts:
         """Test creating default tee ports."""
         ports = create_tee_ports()
         assert len(ports) == 3
-        assert ports[0].id == "run_inlet"
-        assert ports[1].id == "run_outlet"
-        assert ports[2].id == "branch"
+        assert ports[0].id == "P1"
+        assert ports[1].id == "P2"
+        assert ports[2].id == "P3"
         assert all(p.nominal_size == 4.0 for p in ports)
         assert all(p.direction == PortDirection.BIDIRECTIONAL for p in ports)
 
@@ -39,9 +39,9 @@ class TestCreateTeePorts:
     def test_create_reducing_tee(self) -> None:
         """Test creating reducing tee ports."""
         ports = create_tee_ports(run_size=6.0, branch_size=4.0)
-        assert ports[0].nominal_size == 6.0  # run_inlet
-        assert ports[1].nominal_size == 6.0  # run_outlet
-        assert ports[2].nominal_size == 4.0  # branch (smaller)
+        assert ports[0].nominal_size == 6.0  # P1 (Run Inlet)
+        assert ports[1].nominal_size == 6.0  # P2 (Run Outlet)
+        assert ports[2].nominal_size == 4.0  # P3 (Branch, smaller)
 
 
 class TestCreateWyePorts:
@@ -51,9 +51,9 @@ class TestCreateWyePorts:
         """Test creating default wye ports."""
         ports = create_wye_ports()
         assert len(ports) == 3
-        assert ports[0].id == "run_inlet"
-        assert ports[1].id == "run_outlet"
-        assert ports[2].id == "branch"
+        assert ports[0].id == "P1"
+        assert ports[1].id == "P2"
+        assert ports[2].id == "P3"
 
     def test_create_reducing_wye(self) -> None:
         """Test creating reducing wye ports."""
@@ -69,18 +69,18 @@ class TestCreateCrossPorts:
         """Test creating default cross ports."""
         ports = create_cross_ports()
         assert len(ports) == 4
-        assert ports[0].id == "run_inlet"
-        assert ports[1].id == "run_outlet"
-        assert ports[2].id == "branch_1"
-        assert ports[3].id == "branch_2"
+        assert ports[0].id == "P1"
+        assert ports[1].id == "P2"
+        assert ports[2].id == "P3"
+        assert ports[3].id == "P4"
 
     def test_create_reducing_cross(self) -> None:
         """Test creating reducing cross ports."""
         ports = create_cross_ports(main_size=6.0, branch_size=4.0)
-        assert ports[0].nominal_size == 6.0  # run_inlet
-        assert ports[1].nominal_size == 6.0  # run_outlet
-        assert ports[2].nominal_size == 4.0  # branch_1
-        assert ports[3].nominal_size == 4.0  # branch_2
+        assert ports[0].nominal_size == 6.0  # P1 (Run Inlet)
+        assert ports[1].nominal_size == 6.0  # P2 (Run Outlet)
+        assert ports[2].nominal_size == 4.0  # P3 (Branch 1)
+        assert ports[3].nominal_size == 4.0  # P4 (Branch 2)
 
 
 class TestTeeBranch:
@@ -107,9 +107,9 @@ class TestTeeBranch:
             elevation=0.0,
         )
         assert len(tee.ports) == 3
-        assert tee.ports[0].id == "run_inlet"
-        assert tee.ports[1].id == "run_outlet"
-        assert tee.ports[2].id == "branch"
+        assert tee.ports[0].id == "P1"
+        assert tee.ports[1].id == "P2"
+        assert tee.ports[2].id == "P3"
 
     def test_tee_branch_custom_ports(self) -> None:
         """Test that custom ports are preserved."""
@@ -153,7 +153,7 @@ class TestTeeBranch:
                 id="tee_1",
                 name="Invalid",
                 elevation=0.0,
-                ports=[Port(id="single", nominal_size=4.0)],
+                ports=[Port(id="P1", name="Single", nominal_size=4.0)],
             )
         assert "exactly 3 ports" in str(exc_info.value)
 
@@ -164,9 +164,9 @@ class TestTeeBranch:
             name="Tee",
             elevation=0.0,
         )
-        port = tee.get_port("branch")
+        port = tee.get_port("P3")
         assert port is not None
-        assert port.id == "branch"
+        assert port.id == "P3"
         assert tee.get_port("nonexistent") is None
 
     def test_tee_branch_get_run_ports(self) -> None:
@@ -178,8 +178,8 @@ class TestTeeBranch:
         )
         run_ports = tee.get_run_ports()
         assert len(run_ports) == 2
-        assert run_ports[0].id == "run_inlet"
-        assert run_ports[1].id == "run_outlet"
+        assert run_ports[0].id == "P1"
+        assert run_ports[1].id == "P2"
 
     def test_tee_branch_get_branch_ports(self) -> None:
         """Test get_branch_ports method."""
@@ -190,7 +190,7 @@ class TestTeeBranch:
         )
         branch_ports = tee.get_branch_ports()
         assert len(branch_ports) == 1
-        assert branch_ports[0].id == "branch"
+        assert branch_ports[0].id == "P3"
 
 
 class TestWyeBranch:
@@ -246,8 +246,8 @@ class TestWyeBranch:
                 name="Invalid",
                 elevation=0.0,
                 ports=[
-                    Port(id="p1", nominal_size=4.0),
-                    Port(id="p2", nominal_size=4.0),
+                    Port(id="P1", name="Port 1", nominal_size=4.0),
+                    Port(id="P2", name="Port 2", nominal_size=4.0),
                 ],
             )
         assert "exactly 3 ports" in str(exc_info.value)
@@ -274,10 +274,10 @@ class TestCrossBranch:
             elevation=0.0,
         )
         assert len(cross.ports) == 4
-        assert cross.ports[0].id == "run_inlet"
-        assert cross.ports[1].id == "run_outlet"
-        assert cross.ports[2].id == "branch_1"
-        assert cross.ports[3].id == "branch_2"
+        assert cross.ports[0].id == "P1"
+        assert cross.ports[1].id == "P2"
+        assert cross.ports[2].id == "P3"
+        assert cross.ports[3].id == "P4"
 
     def test_cross_branch_invalid_port_count(self) -> None:
         """Test cross branch rejects wrong number of ports."""
@@ -288,7 +288,7 @@ class TestCrossBranch:
                 id="cross_1",
                 name="Invalid",
                 elevation=0.0,
-                ports=[Port(id="p1", nominal_size=4.0)],
+                ports=[Port(id="P1", name="Port 1", nominal_size=4.0)],
             )
         assert "exactly 4 ports" in str(exc_info.value)
 
@@ -301,8 +301,8 @@ class TestCrossBranch:
         )
         branch_ports = cross.get_branch_ports()
         assert len(branch_ports) == 2
-        assert branch_ports[0].id == "branch_1"
-        assert branch_ports[1].id == "branch_2"
+        assert branch_ports[0].id == "P3"
+        assert branch_ports[1].id == "P4"
 
 
 class TestBranchSerialization:

--- a/apps/api/tests/models/test_plug.py
+++ b/apps/api/tests/models/test_plug.py
@@ -14,7 +14,7 @@ class TestCreatePlugPort:
         """Test creating default plug port."""
         ports = create_plug_port()
         assert len(ports) == 1
-        assert ports[0].id == "port_1"
+        assert ports[0].id == "P1"
         assert ports[0].nominal_size == 4.0
         assert ports[0].direction == PortDirection.BIDIRECTIONAL
 
@@ -48,7 +48,7 @@ class TestPlug:
             elevation=0.0,
         )
         assert len(plug.ports) == 1
-        assert plug.ports[0].id == "port_1"
+        assert plug.ports[0].id == "P1"
         assert plug.ports[0].direction == PortDirection.BIDIRECTIONAL
 
     def test_plug_custom_ports(self) -> None:
@@ -102,12 +102,12 @@ class TestPlug:
             name="Cap",
             elevation=0.0,
         )
-        port = plug.get_port("port_1")
+        port = plug.get_port("P1")
         assert port is not None
-        assert port.id == "port_1"
+        assert port.id == "P1"
 
         # Non-existent port
-        assert plug.get_port("port_2") is None
+        assert plug.get_port("P2") is None
 
 
 class TestPlugSerialization:

--- a/apps/api/tests/models/test_reference_node.py
+++ b/apps/api/tests/models/test_reference_node.py
@@ -45,7 +45,7 @@ class TestCreateReferenceNodePort:
         """Test creating default reference node port."""
         ports = create_reference_node_port()
         assert len(ports) == 1
-        assert ports[0].id == "port_1"
+        assert ports[0].id == "P1"
         assert ports[0].nominal_size == 4.0
         assert ports[0].direction == PortDirection.BIDIRECTIONAL
 
@@ -82,7 +82,7 @@ class TestIdealReferenceNode:
             pressure=50.0,
         )
         assert len(node.ports) == 1
-        assert node.ports[0].id == "port_1"
+        assert node.ports[0].id == "P1"
         assert node.ports[0].direction == PortDirection.BIDIRECTIONAL
 
     def test_ideal_reference_node_custom_ports(self) -> None:
@@ -126,12 +126,12 @@ class TestIdealReferenceNode:
             elevation=0.0,
             pressure=50.0,
         )
-        port = node.get_port("port_1")
+        port = node.get_port("P1")
         assert port is not None
-        assert port.id == "port_1"
+        assert port.id == "P1"
 
         # Non-existent port
-        assert node.get_port("port_2") is None
+        assert node.get_port("P2") is None
 
 
 class TestNonIdealReferenceNode:

--- a/apps/api/tests/test_models/test_components.py
+++ b/apps/api/tests/test_models/test_components.py
@@ -313,7 +313,7 @@ class TestGetPortElevation:
             water_level=10.0,
         )
         # Default port has no elevation set
-        assert reservoir.get_port_elevation("outlet_1") == 100.0
+        assert reservoir.get_port_elevation("P1") == 100.0
 
     def test_port_uses_own_elevation_when_set(self):
         """Test that port uses its own elevation when explicitly set."""
@@ -329,19 +329,22 @@ class TestGetPortElevation:
             initial_level=10.0,
             ports=[
                 Port(
-                    id="bottom_drain",
+                    id="P1",
+                    name="Bottom Drain",
                     nominal_size=4.0,
                     direction=PortDirection.BIDIRECTIONAL,
                     elevation=95.0,
                 ),
                 Port(
-                    id="side_fill",
+                    id="P2",
+                    name="Side Fill",
                     nominal_size=6.0,
                     direction=PortDirection.BIDIRECTIONAL,
                     elevation=105.0,
                 ),
                 Port(
-                    id="top_overflow",
+                    id="P3",
+                    name="Top Overflow",
                     nominal_size=4.0,
                     direction=PortDirection.BIDIRECTIONAL,
                     elevation=120.0,
@@ -349,9 +352,9 @@ class TestGetPortElevation:
             ],
         )
 
-        assert tank.get_port_elevation("bottom_drain") == 95.0
-        assert tank.get_port_elevation("side_fill") == 105.0
-        assert tank.get_port_elevation("top_overflow") == 120.0
+        assert tank.get_port_elevation("P1") == 95.0
+        assert tank.get_port_elevation("P2") == 105.0
+        assert tank.get_port_elevation("P3") == 120.0
 
     def test_port_elevation_can_be_zero(self):
         """Test that port elevation of 0.0 is used (not mistaken for None)."""
@@ -364,7 +367,8 @@ class TestGetPortElevation:
             water_level=10.0,
             ports=[
                 Port(
-                    id="outlet_1",
+                    id="P1",
+                    name="Outlet",
                     nominal_size=4.0,
                     direction=PortDirection.BIDIRECTIONAL,
                     elevation=0.0,
@@ -372,7 +376,7 @@ class TestGetPortElevation:
             ],
         )
         # Port elevation is explicitly 0, should not inherit 50
-        assert reservoir.get_port_elevation("outlet_1") == 0.0
+        assert reservoir.get_port_elevation("P1") == 0.0
 
     def test_port_elevation_can_be_negative(self):
         """Test that port elevation can be negative."""
@@ -388,41 +392,44 @@ class TestGetPortElevation:
             initial_level=10.0,
             ports=[
                 Port(
-                    id="bottom",
+                    id="P1",
+                    name="Bottom",
                     nominal_size=4.0,
                     direction=PortDirection.BIDIRECTIONAL,
                     elevation=-25.0,
                 ),
             ],
         )
-        assert tank.get_port_elevation("bottom") == -25.0
+        assert tank.get_port_elevation("P1") == -25.0
 
     def test_mixed_ports_some_with_elevation(self):
         """Test component with mix of ports with and without elevation."""
         from opensolve_pipe.models import Port, PortDirection
 
         pump = PumpComponent(
-            id="P1",
+            id="PMP1",
             name="Vertical Pump",
             elevation=10.0,  # Pump body at 10 ft
             curve_id="PC1",
             ports=[
                 Port(
-                    id="suction",
+                    id="P1",
+                    name="Suction",
                     nominal_size=6.0,
                     direction=PortDirection.INLET,
                     elevation=5.0,
                 ),  # Suction lower
                 Port(
-                    id="discharge", nominal_size=4.0, direction=PortDirection.OUTLET
+                    id="P2",
+                    name="Discharge",
+                    nominal_size=4.0,
+                    direction=PortDirection.OUTLET,
                 ),  # No elevation, inherits
             ],
         )
 
-        assert pump.get_port_elevation("suction") == 5.0  # Uses explicit elevation
-        assert (
-            pump.get_port_elevation("discharge") == 10.0
-        )  # Inherits component elevation
+        assert pump.get_port_elevation("P1") == 5.0  # Uses explicit elevation
+        assert pump.get_port_elevation("P2") == 10.0  # Inherits component elevation
 
     def test_get_port_elevation_raises_for_missing_port(self):
         """Test that get_port_elevation raises ValueError for non-existent port."""
@@ -453,21 +460,23 @@ class TestGetPortElevation:
             design_flow=200.0,
             ports=[
                 Port(
-                    id="inlet",
+                    id="P1",
+                    name="Inlet",
                     nominal_size=4.0,
                     direction=PortDirection.INLET,
                     elevation=18.0,
                 ),
                 Port(
-                    id="outlet",
+                    id="P2",
+                    name="Outlet",
                     nominal_size=4.0,
                     direction=PortDirection.OUTLET,
                     elevation=22.0,
                 ),
             ],
         )
-        assert hx.get_port_elevation("inlet") == 18.0
-        assert hx.get_port_elevation("outlet") == 22.0
+        assert hx.get_port_elevation("P1") == 18.0
+        assert hx.get_port_elevation("P2") == 22.0
 
         # Test on Junction (inherits)
         junction = Junction(
@@ -475,7 +484,7 @@ class TestGetPortElevation:
             name="Junction",
             elevation=30.0,
         )
-        assert junction.get_port_elevation("port_1") == 30.0
+        assert junction.get_port_elevation("P1") == 30.0
 
         # Test on Valve
         valve = ValveComponent(
@@ -484,5 +493,5 @@ class TestGetPortElevation:
             elevation=25.0,
             valve_type=ValveType.GATE,
         )
-        assert valve.get_port_elevation("inlet") == 25.0
-        assert valve.get_port_elevation("outlet") == 25.0
+        assert valve.get_port_elevation("P1") == 25.0
+        assert valve.get_port_elevation("P2") == 25.0

--- a/apps/api/tests/test_models/test_connections.py
+++ b/apps/api/tests/test_models/test_connections.py
@@ -28,16 +28,16 @@ class TestPipeConnection:
         conn = PipeConnection(
             id="conn-1",
             from_component_id="pump-1",
-            from_port_id="discharge",
+            from_port_id="P2",
             to_component_id="valve-1",
-            to_port_id="inlet",
+            to_port_id="P1",
         )
 
         assert conn.id == "conn-1"
         assert conn.from_component_id == "pump-1"
-        assert conn.from_port_id == "discharge"
+        assert conn.from_port_id == "P2"
         assert conn.to_component_id == "valve-1"
-        assert conn.to_port_id == "inlet"
+        assert conn.to_port_id == "P1"
         assert conn.piping is None
 
     def test_connection_with_piping(self):
@@ -55,9 +55,9 @@ class TestPipeConnection:
         conn = PipeConnection(
             id="conn-1",
             from_component_id="pump-1",
-            from_port_id="discharge",
+            from_port_id="P2",
             to_component_id="valve-1",
-            to_port_id="inlet",
+            to_port_id="P1",
             piping=piping,
         )
 
@@ -70,16 +70,16 @@ class TestPipeConnection:
         conn = PipeConnection(
             id="conn-1",
             from_component_id="pump-1",
-            from_port_id="discharge",
+            from_port_id="P2",
             to_component_id="valve-1",
-            to_port_id="inlet",
+            to_port_id="P1",
         )
 
         data = conn.model_dump()
 
         assert data["id"] == "conn-1"
         assert data["from_component_id"] == "pump-1"
-        assert data["from_port_id"] == "discharge"
+        assert data["from_port_id"] == "P2"
 
 
 class TestPortDirectionValidation:
@@ -87,8 +87,12 @@ class TestPortDirectionValidation:
 
     def test_outlet_to_inlet_valid(self):
         """Test outlet -> inlet is valid."""
-        from_port = Port(id="out", nominal_size=4.0, direction=PortDirection.OUTLET)
-        to_port = Port(id="in", nominal_size=4.0, direction=PortDirection.INLET)
+        from_port = Port(
+            id="P1", name="Outlet", nominal_size=4.0, direction=PortDirection.OUTLET
+        )
+        to_port = Port(
+            id="P1", name="Inlet", nominal_size=4.0, direction=PortDirection.INLET
+        )
 
         valid, error = validate_port_direction_compatibility(from_port, to_port)
 
@@ -97,8 +101,15 @@ class TestPortDirectionValidation:
 
     def test_outlet_to_bidirectional_valid(self):
         """Test outlet -> bidirectional is valid."""
-        from_port = Port(id="out", nominal_size=4.0, direction=PortDirection.OUTLET)
-        to_port = Port(id="bi", nominal_size=4.0, direction=PortDirection.BIDIRECTIONAL)
+        from_port = Port(
+            id="P1", name="Outlet", nominal_size=4.0, direction=PortDirection.OUTLET
+        )
+        to_port = Port(
+            id="P1",
+            name="Port",
+            nominal_size=4.0,
+            direction=PortDirection.BIDIRECTIONAL,
+        )
 
         valid, error = validate_port_direction_compatibility(from_port, to_port)
 
@@ -108,9 +119,14 @@ class TestPortDirectionValidation:
     def test_bidirectional_to_inlet_valid(self):
         """Test bidirectional -> inlet is valid."""
         from_port = Port(
-            id="bi", nominal_size=4.0, direction=PortDirection.BIDIRECTIONAL
+            id="P1",
+            name="Port",
+            nominal_size=4.0,
+            direction=PortDirection.BIDIRECTIONAL,
         )
-        to_port = Port(id="in", nominal_size=4.0, direction=PortDirection.INLET)
+        to_port = Port(
+            id="P1", name="Inlet", nominal_size=4.0, direction=PortDirection.INLET
+        )
 
         valid, error = validate_port_direction_compatibility(from_port, to_port)
 
@@ -120,10 +136,16 @@ class TestPortDirectionValidation:
     def test_bidirectional_to_bidirectional_valid(self):
         """Test bidirectional -> bidirectional is valid."""
         from_port = Port(
-            id="bi1", nominal_size=4.0, direction=PortDirection.BIDIRECTIONAL
+            id="P1",
+            name="Port 1",
+            nominal_size=4.0,
+            direction=PortDirection.BIDIRECTIONAL,
         )
         to_port = Port(
-            id="bi2", nominal_size=4.0, direction=PortDirection.BIDIRECTIONAL
+            id="P2",
+            name="Port 2",
+            nominal_size=4.0,
+            direction=PortDirection.BIDIRECTIONAL,
         )
 
         valid, error = validate_port_direction_compatibility(from_port, to_port)
@@ -133,8 +155,15 @@ class TestPortDirectionValidation:
 
     def test_inlet_to_anything_invalid(self):
         """Test inlet -> anything is invalid."""
-        from_port = Port(id="in", nominal_size=4.0, direction=PortDirection.INLET)
-        to_port = Port(id="bi", nominal_size=4.0, direction=PortDirection.BIDIRECTIONAL)
+        from_port = Port(
+            id="P1", name="Inlet", nominal_size=4.0, direction=PortDirection.INLET
+        )
+        to_port = Port(
+            id="P1",
+            name="Port",
+            nominal_size=4.0,
+            direction=PortDirection.BIDIRECTIONAL,
+        )
 
         valid, error = validate_port_direction_compatibility(from_port, to_port)
 
@@ -143,8 +172,12 @@ class TestPortDirectionValidation:
 
     def test_anything_to_outlet_invalid(self):
         """Test anything -> outlet is invalid."""
-        from_port = Port(id="out", nominal_size=4.0, direction=PortDirection.OUTLET)
-        to_port = Port(id="out2", nominal_size=4.0, direction=PortDirection.OUTLET)
+        from_port = Port(
+            id="P1", name="Outlet 1", nominal_size=4.0, direction=PortDirection.OUTLET
+        )
+        to_port = Port(
+            id="P2", name="Outlet 2", nominal_size=4.0, direction=PortDirection.OUTLET
+        )
 
         valid, error = validate_port_direction_compatibility(from_port, to_port)
 
@@ -157,8 +190,12 @@ class TestPortSizeValidation:
 
     def test_same_size_valid(self):
         """Test same size ports are valid."""
-        from_port = Port(id="out", nominal_size=4.0, direction=PortDirection.OUTLET)
-        to_port = Port(id="in", nominal_size=4.0, direction=PortDirection.INLET)
+        from_port = Port(
+            id="P1", name="Outlet", nominal_size=4.0, direction=PortDirection.OUTLET
+        )
+        to_port = Port(
+            id="P1", name="Inlet", nominal_size=4.0, direction=PortDirection.INLET
+        )
 
         valid, error = validate_port_size_compatibility(from_port, to_port)
 
@@ -167,9 +204,11 @@ class TestPortSizeValidation:
 
     def test_within_tolerance_valid(self):
         """Test ports within tolerance are valid."""
-        from_port = Port(id="out", nominal_size=4.0, direction=PortDirection.OUTLET)
+        from_port = Port(
+            id="P1", name="Outlet", nominal_size=4.0, direction=PortDirection.OUTLET
+        )
         to_port = Port(
-            id="in", nominal_size=4.3, direction=PortDirection.INLET
+            id="P1", name="Inlet", nominal_size=4.3, direction=PortDirection.INLET
         )  # 7.5% diff
 
         valid, error = validate_port_size_compatibility(
@@ -181,9 +220,11 @@ class TestPortSizeValidation:
 
     def test_exceeds_tolerance_invalid(self):
         """Test ports exceeding tolerance are invalid."""
-        from_port = Port(id="out", nominal_size=4.0, direction=PortDirection.OUTLET)
+        from_port = Port(
+            id="P1", name="Outlet", nominal_size=4.0, direction=PortDirection.OUTLET
+        )
         to_port = Port(
-            id="in", nominal_size=6.0, direction=PortDirection.INLET
+            id="P1", name="Inlet", nominal_size=6.0, direction=PortDirection.INLET
         )  # 50% diff
 
         valid, error = validate_port_size_compatibility(
@@ -195,9 +236,11 @@ class TestPortSizeValidation:
 
     def test_custom_tolerance(self):
         """Test custom tolerance value."""
-        from_port = Port(id="out", nominal_size=4.0, direction=PortDirection.OUTLET)
+        from_port = Port(
+            id="P1", name="Outlet", nominal_size=4.0, direction=PortDirection.OUTLET
+        )
         to_port = Port(
-            id="in", nominal_size=5.5, direction=PortDirection.INLET
+            id="P1", name="Inlet", nominal_size=5.5, direction=PortDirection.INLET
         )  # 27% diff
 
         # With 20% tolerance, should fail (27% > 20%)
@@ -217,14 +260,16 @@ class TestValidateConnection:
         conn = PipeConnection(
             id="conn-1",
             from_component_id="pump-1",
-            from_port_id="discharge",
+            from_port_id="P2",
             to_component_id="valve-1",
-            to_port_id="inlet",
+            to_port_id="P1",
         )
         from_port = Port(
-            id="discharge", nominal_size=4.0, direction=PortDirection.OUTLET
+            id="P2", name="Discharge", nominal_size=4.0, direction=PortDirection.OUTLET
         )
-        to_port = Port(id="inlet", nominal_size=4.0, direction=PortDirection.INLET)
+        to_port = Port(
+            id="P1", name="Inlet", nominal_size=4.0, direction=PortDirection.INLET
+        )
 
         errors = validate_connection(conn, from_port, to_port)
 
@@ -235,12 +280,16 @@ class TestValidateConnection:
         conn = PipeConnection(
             id="conn-1",
             from_component_id="a",
-            from_port_id="inlet",
+            from_port_id="P1",
             to_component_id="b",
-            to_port_id="outlet",
+            to_port_id="P2",
         )
-        from_port = Port(id="inlet", nominal_size=4.0, direction=PortDirection.INLET)
-        to_port = Port(id="outlet", nominal_size=4.0, direction=PortDirection.OUTLET)
+        from_port = Port(
+            id="P1", name="Inlet", nominal_size=4.0, direction=PortDirection.INLET
+        )
+        to_port = Port(
+            id="P2", name="Outlet", nominal_size=4.0, direction=PortDirection.OUTLET
+        )
 
         errors = validate_connection(conn, from_port, to_port)
 
@@ -252,12 +301,16 @@ class TestValidateConnection:
         conn = PipeConnection(
             id="conn-1",
             from_component_id="a",
-            from_port_id="out",
+            from_port_id="P1",
             to_component_id="b",
-            to_port_id="in",
+            to_port_id="P1",
         )
-        from_port = Port(id="out", nominal_size=4.0, direction=PortDirection.OUTLET)
-        to_port = Port(id="in", nominal_size=8.0, direction=PortDirection.INLET)
+        from_port = Port(
+            id="P1", name="Outlet", nominal_size=4.0, direction=PortDirection.OUTLET
+        )
+        to_port = Port(
+            id="P1", name="Inlet", nominal_size=8.0, direction=PortDirection.INLET
+        )
 
         errors = validate_connection(conn, from_port, to_port, check_size=True)
 
@@ -269,12 +322,16 @@ class TestValidateConnection:
         conn = PipeConnection(
             id="conn-1",
             from_component_id="a",
-            from_port_id="out",
+            from_port_id="P1",
             to_component_id="b",
-            to_port_id="in",
+            to_port_id="P1",
         )
-        from_port = Port(id="out", nominal_size=4.0, direction=PortDirection.OUTLET)
-        to_port = Port(id="in", nominal_size=8.0, direction=PortDirection.INLET)
+        from_port = Port(
+            id="P1", name="Outlet", nominal_size=4.0, direction=PortDirection.OUTLET
+        )
+        to_port = Port(
+            id="P1", name="Inlet", nominal_size=8.0, direction=PortDirection.INLET
+        )
 
         errors = validate_connection(conn, from_port, to_port, check_size=False)
 
@@ -288,16 +345,16 @@ class TestConnectionBuilder:
         """Test basic connection building."""
         conn = (
             ConnectionBuilder("conn-1")
-            .from_component("pump-1", "discharge")
-            .to_component("valve-1", "inlet")
+            .from_component("pump-1", "P2")
+            .to_component("valve-1", "P1")
             .build()
         )
 
         assert conn.id == "conn-1"
         assert conn.from_component_id == "pump-1"
-        assert conn.from_port_id == "discharge"
+        assert conn.from_port_id == "P2"
         assert conn.to_component_id == "valve-1"
-        assert conn.to_port_id == "inlet"
+        assert conn.to_port_id == "P1"
 
     def test_builder_with_piping(self):
         """Test builder with piping segment."""
@@ -312,8 +369,8 @@ class TestConnectionBuilder:
 
         conn = (
             ConnectionBuilder("conn-1")
-            .from_component("pump-1", "discharge")
-            .to_component("valve-1", "inlet")
+            .from_component("pump-1", "P2")
+            .to_component("valve-1", "P1")
             .with_piping(piping)
             .build()
         )
@@ -323,14 +380,14 @@ class TestConnectionBuilder:
 
     def test_builder_missing_from_raises(self):
         """Test builder raises if from not set."""
-        builder = ConnectionBuilder("conn-1").to_component("valve-1", "inlet")
+        builder = ConnectionBuilder("conn-1").to_component("valve-1", "P1")
 
         with pytest.raises(ValueError, match="Source component"):
             builder.build()
 
     def test_builder_missing_to_raises(self):
         """Test builder raises if to not set."""
-        builder = ConnectionBuilder("conn-1").from_component("pump-1", "discharge")
+        builder = ConnectionBuilder("conn-1").from_component("pump-1", "P2")
 
         with pytest.raises(ValueError, match="Target component"):
             builder.build()

--- a/apps/api/tests/test_models/test_ports.py
+++ b/apps/api/tests/test_models/test_ports.py
@@ -22,41 +22,53 @@ class TestPort:
 
     def test_port_creation(self):
         """Test basic port creation."""
-        port = Port(id="inlet", nominal_size=4.0, direction=PortDirection.INLET)
+        port = Port(
+            id="P1", name="Inlet", nominal_size=4.0, direction=PortDirection.INLET
+        )
 
-        assert port.id == "inlet"
+        assert port.id == "P1"
+        assert port.name == "Inlet"
         assert port.nominal_size == 4.0
         assert port.direction == PortDirection.INLET
 
     def test_port_default_direction(self):
         """Test that port defaults to bidirectional."""
-        port = Port(id="port_1", nominal_size=4.0)
+        port = Port(id="P1", name="Port", nominal_size=4.0)
 
         assert port.direction == PortDirection.BIDIRECTIONAL
 
     def test_port_requires_positive_size(self):
         """Test that port size must be positive."""
         with pytest.raises(ValueError):
-            Port(id="port_1", nominal_size=0)
+            Port(id="P1", name="Port", nominal_size=0)
 
         with pytest.raises(ValueError):
-            Port(id="port_1", nominal_size=-1.0)
+            Port(id="P1", name="Port", nominal_size=-1.0)
 
     def test_port_serialization(self):
         """Test port serializes correctly."""
-        port = Port(id="discharge", nominal_size=6.0, direction=PortDirection.OUTLET)
+        port = Port(
+            id="P2", name="Discharge", nominal_size=6.0, direction=PortDirection.OUTLET
+        )
         data = port.model_dump()
 
-        assert data["id"] == "discharge"
+        assert data["id"] == "P2"
+        assert data["name"] == "Discharge"
         assert data["nominal_size"] == 6.0
         assert data["direction"] == "outlet"
 
     def test_port_deserialization(self):
         """Test port deserializes correctly."""
-        data = {"id": "suction", "nominal_size": 8.0, "direction": "inlet"}
+        data = {
+            "id": "P1",
+            "name": "Suction",
+            "nominal_size": 8.0,
+            "direction": "inlet",
+        }
         port = Port.model_validate(data)
 
-        assert port.id == "suction"
+        assert port.id == "P1"
+        assert port.name == "Suction"
         assert port.nominal_size == 8.0
         assert port.direction == PortDirection.INLET
 
@@ -69,20 +81,21 @@ class TestReservoirPorts:
         ports = create_reservoir_ports()
 
         assert len(ports) == 1
-        assert ports[0].id == "outlet_1"
+        assert ports[0].id == "P1"
+        assert ports[0].name == "Outlet"
         assert ports[0].nominal_size == 4.0
         assert ports[0].direction == PortDirection.BIDIRECTIONAL
 
-    def test_custom_reservoir_ports(self):
-        """Test reservoir with custom port configs."""
-        configs = [{"port_a": 6.0}, {"port_b": 4.0}]
-        ports = create_reservoir_ports(configs)
-
-        assert len(ports) == 2
-        assert {p.id for p in ports} == {"port_a", "port_b"}
-
-    def test_reservoir_custom_default_size(self):
+    def test_custom_reservoir_default_size(self):
         """Test reservoir with custom default size."""
+        ports = create_reservoir_ports(default_size=6.0)
+
+        assert len(ports) == 1
+        assert ports[0].id == "P1"
+        assert ports[0].nominal_size == 6.0
+
+    def test_reservoir_large_default_size(self):
+        """Test reservoir with large default size."""
         ports = create_reservoir_ports(default_size=8.0)
 
         assert len(ports) == 1
@@ -97,7 +110,8 @@ class TestTankPorts:
         ports = create_tank_ports()
 
         assert len(ports) == 1
-        assert ports[0].id == "port_1"
+        assert ports[0].id == "P1"
+        assert ports[0].name == "Port"
         assert ports[0].direction == PortDirection.BIDIRECTIONAL
 
 
@@ -109,7 +123,8 @@ class TestJunctionPorts:
         ports = create_junction_ports()
 
         assert len(ports) == 1
-        assert ports[0].id == "port_1"
+        assert ports[0].id == "P1"
+        assert ports[0].name == "Port"
         assert ports[0].direction == PortDirection.BIDIRECTIONAL
 
 
@@ -122,9 +137,11 @@ class TestPumpPorts:
 
         assert len(ports) == 2
 
-        suction = next(p for p in ports if p.id == "suction")
-        discharge = next(p for p in ports if p.id == "discharge")
+        suction = next(p for p in ports if p.id == "P1")
+        discharge = next(p for p in ports if p.id == "P2")
 
+        assert suction.name == "Suction"
+        assert discharge.name == "Discharge"
         assert suction.direction == PortDirection.INLET
         assert discharge.direction == PortDirection.OUTLET
         assert suction.nominal_size == 4.0
@@ -134,8 +151,8 @@ class TestPumpPorts:
         """Test pump with custom port sizes."""
         ports = create_pump_ports(suction_size=6.0, discharge_size=4.0)
 
-        suction = next(p for p in ports if p.id == "suction")
-        discharge = next(p for p in ports if p.id == "discharge")
+        suction = next(p for p in ports if p.id == "P1")
+        discharge = next(p for p in ports if p.id == "P2")
 
         assert suction.nominal_size == 6.0
         assert discharge.nominal_size == 4.0
@@ -150,9 +167,11 @@ class TestValvePorts:
 
         assert len(ports) == 2
 
-        inlet = next(p for p in ports if p.id == "inlet")
-        outlet = next(p for p in ports if p.id == "outlet")
+        inlet = next(p for p in ports if p.id == "P1")
+        outlet = next(p for p in ports if p.id == "P2")
 
+        assert inlet.name == "Inlet"
+        assert outlet.name == "Outlet"
         assert inlet.direction == PortDirection.INLET
         assert outlet.direction == PortDirection.OUTLET
 
@@ -160,8 +179,8 @@ class TestValvePorts:
         """Test valve outlet defaults to inlet size."""
         ports = create_valve_ports(inlet_size=6.0)
 
-        inlet = next(p for p in ports if p.id == "inlet")
-        outlet = next(p for p in ports if p.id == "outlet")
+        inlet = next(p for p in ports if p.id == "P1")
+        outlet = next(p for p in ports if p.id == "P2")
 
         assert inlet.nominal_size == 6.0
         assert outlet.nominal_size == 6.0
@@ -170,8 +189,8 @@ class TestValvePorts:
         """Test valve with different inlet/outlet sizes."""
         ports = create_valve_ports(inlet_size=6.0, outlet_size=4.0)
 
-        inlet = next(p for p in ports if p.id == "inlet")
-        outlet = next(p for p in ports if p.id == "outlet")
+        inlet = next(p for p in ports if p.id == "P1")
+        outlet = next(p for p in ports if p.id == "P2")
 
         assert inlet.nominal_size == 6.0
         assert outlet.nominal_size == 4.0
@@ -185,7 +204,8 @@ class TestHeatExchangerPorts:
         ports = create_heat_exchanger_ports()
 
         assert len(ports) == 2
-        assert {p.id for p in ports} == {"inlet", "outlet"}
+        assert {p.id for p in ports} == {"P1", "P2"}
+        assert {p.name for p in ports} == {"Inlet", "Outlet"}
 
 
 class TestStrainerPorts:
@@ -196,7 +216,8 @@ class TestStrainerPorts:
         ports = create_strainer_ports()
 
         assert len(ports) == 2
-        assert {p.id for p in ports} == {"inlet", "outlet"}
+        assert {p.id for p in ports} == {"P1", "P2"}
+        assert {p.name for p in ports} == {"Inlet", "Outlet"}
 
 
 class TestOrificePorts:
@@ -207,7 +228,8 @@ class TestOrificePorts:
         ports = create_orifice_ports()
 
         assert len(ports) == 2
-        assert {p.id for p in ports} == {"inlet", "outlet"}
+        assert {p.id for p in ports} == {"P1", "P2"}
+        assert {p.name for p in ports} == {"Inlet", "Outlet"}
 
 
 class TestSprinklerPorts:
@@ -218,7 +240,8 @@ class TestSprinklerPorts:
         ports = create_sprinkler_ports()
 
         assert len(ports) == 1
-        assert ports[0].id == "inlet"
+        assert ports[0].id == "P1"
+        assert ports[0].name == "Inlet"
         assert ports[0].direction == PortDirection.INLET
 
     def test_sprinkler_ports_custom_size(self):
@@ -233,40 +256,41 @@ class TestPortElevation:
 
     def test_port_elevation_default_none(self):
         """Test that port elevation defaults to None."""
-        port = Port(id="port_1", nominal_size=4.0)
+        port = Port(id="P1", name="Port", nominal_size=4.0)
 
         assert port.elevation is None
 
     def test_port_elevation_can_be_set(self):
         """Test that port elevation can be explicitly set."""
-        port = Port(id="port_1", nominal_size=4.0, elevation=10.0)
+        port = Port(id="P1", name="Port", nominal_size=4.0, elevation=10.0)
 
         assert port.elevation == 10.0
 
     def test_port_elevation_can_be_negative(self):
         """Test that port elevation can be negative (below reference)."""
-        port = Port(id="port_1", nominal_size=4.0, elevation=-5.0)
+        port = Port(id="P1", name="Port", nominal_size=4.0, elevation=-5.0)
 
         assert port.elevation == -5.0
 
     def test_port_elevation_can_be_zero(self):
         """Test that port elevation can be zero."""
-        port = Port(id="port_1", nominal_size=4.0, elevation=0.0)
+        port = Port(id="P1", name="Port", nominal_size=4.0, elevation=0.0)
 
         assert port.elevation == 0.0
 
     def test_port_serialization_with_elevation(self):
         """Test port with elevation serializes correctly."""
-        port = Port(id="outlet", nominal_size=6.0, elevation=15.5)
+        port = Port(id="P2", name="Outlet", nominal_size=6.0, elevation=15.5)
         data = port.model_dump()
 
-        assert data["id"] == "outlet"
+        assert data["id"] == "P2"
+        assert data["name"] == "Outlet"
         assert data["nominal_size"] == 6.0
         assert data["elevation"] == 15.5
 
     def test_port_serialization_without_elevation(self):
         """Test port without elevation serializes with None."""
-        port = Port(id="outlet", nominal_size=6.0)
+        port = Port(id="P2", name="Outlet", nominal_size=6.0)
         data = port.model_dump()
 
         assert data["elevation"] is None
@@ -274,26 +298,28 @@ class TestPortElevation:
     def test_port_deserialization_with_elevation(self):
         """Test port with elevation deserializes correctly."""
         data = {
-            "id": "drain",
+            "id": "P3",
+            "name": "Drain",
             "nominal_size": 2.0,
             "direction": "outlet",
             "elevation": -2.5,
         }
         port = Port.model_validate(data)
 
-        assert port.id == "drain"
+        assert port.id == "P3"
+        assert port.name == "Drain"
         assert port.elevation == -2.5
 
     def test_port_deserialization_without_elevation(self):
         """Test port without elevation field deserializes to None."""
-        data = {"id": "inlet", "nominal_size": 4.0, "direction": "inlet"}
+        data = {"id": "P1", "name": "Inlet", "nominal_size": 4.0, "direction": "inlet"}
         port = Port.model_validate(data)
 
         assert port.elevation is None
 
     def test_port_deserialization_with_null_elevation(self):
         """Test port with explicit null elevation deserializes to None."""
-        data = {"id": "inlet", "nominal_size": 4.0, "elevation": None}
+        data = {"id": "P1", "name": "Inlet", "nominal_size": 4.0, "elevation": None}
         port = Port.model_validate(data)
 
         assert port.elevation is None

--- a/apps/api/tests/test_models/test_project.py
+++ b/apps/api/tests/test_models/test_project.py
@@ -217,7 +217,7 @@ class TestProject:
     def test_project_get_connections_for_port(self, sample_project: Project):
         """Test getting connections for a specific port."""
         # Get connections for a port
-        conns = sample_project.get_connections_for_port("R1", "outlet_1")
+        conns = sample_project.get_connections_for_port("R1", "P1")
         assert isinstance(conns, list)
 
     def test_project_duplicate_connection_ids(self):
@@ -232,16 +232,16 @@ class TestProject:
                     PipeConnection(
                         id="conn_1",
                         from_component_id="R1",
-                        from_port_id="outlet_1",
+                        from_port_id="P1",
                         to_component_id="J1",
-                        to_port_id="port_1",
+                        to_port_id="P1",
                     ),
                     PipeConnection(
                         id="conn_1",  # Duplicate ID
                         from_component_id="R1",
-                        from_port_id="outlet_1",
+                        from_port_id="P1",
                         to_component_id="J1",
-                        to_port_id="port_1",
+                        to_port_id="P1",
                     ),
                 ],
             )
@@ -258,9 +258,9 @@ class TestProject:
                     PipeConnection(
                         id="conn_1",
                         from_component_id="nonexistent",  # Invalid
-                        from_port_id="outlet_1",
+                        from_port_id="P1",
                         to_component_id="J1",
-                        to_port_id="port_1",
+                        to_port_id="P1",
                     ),
                 ],
             )
@@ -277,9 +277,9 @@ class TestProject:
                     PipeConnection(
                         id="conn_1",
                         from_component_id="R1",
-                        from_port_id="outlet_1",
+                        from_port_id="P1",
                         to_component_id="nonexistent",  # Invalid
-                        to_port_id="port_1",
+                        to_port_id="P1",
                     ),
                 ],
             )
@@ -299,7 +299,7 @@ class TestProject:
                         from_component_id="R1",
                         from_port_id="invalid_port",  # Invalid port
                         to_component_id="J1",
-                        to_port_id="port_1",
+                        to_port_id="P1",
                     ),
                 ],
             )
@@ -317,7 +317,7 @@ class TestProject:
                     PipeConnection(
                         id="conn_1",
                         from_component_id="R1",
-                        from_port_id="outlet_1",
+                        from_port_id="P1",
                         to_component_id="J1",
                         to_port_id="invalid_port",  # Invalid port
                     ),
@@ -327,7 +327,7 @@ class TestProject:
 
     def test_project_connection_port_direction_incompatible(self):
         """Test that incompatible port directions are rejected."""
-        # Create a pump to test with (has inlet suction and outlet discharge)
+        # Create a pump to test with (has inlet P1/Suction and outlet P2/Discharge)
         pump_curve = PumpCurve(
             id="PC1",
             name="Test Pump",
@@ -336,8 +336,8 @@ class TestProject:
                 FlowHeadPoint(flow=100, head=50),
             ],
         )
-        pump1 = PumpComponent(id="P1", name="Pump 1", elevation=10, curve_id="PC1")
-        pump2 = PumpComponent(id="P2", name="Pump 2", elevation=10, curve_id="PC1")
+        pump1 = PumpComponent(id="PM1", name="Pump 1", elevation=10, curve_id="PC1")
+        pump2 = PumpComponent(id="PM2", name="Pump 2", elevation=10, curve_id="PC1")
 
         with pytest.raises(ValidationError) as exc_info:
             Project(
@@ -346,11 +346,11 @@ class TestProject:
                 connections=[
                     PipeConnection(
                         id="conn_1",
-                        # Try to connect from inlet (suction) port - invalid
-                        from_component_id="P1",
-                        from_port_id="suction",  # inlet port
-                        to_component_id="P2",
-                        to_port_id="suction",  # inlet port
+                        # Try to connect from inlet (P1/Suction) port - invalid
+                        from_component_id="PM1",
+                        from_port_id="P1",  # inlet port (Suction)
+                        to_component_id="PM2",
+                        to_port_id="P1",  # inlet port (Suction)
                     ),
                 ],
             )
@@ -367,9 +367,9 @@ class TestProject:
                 PipeConnection(
                     id="conn_1",
                     from_component_id="R1",
-                    from_port_id="outlet_1",
+                    from_port_id="P1",
                     to_component_id="J1",
-                    to_port_id="port_1",
+                    to_port_id="P1",
                 ),
             ],
         )

--- a/apps/api/tests/test_services/test_solver/test_network.py
+++ b/apps/api/tests/test_services/test_solver/test_network.py
@@ -156,7 +156,8 @@ class TestSolveProject:
                     elevation=0.0,
                     ports=[
                         Port(
-                            id="port_1",
+                            id="P1",
+                            name="Port",
                             nominal_size=4.0,
                             direction=PortDirection.BIDIRECTIONAL,
                         )
@@ -182,7 +183,8 @@ class TestSolveProject:
                     water_level=10.0,
                     ports=[
                         Port(
-                            id="outlet",
+                            id="P1",
+                            name="Outlet",
                             nominal_size=4.0,
                             direction=PortDirection.OUTLET,
                         )
@@ -198,7 +200,10 @@ class TestSolveProject:
                     initial_level=5.0,
                     ports=[
                         Port(
-                            id="inlet", nominal_size=4.0, direction=PortDirection.INLET
+                            id="P1",
+                            name="Inlet",
+                            nominal_size=4.0,
+                            direction=PortDirection.INLET,
                         )
                     ],
                 ),
@@ -207,9 +212,9 @@ class TestSolveProject:
                 PipeConnection(
                     id="pipe-1",
                     from_component_id="reservoir-1",
-                    from_port_id="outlet",
+                    from_port_id="P1",
                     to_component_id="tank-1",
-                    to_port_id="inlet",
+                    to_port_id="P1",
                     piping=PipingSegment(
                         pipe=PipeDefinition(
                             material=PipeMaterial.CARBON_STEEL,
@@ -382,7 +387,8 @@ def _create_simple_pump_project(pipe_diameter: float = 4.0) -> Project:
                 water_level=10.0,
                 ports=[
                     Port(
-                        id="outlet",
+                        id="P1",
+                        name="Outlet",
                         nominal_size=pipe_diameter,
                         direction=PortDirection.OUTLET,
                     )
@@ -395,12 +401,14 @@ def _create_simple_pump_project(pipe_diameter: float = 4.0) -> Project:
                 curve_id="pump-curve-1",
                 ports=[
                     Port(
-                        id="suction",
+                        id="P1",
+                        name="Suction",
                         nominal_size=pipe_diameter,
                         direction=PortDirection.INLET,
                     ),
                     Port(
-                        id="discharge",
+                        id="P2",
+                        name="Discharge",
                         nominal_size=pipe_diameter,
                         direction=PortDirection.OUTLET,
                     ),
@@ -416,7 +424,8 @@ def _create_simple_pump_project(pipe_diameter: float = 4.0) -> Project:
                 initial_level=5.0,
                 ports=[
                     Port(
-                        id="inlet",
+                        id="P1",
+                        name="Inlet",
                         nominal_size=pipe_diameter,
                         direction=PortDirection.INLET,
                     )
@@ -427,9 +436,9 @@ def _create_simple_pump_project(pipe_diameter: float = 4.0) -> Project:
             PipeConnection(
                 id="suction-pipe",
                 from_component_id="reservoir-1",
-                from_port_id="outlet",
+                from_port_id="P1",
                 to_component_id="pump-1",
-                to_port_id="suction",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -445,9 +454,9 @@ def _create_simple_pump_project(pipe_diameter: float = 4.0) -> Project:
             PipeConnection(
                 id="discharge-pipe",
                 from_component_id="pump-1",
-                from_port_id="discharge",
+                from_port_id="P2",
                 to_component_id="tank-1",
-                to_port_id="inlet",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -490,7 +499,12 @@ def _create_reference_node_project() -> Project:
                 elevation=0.0,
                 pressure=50.0,  # 50 psi
                 ports=[
-                    Port(id="outlet", nominal_size=4.0, direction=PortDirection.OUTLET)
+                    Port(
+                        id="P1",
+                        name="Outlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
+                    )
                 ],
             ),
             PumpComponent(
@@ -499,9 +513,17 @@ def _create_reference_node_project() -> Project:
                 elevation=0.0,
                 curve_id="pump-curve-1",
                 ports=[
-                    Port(id="suction", nominal_size=4.0, direction=PortDirection.INLET),
                     Port(
-                        id="discharge", nominal_size=4.0, direction=PortDirection.OUTLET
+                        id="P1",
+                        name="Suction",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    ),
+                    Port(
+                        id="P2",
+                        name="Discharge",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
                     ),
                 ],
             ),
@@ -514,7 +536,12 @@ def _create_reference_node_project() -> Project:
                 max_level=20.0,
                 initial_level=5.0,
                 ports=[
-                    Port(id="inlet", nominal_size=4.0, direction=PortDirection.INLET)
+                    Port(
+                        id="P1",
+                        name="Inlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    )
                 ],
             ),
         ],
@@ -522,9 +549,9 @@ def _create_reference_node_project() -> Project:
             PipeConnection(
                 id="suction-pipe",
                 from_component_id="reference-1",
-                from_port_id="outlet",
+                from_port_id="P1",
                 to_component_id="pump-1",
-                to_port_id="suction",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -537,9 +564,9 @@ def _create_reference_node_project() -> Project:
             PipeConnection(
                 id="discharge-pipe",
                 from_component_id="pump-1",
-                from_port_id="discharge",
+                from_port_id="P2",
                 to_component_id="tank-1",
-                to_port_id="inlet",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -577,7 +604,12 @@ def _create_plug_project() -> Project:
                 elevation=0.0,
                 water_level=10.0,
                 ports=[
-                    Port(id="outlet", nominal_size=4.0, direction=PortDirection.OUTLET)
+                    Port(
+                        id="P1",
+                        name="Outlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
+                    )
                 ],
             ),
             PumpComponent(
@@ -586,9 +618,17 @@ def _create_plug_project() -> Project:
                 elevation=0.0,
                 curve_id="pump-curve-1",
                 ports=[
-                    Port(id="suction", nominal_size=4.0, direction=PortDirection.INLET),
                     Port(
-                        id="discharge", nominal_size=4.0, direction=PortDirection.OUTLET
+                        id="P1",
+                        name="Suction",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    ),
+                    Port(
+                        id="P2",
+                        name="Discharge",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
                     ),
                 ],
             ),
@@ -597,7 +637,12 @@ def _create_plug_project() -> Project:
                 name="Dead End",
                 elevation=50.0,
                 ports=[
-                    Port(id="inlet", nominal_size=4.0, direction=PortDirection.INLET)
+                    Port(
+                        id="P1",
+                        name="Inlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    )
                 ],
             ),
         ],
@@ -605,9 +650,9 @@ def _create_plug_project() -> Project:
             PipeConnection(
                 id="suction-pipe",
                 from_component_id="reservoir-1",
-                from_port_id="outlet",
+                from_port_id="P1",
                 to_component_id="pump-1",
-                to_port_id="suction",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -620,9 +665,9 @@ def _create_plug_project() -> Project:
             PipeConnection(
                 id="discharge-pipe",
                 from_component_id="pump-1",
-                from_port_id="discharge",
+                from_port_id="P2",
                 to_component_id="plug-1",
-                to_port_id="inlet",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -659,7 +704,12 @@ def _create_branching_project() -> Project:
                 elevation=0.0,
                 water_level=10.0,
                 ports=[
-                    Port(id="outlet", nominal_size=4.0, direction=PortDirection.OUTLET)
+                    Port(
+                        id="P1",
+                        name="Outlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
+                    )
                 ],
             ),
             PumpComponent(
@@ -668,9 +718,17 @@ def _create_branching_project() -> Project:
                 elevation=0.0,
                 curve_id="pump-curve-1",
                 ports=[
-                    Port(id="suction", nominal_size=4.0, direction=PortDirection.INLET),
                     Port(
-                        id="discharge", nominal_size=4.0, direction=PortDirection.OUTLET
+                        id="P1",
+                        name="Suction",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    ),
+                    Port(
+                        id="P2",
+                        name="Discharge",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
                     ),
                 ],
             ),
@@ -681,15 +739,20 @@ def _create_branching_project() -> Project:
                 branch_angle=90.0,
                 ports=[
                     Port(
-                        id="run_inlet", nominal_size=4.0, direction=PortDirection.INLET
+                        id="P1",
+                        name="Run Inlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
                     ),
                     Port(
-                        id="run_outlet",
+                        id="P2",
+                        name="Run Outlet",
                         nominal_size=4.0,
                         direction=PortDirection.OUTLET,
                     ),
                     Port(
-                        id="branch",
+                        id="P3",
+                        name="Branch",
                         nominal_size=4.0,
                         direction=PortDirection.BIDIRECTIONAL,
                     ),
@@ -704,7 +767,12 @@ def _create_branching_project() -> Project:
                 max_level=20.0,
                 initial_level=5.0,
                 ports=[
-                    Port(id="inlet", nominal_size=4.0, direction=PortDirection.INLET)
+                    Port(
+                        id="P1",
+                        name="Inlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    )
                 ],
             ),
             Tank(
@@ -716,7 +784,12 @@ def _create_branching_project() -> Project:
                 max_level=20.0,
                 initial_level=5.0,
                 ports=[
-                    Port(id="inlet", nominal_size=4.0, direction=PortDirection.INLET)
+                    Port(
+                        id="P1",
+                        name="Inlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    )
                 ],
             ),
         ],
@@ -724,9 +797,9 @@ def _create_branching_project() -> Project:
             PipeConnection(
                 id="suction-pipe",
                 from_component_id="reservoir-1",
-                from_port_id="outlet",
+                from_port_id="P1",
                 to_component_id="pump-1",
-                to_port_id="suction",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -739,9 +812,9 @@ def _create_branching_project() -> Project:
             PipeConnection(
                 id="pump-to-tee",
                 from_component_id="pump-1",
-                from_port_id="discharge",
+                from_port_id="P2",
                 to_component_id="tee-1",
-                to_port_id="run_inlet",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -754,9 +827,9 @@ def _create_branching_project() -> Project:
             PipeConnection(
                 id="tee-to-tank1",
                 from_component_id="tee-1",
-                from_port_id="run_outlet",
+                from_port_id="P2",
                 to_component_id="tank-1",
-                to_port_id="inlet",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -769,9 +842,9 @@ def _create_branching_project() -> Project:
             PipeConnection(
                 id="tee-to-tank2",
                 from_component_id="tee-1",
-                from_port_id="branch",
+                from_port_id="P3",
                 to_component_id="tank-2",
-                to_port_id="inlet",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -813,7 +886,12 @@ def _create_looped_project() -> Project:
                 elevation=0.0,
                 water_level=10.0,
                 ports=[
-                    Port(id="outlet", nominal_size=4.0, direction=PortDirection.OUTLET)
+                    Port(
+                        id="P1",
+                        name="Outlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
+                    )
                 ],
             ),
             PumpComponent(
@@ -822,9 +900,17 @@ def _create_looped_project() -> Project:
                 elevation=0.0,
                 curve_id="pump-curve-1",
                 ports=[
-                    Port(id="suction", nominal_size=4.0, direction=PortDirection.INLET),
                     Port(
-                        id="discharge", nominal_size=4.0, direction=PortDirection.OUTLET
+                        id="P1",
+                        name="Suction",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    ),
+                    Port(
+                        id="P2",
+                        name="Discharge",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
                     ),
                 ],
             ),
@@ -833,9 +919,24 @@ def _create_looped_project() -> Project:
                 name="Junction A",
                 elevation=10.0,
                 ports=[
-                    Port(id="inlet1", nominal_size=4.0, direction=PortDirection.INLET),
-                    Port(id="inlet2", nominal_size=4.0, direction=PortDirection.INLET),
-                    Port(id="outlet", nominal_size=4.0, direction=PortDirection.OUTLET),
+                    Port(
+                        id="P1",
+                        name="Inlet 1",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    ),
+                    Port(
+                        id="P2",
+                        name="Inlet 2",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    ),
+                    Port(
+                        id="P3",
+                        name="Outlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
+                    ),
                 ],
             ),
             Junction(
@@ -843,12 +944,23 @@ def _create_looped_project() -> Project:
                 name="Junction B",
                 elevation=10.0,
                 ports=[
-                    Port(id="inlet", nominal_size=4.0, direction=PortDirection.INLET),
                     Port(
-                        id="outlet1", nominal_size=4.0, direction=PortDirection.OUTLET
+                        id="P1",
+                        name="Inlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
                     ),
                     Port(
-                        id="outlet2", nominal_size=4.0, direction=PortDirection.OUTLET
+                        id="P2",
+                        name="Outlet 1",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
+                    ),
+                    Port(
+                        id="P3",
+                        name="Outlet 2",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
                     ),
                 ],
             ),
@@ -861,7 +973,12 @@ def _create_looped_project() -> Project:
                 max_level=20.0,
                 initial_level=5.0,
                 ports=[
-                    Port(id="inlet", nominal_size=4.0, direction=PortDirection.INLET)
+                    Port(
+                        id="P1",
+                        name="Inlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    )
                 ],
             ),
         ],
@@ -869,9 +986,9 @@ def _create_looped_project() -> Project:
             PipeConnection(
                 id="suction-pipe",
                 from_component_id="reservoir-1",
-                from_port_id="outlet",
+                from_port_id="P1",
                 to_component_id="pump-1",
-                to_port_id="suction",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -884,9 +1001,9 @@ def _create_looped_project() -> Project:
             PipeConnection(
                 id="pump-to-j1",
                 from_component_id="pump-1",
-                from_port_id="discharge",
+                from_port_id="P2",
                 to_component_id="junction-1",
-                to_port_id="inlet1",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -900,9 +1017,9 @@ def _create_looped_project() -> Project:
             PipeConnection(
                 id="j1-to-j2",
                 from_component_id="junction-1",
-                from_port_id="outlet",
+                from_port_id="P3",
                 to_component_id="junction-2",
-                to_port_id="inlet",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -916,9 +1033,9 @@ def _create_looped_project() -> Project:
             PipeConnection(
                 id="j2-to-j1-loop",
                 from_component_id="junction-2",
-                from_port_id="outlet1",
+                from_port_id="P2",
                 to_component_id="junction-1",
-                to_port_id="inlet2",
+                to_port_id="P2",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -931,9 +1048,9 @@ def _create_looped_project() -> Project:
             PipeConnection(
                 id="j2-to-tank",
                 from_component_id="junction-2",
-                from_port_id="outlet2",
+                from_port_id="P3",
                 to_component_id="tank-1",
-                to_port_id="inlet",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -974,7 +1091,12 @@ def _create_non_ideal_reference_node_project() -> Project:
                     FlowPressurePoint(flow=200, pressure=45.0),
                 ],
                 ports=[
-                    Port(id="outlet", nominal_size=4.0, direction=PortDirection.OUTLET)
+                    Port(
+                        id="P1",
+                        name="Outlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
+                    )
                 ],
             ),
             PumpComponent(
@@ -983,9 +1105,17 @@ def _create_non_ideal_reference_node_project() -> Project:
                 elevation=0.0,
                 curve_id="pump-curve-1",
                 ports=[
-                    Port(id="suction", nominal_size=4.0, direction=PortDirection.INLET),
                     Port(
-                        id="discharge", nominal_size=4.0, direction=PortDirection.OUTLET
+                        id="P1",
+                        name="Suction",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    ),
+                    Port(
+                        id="P2",
+                        name="Discharge",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
                     ),
                 ],
             ),
@@ -998,7 +1128,12 @@ def _create_non_ideal_reference_node_project() -> Project:
                 max_level=20.0,
                 initial_level=5.0,
                 ports=[
-                    Port(id="inlet", nominal_size=4.0, direction=PortDirection.INLET)
+                    Port(
+                        id="P1",
+                        name="Inlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    )
                 ],
             ),
         ],
@@ -1006,9 +1141,9 @@ def _create_non_ideal_reference_node_project() -> Project:
             PipeConnection(
                 id="suction-pipe",
                 from_component_id="reference-1",
-                from_port_id="outlet",
+                from_port_id="P1",
                 to_component_id="pump-1",
-                to_port_id="suction",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -1021,9 +1156,9 @@ def _create_non_ideal_reference_node_project() -> Project:
             PipeConnection(
                 id="discharge-pipe",
                 from_component_id="pump-1",
-                from_port_id="discharge",
+                from_port_id="P2",
                 to_component_id="tank-1",
-                to_port_id="inlet",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -1061,7 +1196,12 @@ def _create_pump_with_npshr_project() -> Project:
                 elevation=0.0,
                 water_level=5.0,  # Low water level for NPSH concern
                 ports=[
-                    Port(id="outlet", nominal_size=4.0, direction=PortDirection.OUTLET)
+                    Port(
+                        id="P1",
+                        name="Outlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
+                    )
                 ],
             ),
             PumpComponent(
@@ -1070,9 +1210,17 @@ def _create_pump_with_npshr_project() -> Project:
                 elevation=5.0,  # Pump above water level
                 curve_id="pump-curve-1",
                 ports=[
-                    Port(id="suction", nominal_size=4.0, direction=PortDirection.INLET),
                     Port(
-                        id="discharge", nominal_size=4.0, direction=PortDirection.OUTLET
+                        id="P1",
+                        name="Suction",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    ),
+                    Port(
+                        id="P2",
+                        name="Discharge",
+                        nominal_size=4.0,
+                        direction=PortDirection.OUTLET,
                     ),
                 ],
             ),
@@ -1085,7 +1233,12 @@ def _create_pump_with_npshr_project() -> Project:
                 max_level=20.0,
                 initial_level=5.0,
                 ports=[
-                    Port(id="inlet", nominal_size=4.0, direction=PortDirection.INLET)
+                    Port(
+                        id="P1",
+                        name="Inlet",
+                        nominal_size=4.0,
+                        direction=PortDirection.INLET,
+                    )
                 ],
             ),
         ],
@@ -1093,9 +1246,9 @@ def _create_pump_with_npshr_project() -> Project:
             PipeConnection(
                 id="suction-pipe",
                 from_component_id="reservoir-1",
-                from_port_id="outlet",
+                from_port_id="P1",
                 to_component_id="pump-1",
-                to_port_id="suction",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -1111,9 +1264,9 @@ def _create_pump_with_npshr_project() -> Project:
             PipeConnection(
                 id="discharge-pipe",
                 from_component_id="pump-1",
-                from_port_id="discharge",
+                from_port_id="P2",
                 to_component_id="tank-1",
-                to_port_id="inlet",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -1159,7 +1312,12 @@ def _create_large_pipe_low_velocity_project() -> Project:
                 elevation=0.0,
                 water_level=10.0,
                 ports=[
-                    Port(id="outlet", nominal_size=12.0, direction=PortDirection.OUTLET)
+                    Port(
+                        id="P1",
+                        name="Outlet",
+                        nominal_size=12.0,
+                        direction=PortDirection.OUTLET,
+                    )
                 ],
             ),
             PumpComponent(
@@ -1169,10 +1327,14 @@ def _create_large_pipe_low_velocity_project() -> Project:
                 curve_id="pump-curve-1",
                 ports=[
                     Port(
-                        id="suction", nominal_size=12.0, direction=PortDirection.INLET
+                        id="P1",
+                        name="Suction",
+                        nominal_size=12.0,
+                        direction=PortDirection.INLET,
                     ),
                     Port(
-                        id="discharge",
+                        id="P2",
+                        name="Discharge",
                         nominal_size=12.0,
                         direction=PortDirection.OUTLET,
                     ),
@@ -1187,7 +1349,12 @@ def _create_large_pipe_low_velocity_project() -> Project:
                 max_level=20.0,
                 initial_level=5.0,
                 ports=[
-                    Port(id="inlet", nominal_size=12.0, direction=PortDirection.INLET)
+                    Port(
+                        id="P1",
+                        name="Inlet",
+                        nominal_size=12.0,
+                        direction=PortDirection.INLET,
+                    )
                 ],
             ),
         ],
@@ -1195,9 +1362,9 @@ def _create_large_pipe_low_velocity_project() -> Project:
             PipeConnection(
                 id="suction-pipe",
                 from_component_id="reservoir-1",
-                from_port_id="outlet",
+                from_port_id="P1",
                 to_component_id="pump-1",
-                to_port_id="suction",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,
@@ -1210,9 +1377,9 @@ def _create_large_pipe_low_velocity_project() -> Project:
             PipeConnection(
                 id="discharge-pipe",
                 from_component_id="pump-1",
-                from_port_id="discharge",
+                from_port_id="P2",
                 to_component_id="tank-1",
-                to_port_id="inlet",
+                to_port_id="P1",
                 piping=PipingSegment(
                     pipe=PipeDefinition(
                         material=PipeMaterial.CARBON_STEEL,

--- a/apps/web/src/lib/components/results/ComponentTable.svelte
+++ b/apps/web/src/lib/components/results/ComponentTable.svelte
@@ -61,7 +61,7 @@
 					componentId: component.id,
 					componentName: component.name,
 					componentType: component.type,
-					port: { id: 'default', nominal_size: 0, direction: 'bidirectional' },
+					port: { id: 'P0', name: 'Default', nominal_size: 0, direction: 'bidirectional' },
 					isFirstPort: true,
 					portCount: 1,
 					result

--- a/apps/web/src/lib/data/exampleProject.ts
+++ b/apps/web/src/lib/data/exampleProject.ts
@@ -55,7 +55,7 @@ export const EXAMPLE_PROJECT: Project = {
 			name: 'Supply Reservoir',
 			elevation: 0,
 			water_level: 15,
-			ports: [{ id: 'outlet_1', nominal_size: 6, direction: 'bidirectional' }],
+			ports: [{ id: 'P1', name: 'Outlet', nominal_size: 6, direction: 'bidirectional' }],
 			downstream_connections: [
 				{
 					target_component_id: 'valve_suction',
@@ -87,8 +87,8 @@ export const EXAMPLE_PROJECT: Project = {
 			position: 1.0,
 			cv: 450,
 			ports: [
-				{ id: 'inlet', nominal_size: 4, direction: 'inlet' },
-				{ id: 'outlet', nominal_size: 4, direction: 'outlet' }
+				{ id: 'P1', name: 'Inlet', nominal_size: 4, direction: 'inlet' },
+				{ id: 'P2', name: 'Outlet', nominal_size: 4, direction: 'outlet' }
 			],
 			downstream_connections: [
 				{
@@ -120,8 +120,8 @@ export const EXAMPLE_PROJECT: Project = {
 			speed: 1.0,
 			status: 'on',
 			ports: [
-				{ id: 'suction', nominal_size: 4, direction: 'inlet' },
-				{ id: 'discharge', nominal_size: 4, direction: 'outlet' }
+				{ id: 'P1', name: 'Suction', nominal_size: 4, direction: 'inlet' },
+				{ id: 'P2', name: 'Discharge', nominal_size: 4, direction: 'outlet' }
 			],
 			downstream_connections: [
 				{
@@ -150,8 +150,8 @@ export const EXAMPLE_PROJECT: Project = {
 			position: 0.85,
 			cv: 200,
 			ports: [
-				{ id: 'inlet', nominal_size: 4, direction: 'inlet' },
-				{ id: 'outlet', nominal_size: 4, direction: 'outlet' }
+				{ id: 'P1', name: 'Inlet', nominal_size: 4, direction: 'inlet' },
+				{ id: 'P2', name: 'Outlet', nominal_size: 4, direction: 'outlet' }
 			],
 			downstream_connections: [
 				{
@@ -185,7 +185,7 @@ export const EXAMPLE_PROJECT: Project = {
 			min_level: 2,
 			max_level: 25,
 			initial_level: 10,
-			ports: [{ id: 'port_1', nominal_size: 4, direction: 'bidirectional' }],
+			ports: [{ id: 'P1', name: 'Port', nominal_size: 4, direction: 'bidirectional' }],
 			downstream_connections: []
 		}
 	],
@@ -193,9 +193,9 @@ export const EXAMPLE_PROJECT: Project = {
 		{
 			id: 'conn_1',
 			from_component_id: 'reservoir_1',
-			from_port_id: 'outlet_1',
+			from_port_id: 'P1',
 			to_component_id: 'valve_suction',
-			to_port_id: 'inlet',
+			to_port_id: 'P1',
 			piping: {
 				pipe: {
 					material: 'carbon_steel',
@@ -213,9 +213,9 @@ export const EXAMPLE_PROJECT: Project = {
 		{
 			id: 'conn_2',
 			from_component_id: 'valve_suction',
-			from_port_id: 'outlet',
+			from_port_id: 'P2',
 			to_component_id: 'pump_1',
-			to_port_id: 'suction',
+			to_port_id: 'P1',
 			piping: {
 				pipe: {
 					material: 'carbon_steel',
@@ -232,9 +232,9 @@ export const EXAMPLE_PROJECT: Project = {
 		{
 			id: 'conn_3',
 			from_component_id: 'pump_1',
-			from_port_id: 'discharge',
+			from_port_id: 'P2',
 			to_component_id: 'valve_discharge',
-			to_port_id: 'inlet',
+			to_port_id: 'P1',
 			piping: {
 				pipe: {
 					material: 'carbon_steel',
@@ -248,9 +248,9 @@ export const EXAMPLE_PROJECT: Project = {
 		{
 			id: 'conn_4',
 			from_component_id: 'valve_discharge',
-			from_port_id: 'outlet',
+			from_port_id: 'P2',
 			to_component_id: 'tank_1',
-			to_port_id: 'port_1',
+			to_port_id: 'P1',
 			piping: {
 				pipe: {
 					material: 'carbon_steel',

--- a/apps/web/src/lib/models/__tests__/components.test.ts
+++ b/apps/web/src/lib/models/__tests__/components.test.ts
@@ -24,14 +24,14 @@ describe('getPortElevation', () => {
 			downstream_connections: []
 		};
 
-		expect(getPortElevation(component, 'outlet_1')).toBe(100);
+		expect(getPortElevation(component, 'P1')).toBe(100);
 	});
 
 	it('returns port elevation when explicitly set', () => {
 		const ports: Port[] = [
-			{ id: 'bottom_drain', nominal_size: 4.0, direction: 'bidirectional', elevation: 95 },
-			{ id: 'side_fill', nominal_size: 6.0, direction: 'bidirectional', elevation: 105 },
-			{ id: 'top_overflow', nominal_size: 4.0, direction: 'bidirectional', elevation: 120 }
+			{ id: 'P1', name: 'Bottom Drain', nominal_size: 4.0, direction: 'bidirectional', elevation: 95 },
+			{ id: 'P2', name: 'Side Fill', nominal_size: 6.0, direction: 'bidirectional', elevation: 105 },
+			{ id: 'P3', name: 'Top Overflow', nominal_size: 4.0, direction: 'bidirectional', elevation: 120 }
 		];
 
 		const component: Component = {
@@ -47,14 +47,14 @@ describe('getPortElevation', () => {
 			downstream_connections: []
 		};
 
-		expect(getPortElevation(component, 'bottom_drain')).toBe(95);
-		expect(getPortElevation(component, 'side_fill')).toBe(105);
-		expect(getPortElevation(component, 'top_overflow')).toBe(120);
+		expect(getPortElevation(component, 'P1')).toBe(95);
+		expect(getPortElevation(component, 'P2')).toBe(105);
+		expect(getPortElevation(component, 'P3')).toBe(120);
 	});
 
 	it('returns 0 when port elevation is explicitly set to 0', () => {
 		const ports: Port[] = [
-			{ id: 'outlet_1', nominal_size: 4.0, direction: 'bidirectional', elevation: 0 }
+			{ id: 'P1', name: 'Outlet', nominal_size: 4.0, direction: 'bidirectional', elevation: 0 }
 		];
 
 		const component: Component = {
@@ -68,12 +68,12 @@ describe('getPortElevation', () => {
 		};
 
 		// Port elevation is explicitly 0, should not inherit 50
-		expect(getPortElevation(component, 'outlet_1')).toBe(0);
+		expect(getPortElevation(component, 'P1')).toBe(0);
 	});
 
 	it('supports negative port elevations', () => {
 		const ports: Port[] = [
-			{ id: 'bottom', nominal_size: 4.0, direction: 'bidirectional', elevation: -25 }
+			{ id: 'P1', name: 'Bottom', nominal_size: 4.0, direction: 'bidirectional', elevation: -25 }
 		];
 
 		const component: Component = {
@@ -89,17 +89,17 @@ describe('getPortElevation', () => {
 			downstream_connections: []
 		};
 
-		expect(getPortElevation(component, 'bottom')).toBe(-25);
+		expect(getPortElevation(component, 'P1')).toBe(-25);
 	});
 
 	it('handles mixed ports - some with elevation, some without', () => {
 		const ports: Port[] = [
-			{ id: 'suction', nominal_size: 6.0, direction: 'inlet', elevation: 5 }, // Explicit elevation
-			{ id: 'discharge', nominal_size: 4.0, direction: 'outlet' } // No elevation, inherits
+			{ id: 'P1', name: 'Suction', nominal_size: 6.0, direction: 'inlet', elevation: 5 }, // Explicit elevation
+			{ id: 'P2', name: 'Discharge', nominal_size: 4.0, direction: 'outlet' } // No elevation, inherits
 		];
 
 		const component: Component = {
-			id: 'P1',
+			id: 'PMP1',
 			type: 'pump',
 			name: 'Vertical Pump',
 			elevation: 10, // Pump body at 10 ft
@@ -110,8 +110,8 @@ describe('getPortElevation', () => {
 			downstream_connections: []
 		};
 
-		expect(getPortElevation(component, 'suction')).toBe(5); // Uses explicit elevation
-		expect(getPortElevation(component, 'discharge')).toBe(10); // Inherits component elevation
+		expect(getPortElevation(component, 'P1')).toBe(5); // Uses explicit elevation
+		expect(getPortElevation(component, 'P2')).toBe(10); // Inherits component elevation
 	});
 
 	it('throws error for non-existent port', () => {
@@ -134,7 +134,8 @@ describe('getPortElevation', () => {
 describe('Port interface', () => {
 	it('allows port creation without elevation (undefined)', () => {
 		const port: Port = {
-			id: 'port_1',
+			id: 'P1',
+			name: 'Port',
 			nominal_size: 4.0,
 			direction: 'bidirectional'
 		};
@@ -144,7 +145,8 @@ describe('Port interface', () => {
 
 	it('allows port creation with explicit elevation', () => {
 		const port: Port = {
-			id: 'port_1',
+			id: 'P1',
+			name: 'Port',
 			nominal_size: 4.0,
 			direction: 'bidirectional',
 			elevation: 15.5
@@ -155,7 +157,8 @@ describe('Port interface', () => {
 
 	it('allows port creation with zero elevation', () => {
 		const port: Port = {
-			id: 'port_1',
+			id: 'P1',
+			name: 'Port',
 			nominal_size: 4.0,
 			direction: 'bidirectional',
 			elevation: 0
@@ -166,7 +169,8 @@ describe('Port interface', () => {
 
 	it('allows port creation with negative elevation', () => {
 		const port: Port = {
-			id: 'port_1',
+			id: 'P1',
+			name: 'Port',
 			nominal_size: 4.0,
 			direction: 'bidirectional',
 			elevation: -10

--- a/apps/web/src/lib/models/components.ts
+++ b/apps/web/src/lib/models/components.ts
@@ -16,7 +16,8 @@ export type PortDirection = 'inlet' | 'outlet' | 'bidirectional';
  * A connection port on a component.
  *
  * Ports define where pipes can connect to components. Each port has:
- * - A unique ID within the component (e.g., "suction", "discharge")
+ * - A unique ID within the component (P1, P2, P3, etc.)
+ * - A human-readable name describing the port's purpose
  * - A nominal size for pipe size matching
  * - A direction indicating flow constraints
  * - An optional elevation override for port-specific height
@@ -27,8 +28,10 @@ export type PortDirection = 'inlet' | 'outlet' | 'bidirectional';
  * elevations can be set to model connection points at different heights.
  */
 export interface Port {
-	/** Unique port identifier within the component. */
+	/** Unique port identifier within the component (P1, P2, P3, ...). */
 	id: string;
+	/** Human-readable name describing the port (e.g., 'Suction', 'Discharge'). */
+	name: string;
 	/** Nominal port size in project units (typically inches). */
 	nominal_size: number;
 	/** Flow direction constraint for this port. */
@@ -471,99 +474,99 @@ export function generateComponentId(): string {
 
 /** Create default ports for a reservoir. */
 export function createReservoirPorts(size: number = 4.0): Port[] {
-	return [{ id: 'outlet_1', nominal_size: size, direction: 'bidirectional' }];
+	return [{ id: 'P1', name: 'Outlet', nominal_size: size, direction: 'bidirectional' }];
 }
 
 /** Create default ports for a tank. */
 export function createTankPorts(size: number = 4.0): Port[] {
-	return [{ id: 'port_1', nominal_size: size, direction: 'bidirectional' }];
+	return [{ id: 'P1', name: 'Port', nominal_size: size, direction: 'bidirectional' }];
 }
 
 /** Create default ports for a junction. */
 export function createJunctionPorts(size: number = 4.0): Port[] {
-	return [{ id: 'port_1', nominal_size: size, direction: 'bidirectional' }];
+	return [{ id: 'P1', name: 'Port', nominal_size: size, direction: 'bidirectional' }];
 }
 
 /** Create default ports for a pump. */
 export function createPumpPorts(suctionSize: number = 4.0, dischargeSize: number = 4.0): Port[] {
 	return [
-		{ id: 'suction', nominal_size: suctionSize, direction: 'inlet' },
-		{ id: 'discharge', nominal_size: dischargeSize, direction: 'outlet' }
+		{ id: 'P1', name: 'Suction', nominal_size: suctionSize, direction: 'inlet' },
+		{ id: 'P2', name: 'Discharge', nominal_size: dischargeSize, direction: 'outlet' }
 	];
 }
 
 /** Create default ports for a valve. */
 export function createValvePorts(size: number = 4.0): Port[] {
 	return [
-		{ id: 'inlet', nominal_size: size, direction: 'inlet' },
-		{ id: 'outlet', nominal_size: size, direction: 'outlet' }
+		{ id: 'P1', name: 'Inlet', nominal_size: size, direction: 'inlet' },
+		{ id: 'P2', name: 'Outlet', nominal_size: size, direction: 'outlet' }
 	];
 }
 
 /** Create default ports for a heat exchanger. */
 export function createHeatExchangerPorts(size: number = 4.0): Port[] {
 	return [
-		{ id: 'inlet', nominal_size: size, direction: 'inlet' },
-		{ id: 'outlet', nominal_size: size, direction: 'outlet' }
+		{ id: 'P1', name: 'Inlet', nominal_size: size, direction: 'inlet' },
+		{ id: 'P2', name: 'Outlet', nominal_size: size, direction: 'outlet' }
 	];
 }
 
 /** Create default ports for a strainer. */
 export function createStrainerPorts(size: number = 4.0): Port[] {
 	return [
-		{ id: 'inlet', nominal_size: size, direction: 'inlet' },
-		{ id: 'outlet', nominal_size: size, direction: 'outlet' }
+		{ id: 'P1', name: 'Inlet', nominal_size: size, direction: 'inlet' },
+		{ id: 'P2', name: 'Outlet', nominal_size: size, direction: 'outlet' }
 	];
 }
 
 /** Create default ports for an orifice. */
 export function createOrificePorts(size: number = 4.0): Port[] {
 	return [
-		{ id: 'inlet', nominal_size: size, direction: 'inlet' },
-		{ id: 'outlet', nominal_size: size, direction: 'outlet' }
+		{ id: 'P1', name: 'Inlet', nominal_size: size, direction: 'inlet' },
+		{ id: 'P2', name: 'Outlet', nominal_size: size, direction: 'outlet' }
 	];
 }
 
 /** Create default ports for a sprinkler. */
 export function createSprinklerPorts(size: number = 1.0): Port[] {
-	return [{ id: 'inlet', nominal_size: size, direction: 'inlet' }];
+	return [{ id: 'P1', name: 'Inlet', nominal_size: size, direction: 'inlet' }];
 }
 
 /** Create default ports for a reference node. */
 export function createReferenceNodePorts(size: number = 4.0): Port[] {
-	return [{ id: 'port_1', nominal_size: size, direction: 'bidirectional' }];
+	return [{ id: 'P1', name: 'Port', nominal_size: size, direction: 'bidirectional' }];
 }
 
 /** Create default ports for a plug. */
 export function createPlugPorts(size: number = 4.0): Port[] {
-	return [{ id: 'port_1', nominal_size: size, direction: 'bidirectional' }];
+	return [{ id: 'P1', name: 'Port', nominal_size: size, direction: 'bidirectional' }];
 }
 
 /** Create default ports for a tee branch. */
 export function createTeePorts(runSize: number = 4.0, branchSize?: number): Port[] {
 	return [
-		{ id: 'run_inlet', nominal_size: runSize, direction: 'bidirectional' },
-		{ id: 'run_outlet', nominal_size: runSize, direction: 'bidirectional' },
-		{ id: 'branch', nominal_size: branchSize ?? runSize, direction: 'bidirectional' }
+		{ id: 'P1', name: 'Run Inlet', nominal_size: runSize, direction: 'bidirectional' },
+		{ id: 'P2', name: 'Run Outlet', nominal_size: runSize, direction: 'bidirectional' },
+		{ id: 'P3', name: 'Branch', nominal_size: branchSize ?? runSize, direction: 'bidirectional' }
 	];
 }
 
 /** Create default ports for a wye branch. */
 export function createWyePorts(runSize: number = 4.0, branchSize?: number): Port[] {
 	return [
-		{ id: 'run_inlet', nominal_size: runSize, direction: 'bidirectional' },
-		{ id: 'run_outlet', nominal_size: runSize, direction: 'bidirectional' },
-		{ id: 'branch', nominal_size: branchSize ?? runSize, direction: 'bidirectional' }
+		{ id: 'P1', name: 'Run Inlet', nominal_size: runSize, direction: 'bidirectional' },
+		{ id: 'P2', name: 'Run Outlet', nominal_size: runSize, direction: 'bidirectional' },
+		{ id: 'P3', name: 'Branch', nominal_size: branchSize ?? runSize, direction: 'bidirectional' }
 	];
 }
 
 /** Create default ports for a cross branch. */
 export function createCrossPorts(mainSize: number = 4.0, branchSize?: number): Port[] {
 	return [
-		{ id: 'run_inlet', nominal_size: mainSize, direction: 'bidirectional' },
-		{ id: 'run_outlet', nominal_size: mainSize, direction: 'bidirectional' },
-		{ id: 'branch_1', nominal_size: branchSize ?? mainSize, direction: 'bidirectional' },
-		{ id: 'branch_2', nominal_size: branchSize ?? mainSize, direction: 'bidirectional' }
+		{ id: 'P1', name: 'Run Inlet', nominal_size: mainSize, direction: 'bidirectional' },
+		{ id: 'P2', name: 'Run Outlet', nominal_size: mainSize, direction: 'bidirectional' },
+		{ id: 'P3', name: 'Branch 1', nominal_size: branchSize ?? mainSize, direction: 'bidirectional' },
+		{ id: 'P4', name: 'Branch 2', nominal_size: branchSize ?? mainSize, direction: 'bidirectional' }
 	];
 }
 


### PR DESCRIPTION
## Summary
- Add `name: str` required field to Port model separating human-readable labels from machine identifiers
- Add regex validation `^P\d+$` on Port id field (P1, P2, P3...)
- Update all port factory functions across Python and TypeScript to use new format
- Update branch model filtering methods to use name instead of id

Closes #92

## Test plan
- [x] All 629 backend tests pass
- [x] All 86 frontend tests pass
- [x] TypeScript type checking passes
- [x] Linting passes (Ruff, ESLint, Prettier)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)