### PR TITLE
feat(ui): add theme toggle and engineering input component (#96)

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -1,1 +1,311 @@
 @import 'tailwindcss';
+
+/* ========================================================================
+   Theme CSS Custom Properties
+   ======================================================================== */
+
+:root {
+	/* Typography */
+	--font-sans: 'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+		sans-serif;
+	--font-mono: 'JetBrains Mono', 'Fira Code', 'SF Mono', Consolas, ui-monospace, monospace;
+
+	/* Spacing */
+	--space-xs: 0.25rem;
+	--space-sm: 0.5rem;
+	--space-md: 1rem;
+	--space-lg: 1.5rem;
+	--space-xl: 2rem;
+
+	/* Borders */
+	--radius-sm: 4px;
+	--radius-md: 6px;
+	--radius-lg: 8px;
+}
+
+/* ========================================================================
+   Dark Theme (Default)
+   ======================================================================== */
+[data-theme='dark'] {
+	--color-bg: #0a0a0a;
+	--color-surface: #111111;
+	--color-surface-elevated: #1a1a1a;
+	--color-border: #262626;
+	--color-border-subtle: #1f1f1f;
+	--color-text: #e5e5e5;
+	--color-text-muted: #a3a3a3;
+	--color-text-subtle: #737373;
+	--color-accent: #f59e0b;
+	--color-accent-hover: #d97706;
+	--color-accent-muted: rgba(245, 158, 11, 0.15);
+	--color-accent-text: #000;
+	--color-success: #22c55e;
+	--color-warning: #f59e0b;
+	--color-error: #ef4444;
+	--color-info: #3b82f6;
+	--color-dropdown-shadow: rgba(0, 0, 0, 0.4);
+}
+
+/* ========================================================================
+   Light Theme
+   ======================================================================== */
+[data-theme='light'] {
+	--color-bg: #f5f5f5;
+	--color-surface: #ffffff;
+	--color-surface-elevated: #fafafa;
+	--color-border: #e5e5e5;
+	--color-border-subtle: #ebebeb;
+	--color-text: #171717;
+	--color-text-muted: #525252;
+	--color-text-subtle: #737373;
+	--color-accent: #2563eb;
+	--color-accent-hover: #1d4ed8;
+	--color-accent-muted: rgba(37, 99, 235, 0.12);
+	--color-accent-text: #fff;
+	--color-success: #16a34a;
+	--color-warning: #ca8a04;
+	--color-error: #dc2626;
+	--color-info: #2563eb;
+	--color-dropdown-shadow: rgba(0, 0, 0, 0.1);
+}
+
+/* ========================================================================
+   Base Styles
+   ======================================================================== */
+html {
+	font-family: var(--font-sans);
+}
+
+body {
+	background-color: var(--color-bg);
+	color: var(--color-text);
+	transition:
+		background-color 0.2s ease,
+		color 0.2s ease;
+}
+
+/* ========================================================================
+   Form Input Utilities
+   ======================================================================== */
+
+/* Hide number input spin buttons */
+input[type='number']::-webkit-outer-spin-button,
+input[type='number']::-webkit-inner-spin-button {
+	-webkit-appearance: none;
+	margin: 0;
+}
+
+input[type='number'] {
+	appearance: textfield;
+	-moz-appearance: textfield;
+}
+
+/* ========================================================================
+   Engineering Input Component Styles
+   ======================================================================== */
+.engineering-input {
+	display: flex;
+	flex-direction: column;
+	gap: var(--space-xs);
+}
+
+.engineering-input .input-label {
+	font-size: 0.75rem;
+	font-weight: 500;
+	color: var(--color-text-muted);
+	text-transform: uppercase;
+	letter-spacing: 0.025em;
+}
+
+.engineering-input .input-wrapper {
+	display: flex;
+	background: var(--color-surface);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-md);
+	transition:
+		border-color 0.15s ease,
+		box-shadow 0.15s ease;
+}
+
+.engineering-input .input-wrapper:focus-within {
+	border-color: var(--color-accent);
+	box-shadow: 0 0 0 3px var(--color-accent-muted);
+}
+
+.engineering-input .value-input {
+	flex: 1;
+	min-width: 0;
+	padding: 0.625rem 0.875rem;
+	background: transparent;
+	border: none;
+	color: var(--color-text);
+	font-family: var(--font-mono);
+	font-size: 0.875rem;
+	font-weight: 500;
+}
+
+.engineering-input .value-input:focus {
+	outline: none;
+}
+
+.engineering-input .value-input::placeholder {
+	color: var(--color-text-subtle);
+}
+
+.engineering-input .unit-button {
+	display: flex;
+	align-items: center;
+	gap: var(--space-xs);
+	padding: 0.625rem 0.75rem;
+	background: var(--color-surface-elevated);
+	border: none;
+	border-left: 1px solid var(--color-border);
+	border-radius: 0 var(--radius-md) var(--radius-md) 0;
+	color: var(--color-text-muted);
+	font-size: 0.75rem;
+	font-weight: 600;
+	text-transform: uppercase;
+	cursor: pointer;
+	transition:
+		background-color 0.15s ease,
+		color 0.15s ease;
+}
+
+.engineering-input .unit-button:hover {
+	background: var(--color-border);
+	color: var(--color-text);
+}
+
+.engineering-input .unit-button:focus {
+	outline: none;
+	background: var(--color-border);
+	color: var(--color-text);
+}
+
+.engineering-input .unit-button .chevron {
+	width: 12px;
+	height: 12px;
+	transition: transform 0.15s ease;
+}
+
+.engineering-input .unit-button.open .chevron {
+	transform: rotate(180deg);
+}
+
+.engineering-input .unit-selector {
+	position: relative;
+}
+
+.engineering-input .unit-dropdown {
+	position: absolute;
+	top: 100%;
+	right: 0;
+	min-width: 80px;
+	margin-top: 4px;
+	padding: 4px;
+	background: var(--color-surface-elevated);
+	border: 1px solid var(--color-border);
+	border-radius: var(--radius-md);
+	box-shadow: 0 4px 12px var(--color-dropdown-shadow);
+	opacity: 0;
+	visibility: hidden;
+	transform: translateY(-4px);
+	transition:
+		opacity 0.15s ease,
+		transform 0.15s ease,
+		visibility 0.15s ease;
+	z-index: 50;
+}
+
+.engineering-input .unit-dropdown.open {
+	opacity: 1;
+	visibility: visible;
+	transform: translateY(0);
+}
+
+.engineering-input .unit-option {
+	display: block;
+	width: 100%;
+	padding: 0.5rem 0.75rem;
+	background: transparent;
+	border: none;
+	border-radius: var(--radius-sm);
+	color: var(--color-text-muted);
+	font-size: 0.75rem;
+	font-weight: 500;
+	text-align: left;
+	cursor: pointer;
+	transition:
+		background-color 0.1s ease,
+		color 0.1s ease;
+}
+
+.engineering-input .unit-option:hover {
+	background: var(--color-border);
+	color: var(--color-text);
+}
+
+.engineering-input .unit-option.selected {
+	background: var(--color-accent-muted);
+	color: var(--color-accent);
+}
+
+.engineering-input.disabled {
+	opacity: 0.5;
+	pointer-events: none;
+}
+
+.engineering-input .input-error {
+	font-size: 0.75rem;
+	color: var(--color-error);
+}
+
+.engineering-input .input-hint {
+	font-size: 0.75rem;
+	color: var(--color-text-subtle);
+}
+
+/* ========================================================================
+   Theme Toggle Styles
+   ======================================================================== */
+.theme-toggle {
+	position: relative;
+	width: 44px;
+	height: 24px;
+	background: var(--color-border);
+	border-radius: 12px;
+	cursor: pointer;
+	transition: background-color 0.2s ease;
+	border: none;
+	padding: 0;
+}
+
+.theme-toggle:focus {
+	outline: none;
+	box-shadow: 0 0 0 3px var(--color-accent-muted);
+}
+
+.theme-toggle-thumb {
+	position: absolute;
+	top: 2px;
+	left: 2px;
+	width: 20px;
+	height: 20px;
+	background: var(--color-surface);
+	border-radius: 50%;
+	transition: transform 0.2s ease;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+}
+
+.theme-toggle-thumb svg {
+	width: 12px;
+	height: 12px;
+	color: var(--color-text-muted);
+}
+
+[data-theme='light'] .theme-toggle-thumb {
+	transform: translateX(20px);
+}

