### PR TITLE
feat(models): add surface_pressure to Reservoir and Tank (#94)

### DIFF
--- a/apps/web/src/lib/data/exampleProject.ts
+++ b/apps/web/src/lib/data/exampleProject.ts
@@ -55,6 +55,7 @@ export const EXAMPLE_PROJECT: Project = {
 			name: 'Supply Reservoir',
 			elevation: 0,
 			water_level: 15,
+			surface_pressure: 0,
 			ports: [{ id: 'P1', name: 'Outlet', nominal_size: 6, direction: 'bidirectional' }],
 			downstream_connections: [
 				{
@@ -185,6 +186,7 @@ export const EXAMPLE_PROJECT: Project = {
 			min_level: 2,
 			max_level: 25,
 			initial_level: 10,
+			surface_pressure: 0,
 			ports: [{ id: 'P1', name: 'Port', nominal_size: 4, direction: 'bidirectional' }],
 			downstream_connections: []
 		}

--- a/apps/web/src/lib/models/__tests__/components.test.ts
+++ b/apps/web/src/lib/models/__tests__/components.test.ts
@@ -20,6 +20,7 @@ describe('getPortElevation', () => {
 			name: 'Test Reservoir',
 			elevation: 100,
 			water_level: 10,
+			surface_pressure: 0,
 			ports: createReservoirPorts(4.0),
 			downstream_connections: []
 		};
@@ -43,6 +44,7 @@ describe('getPortElevation', () => {
 			min_level: 0,
 			max_level: 20,
 			initial_level: 10,
+			surface_pressure: 0,
 			ports,
 			downstream_connections: []
 		};
@@ -63,6 +65,7 @@ describe('getPortElevation', () => {
 			name: 'Test Reservoir',
 			elevation: 50, // Component at 50 ft
 			water_level: 10,
+			surface_pressure: 0,
 			ports,
 			downstream_connections: []
 		};
@@ -85,6 +88,7 @@ describe('getPortElevation', () => {
 			min_level: 0,
 			max_level: 20,
 			initial_level: 10,
+			surface_pressure: 0,
 			ports,
 			downstream_connections: []
 		};
@@ -121,6 +125,7 @@ describe('getPortElevation', () => {
 			name: 'Test Reservoir',
 			elevation: 100,
 			water_level: 10,
+			surface_pressure: 0,
 			ports: createReservoirPorts(4.0),
 			downstream_connections: []
 		};


### PR DESCRIPTION
## Summary
- Add `surface_pressure: float` field (default: 0.0) to `Reservoir` and `Tank` models
- Add `total_head_with_pressure()` method for full head calculation including surface pressure
- Add `getTankTotalHead()` and `getTankTotalHeadWithPressure()` frontend utilities
- Update TypeScript interfaces and example project
- Backward compatible: existing projects default to atmospheric pressure (0)

Closes #94

## Test plan
- [x] All 629 backend tests pass
- [x] All 86 frontend tests pass
- [x] TypeScript type checking passes
- [x] Linting passes (Ruff, ESLint, Prettier)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)