--- a/apps/web/src/lib/components/Header.svelte
+++ b/apps/web/src/lib/components/Header.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+	import ThemeToggle from './ThemeToggle.svelte';
+
 	type ViewMode = 'panel' | 'results';
 
 	interface Props {
@@ -34,14 +36,14 @@
 	}
 </script>
 
-<header class="sticky top-0 z-50 border-b border-gray-200 bg-white shadow-sm">
+<header class="sticky top-0 z-50 border-b border-[var(--color-border)] bg-[var(--color-surface)] shadow-sm">
 	<div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
 		<div class="flex h-14 items-center justify-between">
 			<!-- Left: Logo and Project Name -->
 			<div class="flex items-center gap-3">
-				<a href="/" class="flex items-center gap-2 text-gray-900 hover:text-gray-700">
+				<a href="/" class="flex items-center gap-2 text-[var(--color-text)] hover:text-[var(--color-text-muted)]">
 					<svg
-						class="h-6 w-6 text-blue-600"
+						class="h-6 w-6 text-[var(--color-accent)]"
 						fill="none"
 						stroke="currentColor"
 						viewBox="0 0 24 24"
@@ -65,7 +67,7 @@
 						onclick={handleSolve}
 						disabled={!canSolve || isSolving}
 						title="Solve network (Ctrl+Enter)"
-						class="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+						class="inline-flex items-center gap-2 rounded-lg bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-[var(--color-accent-text)] transition-colors hover:bg-[var(--color-accent-hover)] focus:outline-none focus:ring-2 focus:ring-[var(--color-accent)] focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
 					>
 						{#if isSolving}
 							<svg class="h-4 w-4 animate-spin" fill="none" viewBox="0 0 24 24">
@@ -99,13 +101,13 @@
 				{/if}
 
 				{#if showViewSwitcher}
-					<div class="inline-flex rounded-lg border border-gray-200 bg-gray-50 p-1">
+					<div class="inline-flex rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-elevated)] p-1">
 						<button
 							type="button"
 							class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors {viewMode ===
 							'panel'
-								? 'bg-white text-gray-900 shadow'
-								: 'text-gray-600 hover:text-gray-900'}"
+								? 'bg-[var(--color-surface)] text-[var(--color-text)] shadow'
+								: 'text-[var(--color-text-muted)] hover:text-[var(--color-text)]'}"
 							onclick={() => handleViewModeChange('panel')}
 						>
 							Build
@@ -114,14 +116,16 @@
 							type="button"
 							class="rounded-md px-3 py-1.5 text-sm font-medium transition-colors {viewMode ===
 							'results'
-								? 'bg-white text-gray-900 shadow'
-								: 'text-gray-600 hover:text-gray-900'}"
+								? 'bg-[var(--color-surface)] text-[var(--color-text)] shadow'
+								: 'text-[var(--color-text-muted)] hover:text-[var(--color-text)]'}"
 							onclick={() => handleViewModeChange('results')}
 						>
 							Results
 						</button>
 					</div>
 				{/if}
+
+				<ThemeToggle />
 			</div>
 		</div>
 	</div>

--- a/apps/web/src/lib/components/ThemeToggle.svelte
+++ b/apps/web/src/lib/components/ThemeToggle.svelte
@@ -1,0 +1,46 @@
+<script lang="ts">
+	/**
+	 * Theme Toggle Component
+	 *
+	 * A toggle button for switching between light and dark themes.
+	 * Displays a sun icon in light mode and moon icon in dark mode.
+	 */
+
+	import { themeStore, isDarkMode } from '$lib/stores';
+
+	function handleToggle() {
+		themeStore.toggle();
+	}
+</script>
+
+<button
+	type="button"
+	class="theme-toggle"
+	aria-label={$isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+	title={$isDarkMode ? 'Switch to light mode' : 'Switch to dark mode'}
+	onclick={handleToggle}
+>
+	<span class="theme-toggle-thumb">
+		{#if $isDarkMode}
+			<!-- Moon icon for dark mode -->
+			<svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"
+				></path>
+			</svg>
+		{:else}
+			<!-- Sun icon for light mode -->
+			<svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"
+				></path>
+			</svg>
+		{/if}
+	</span>
+</button>

--- a/apps/web/src/lib/components/forms/EngineeringInput.svelte
+++ b/apps/web/src/lib/components/forms/EngineeringInput.svelte
@@ -1,0 +1,287 @@
+<script lang="ts">
+	/**
+	 * Engineering Input Component
+	 *
+	 * A composite form control for numerical values with integrated unit selection.
+	 * Designed for technical/engineering applications handling physical quantities.
+	 *
+	 * Features:
+	 * - Numerical input with hidden spin buttons
+	 * - Unit selector dropdown with keyboard navigation
+	 * - Focus states with visual ring
+	 * - Disabled state support
+	 * - Error and hint text
+	 */
+
+	interface Props {
+		/** Unique ID for the input element. */
+		id: string;
+		/** Label text to display above the input. */
+		label: string;
+		/** Current numerical value. */
+		value: number | null;
+		/** Currently selected unit. */
+		unit: string;
+		/** Available unit options. */
+		units: string[];
+		/** Minimum allowed value. */
+		min?: number;
+		/** Maximum allowed value. */
+		max?: number;
+		/** Step increment for the input. */
+		step?: number | 'any';
+		/** Whether the field is required. */
+		required?: boolean;
+		/** Placeholder text. */
+		placeholder?: string;
+		/** Helper text to show below input. */
+		hint?: string;
+		/** Whether the component is disabled. */
+		disabled?: boolean;
+		/** Callback when value changes. */
+		onchange?: (value: number | null, unit: string) => void;
+		/** Callback when unit changes. */
+		onunitchange?: (oldUnit: string, newUnit: string, value: number | null) => void;
+	}
+
+	let {
+		id,
+		label,
+		value = $bindable(null),
+		unit = $bindable(''),
+		units,
+		min,
+		max,
+		step = 'any',
+		required = false,
+		placeholder,
+		hint,
+		disabled = false,
+		onchange,
+		onunitchange
+	}: Props = $props();
+
+	let error = $state('');
+	let dropdownOpen = $state(false);
+	let unitButtonRef: HTMLButtonElement | null = $state(null);
+
+	/**
+	 * Validate and handle input changes.
+	 */
+	function handleInput(e: Event) {
+		const input = e.target as HTMLInputElement;
+		const rawValue = input.value;
+
+		// Empty input
+		if (rawValue === '') {
+			if (required) {
+				error = 'This field is required';
+			} else {
+				error = '';
+				value = null;
+				onchange?.(null, unit);
+			}
+			return;
+		}
+
+		const numValue = parseFloat(rawValue);
+
+		// Invalid number
+		if (isNaN(numValue)) {
+			error = 'Please enter a valid number';
+			return;
+		}
+
+		// Range validation
+		if (min !== undefined && numValue < min) {
+			error = `Value must be at least ${min}`;
+			return;
+		}
+
+		if (max !== undefined && numValue > max) {
+			error = `Value must be at most ${max}`;
+			return;
+		}
+
+		error = '';
+		value = numValue;
+		onchange?.(numValue, unit);
+	}
+
+	/**
+	 * Toggle dropdown visibility.
+	 */
+	function toggleDropdown(e: Event) {
+		e.preventDefault();
+		e.stopPropagation();
+		dropdownOpen = !dropdownOpen;
+	}
+
+	/**
+	 * Select a unit from the dropdown.
+	 */
+	function selectUnit(newUnit: string) {
+		if (newUnit !== unit) {
+			const oldUnit = unit;
+			unit = newUnit;
+			onunitchange?.(oldUnit, newUnit, value);
+			onchange?.(value, newUnit);
+		}
+		dropdownOpen = false;
+		unitButtonRef?.focus();
+	}
+
+	/**
+	 * Get the index of the currently selected unit.
+	 */
+	function getCurrentUnitIndex(): number {
+		return units.indexOf(unit);
+	}
+
+	/**
+	 * Cycle to the next or previous unit.
+	 */
+	function cycleUnit(direction: 'next' | 'prev') {
+		if (units.length <= 1) return;
+
+		const currentIndex = getCurrentUnitIndex();
+		let newIndex: number;
+
+		if (direction === 'next') {
+			newIndex = (currentIndex + 1) % units.length;
+		} else {
+			newIndex = (currentIndex - 1 + units.length) % units.length;
+		}
+
+		selectUnit(units[newIndex]);
+	}
+
+	/**
+	 * Handle keyboard navigation on unit button.
+	 */
+	function handleUnitKeydown(e: KeyboardEvent) {
+		switch (e.key) {
+			case 'ArrowDown':
+			case 'ArrowRight':
+				e.preventDefault();
+				cycleUnit('next');
+				break;
+			case 'ArrowUp':
+			case 'ArrowLeft':
+				e.preventDefault();
+				cycleUnit('prev');
+				break;
+			case 'Enter':
+			case ' ':
+				e.preventDefault();
+				dropdownOpen = !dropdownOpen;
+				break;
+			case 'Escape':
+				e.preventDefault();
+				dropdownOpen = false;
+				break;
+		}
+	}
+
+	/**
+	 * Close dropdown when clicking outside.
+	 */
+	function handleClickOutside(e: MouseEvent) {
+		const target = e.target as HTMLElement;
+		if (!target.closest('.unit-selector')) {
+			dropdownOpen = false;
+		}
+	}
+
+	/**
+	 * Handle global keydown for Escape.
+	 */
+	function handleGlobalKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape' && dropdownOpen) {
+			dropdownOpen = false;
+		}
+	}
+
+	// Setup global event listeners
+	$effect(() => {
+		if (typeof window !== 'undefined') {
+			document.addEventListener('click', handleClickOutside);
+			document.addEventListener('keydown', handleGlobalKeydown);
+
+			return () => {
+				document.removeEventListener('click', handleClickOutside);
+				document.removeEventListener('keydown', handleGlobalKeydown);
+			};
+		}
+	});
+</script>
+
+<div class="engineering-input" class:disabled>
+	<label for={id} class="input-label">
+		{label}
+		{#if required}
+			<span class="text-[var(--color-error)]">*</span>
+		{/if}
+	</label>
+
+	<div class="input-wrapper">
+		<input
+			type="number"
+			{id}
+			class="value-input"
+			value={value ?? ''}
+			{min}
+			{max}
+			{step}
+			{placeholder}
+			{disabled}
+			aria-invalid={!!error}
+			aria-describedby={error ? `${id}-error` : hint ? `${id}-hint` : undefined}
+			oninput={handleInput}
+		/>
+
+		{#if units.length > 0}
+			<div class="unit-selector">
+				<button
+					type="button"
+					class="unit-button"
+					class:open={dropdownOpen}
+					{disabled}
+					aria-haspopup="listbox"
+					aria-expanded={dropdownOpen}
+					aria-label="Select unit"
+					bind:this={unitButtonRef}
+					onclick={toggleDropdown}
+					onkeydown={handleUnitKeydown}
+				>
+					<span class="unit-text">{unit}</span>
+					<svg class="chevron" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"
+						></path>
+					</svg>
+				</button>
+
+				<div class="unit-dropdown" class:open={dropdownOpen} role="listbox" aria-label="Unit options">
+					{#each units as unitOption (unitOption)}
+						<button
+							type="button"
+							class="unit-option"
+							class:selected={unitOption === unit}
+							role="option"
+							aria-selected={unitOption === unit}
+							onclick={() => selectUnit(unitOption)}
+						>
+							{unitOption}
+						</button>
+					{/each}
+				</div>
+			</div>
+		{/if}
+	</div>
+
+	{#if error}
+		<p id="{id}-error" class="input-error">{error}</p>
+	{:else if hint}
+		<p id="{id}-hint" class="input-hint">{hint}</p>
+	{/if}
+</div>

--- a/apps/web/src/lib/components/forms/index.ts
+++ b/apps/web/src/lib/components/forms/index.ts
@@ -7,6 +7,7 @@
 
 // Base components
 export { default as NumberInput } from './NumberInput.svelte';
+export { default as EngineeringInput } from './EngineeringInput.svelte';
 
 // Node components
 export { default as ReservoirForm } from './ReservoirForm.svelte';

--- a/apps/web/src/lib/stores/index.ts
+++ b/apps/web/src/lib/stores/index.ts
@@ -30,3 +30,6 @@ export {
 
 // History store (undo/redo)
 export { historyStore, canUndo, canRedo, undoCount, redoCount } from './history';
+
+// Theme store (light/dark mode)
+export { themeStore, isDarkMode, type Theme } from './theme';

--- a/apps/web/src/lib/stores/theme.ts
+++ b/apps/web/src/lib/stores/theme.ts
@@ -1,0 +1,86 @@
+/**
+ * Theme store for managing light/dark mode.
+ */
+
+import { writable, derived } from 'svelte/store';
+import { browser } from '$app/environment';
+
+/** Available theme options. */
+export type Theme = 'light' | 'dark';
+
+/** Storage key for theme preference. */
+const STORAGE_KEY = 'opensolve-pipe-theme';
+
+/**
+ * Get the initial theme from localStorage or system preference.
+ */
+function getInitialTheme(): Theme {
+	if (!browser) return 'dark';
+
+	// Check localStorage first
+	const stored = localStorage.getItem(STORAGE_KEY);
+	if (stored === 'light' || stored === 'dark') {
+		return stored;
+	}
+
+	// Fall back to system preference
+	if (window.matchMedia('(prefers-color-scheme: light)').matches) {
+		return 'light';
+	}
+
+	return 'dark';
+}
+
+/**
+ * Create the theme store.
+ */
+function createThemeStore() {
+	const store = writable<Theme>(getInitialTheme());
+
+	return {
+		subscribe: store.subscribe,
+
+		/**
+		 * Set the theme.
+		 */
+		set(theme: Theme) {
+			store.set(theme);
+			if (browser) {
+				localStorage.setItem(STORAGE_KEY, theme);
+				document.documentElement.setAttribute('data-theme', theme);
+			}
+		},
+
+		/**
+		 * Toggle between light and dark themes.
+		 */
+		toggle() {
+			store.update((current) => {
+				const next = current === 'dark' ? 'light' : 'dark';
+				if (browser) {
+					localStorage.setItem(STORAGE_KEY, next);
+					document.documentElement.setAttribute('data-theme', next);
+				}
+				return next;
+			});
+		},
+
+		/**
+		 * Initialize the theme on mount.
+		 * Call this in +layout.svelte to apply the theme to the document.
+		 */
+		initialize() {
+			if (browser) {
+				const theme = getInitialTheme();
+				store.set(theme);
+				document.documentElement.setAttribute('data-theme', theme);
+			}
+		}
+	};
+}
+
+/** The theme store instance. */
+export const themeStore = createThemeStore();
+
+/** Derived store that returns true if dark mode is active. */
+export const isDarkMode = derived(themeStore, ($theme) => $theme === 'dark');

--- a/apps/web/src/routes/+layout.svelte
+++ b/apps/web/src/routes/+layout.svelte
@@ -1,7 +1,13 @@
 <script lang="ts">
   import '../app.css';
+  import { onMount } from 'svelte';
+  import { themeStore } from '$lib/stores';
 
   let { children } = $props();
+
+  onMount(() => {
+    themeStore.initialize();
+  });
 </script>
 
 <!-- Skip link for keyboard navigation -->


### PR DESCRIPTION
## Summary

Implements #96 - adds light/dark theme toggle and engineering input component matching the component library specification.

## Changes

### Theme System
- **ThemeToggle component**: Toggle button with sun/moon icons
- **Theme store**: Manages light/dark mode state with localStorage persistence
- **CSS custom properties**: All colors defined as CSS variables in `app.css`
- **Dark theme**: Amber accent (#f59e0b) - default
- **Light theme**: Blue accent (#2563eb)
- **System preference**: Respects `prefers-color-scheme` on first visit

### Engineering Input Component
- Numerical input with integrated unit selector dropdown
- **Keyboard navigation**: Arrow Up/Down cycles through units when focused
- Focus states with visual ring using theme accent color
- Dropdown closes on Escape key or click outside
- ARIA attributes for accessibility (`aria-haspopup`, `aria-expanded`, `role="listbox"`)
- Disabled state support
- Error and hint text display

### Header Updates
- All hardcoded colors replaced with CSS custom properties
- Theme toggle button added to header
- Consistent styling in both light and dark themes

## Testing

- ✅ All 86 existing tests pass
- ✅ Type checking passes (svelte-check)
- ✅ Linting passes (ESLint)
- ✅ Pre-commit hooks pass

## Acceptance Criteria

- [x] All engineering input fields follow the spec (keyboard nav, focus states, unit selector)
- [x] Theme toggle is accessible and persists across sessions
- [x] Smooth transitions on theme change
- [x] Accessible: proper ARIA attributes, keyboard navigation

## Plan

See `apps/web/docs/FORM_SPEC_INPUT_FIELD_WITH_UNITS.md` for the engineering input specification.
See `apps/web/docs/COMPONENT_LIBRARY.html` for the living component library reference.

Closes #96