### PR TITLE
fix(ui): replace hardcoded colors with CSS custom properties

### DIFF
--- a/apps/web/src/lib/components/forms/CrossBranchForm.svelte
+++ b/apps/web/src/lib/components/forms/CrossBranchForm.svelte
@@ -38,15 +38,15 @@
 </script>
 
 <div class="space-y-4">
-	<div class="rounded-md bg-purple-50 p-3">
-		<p class="text-sm text-purple-800">
+	<div class="rounded-md bg-[var(--color-accent-muted)] p-3">
+		<p class="text-sm text-[var(--color-accent)]">
 			<strong>Cross Branch:</strong> Four-way fitting with perpendicular branches. Used for complex
 			flow distribution.
 		</p>
 	</div>
 
 	<!-- Visual diagram -->
-	<div class="rounded-md border border-gray-200 bg-gray-50 p-4">
+	<div class="rounded-md border border-[var(--color-border)] bg-[var(--color-surface-elevated)] p-4">
 		<div class="flex items-center justify-center">
 			<svg viewBox="0 0 100 100" class="h-20 w-20">
 				<!-- Run line (horizontal) -->
@@ -54,10 +54,10 @@
 				<!-- Branch lines (vertical) -->
 				<line x1="50" y1="10" x2="50" y2="90" stroke="currentColor" stroke-width="4" />
 				<!-- Port labels -->
-				<text x="10" y="45" class="fill-gray-600 text-[7px]">In</text>
-				<text x="80" y="45" class="fill-gray-600 text-[7px]">Out</text>
-				<text x="55" y="18" class="fill-gray-600 text-[7px]">Br 1</text>
-				<text x="55" y="92" class="fill-gray-600 text-[7px]">Br 2</text>
+				<text x="10" y="45" class="fill-current text-[7px] opacity-60">In</text>
+				<text x="80" y="45" class="fill-current text-[7px] opacity-60">Out</text>
+				<text x="55" y="18" class="fill-current text-[7px] opacity-60">Br 1</text>
+				<text x="55" y="92" class="fill-current text-[7px] opacity-60">Br 2</text>
 				<!-- Flow arrows from center -->
 				<polygon points="30,47 20,50 30,53" fill="currentColor" />
 				<polygon points="70,47 80,50 70,53" fill="currentColor" />
@@ -65,7 +65,7 @@
 				<polygon points="47,70 50,80 53,70" fill="currentColor" />
 			</svg>
 		</div>
-		<p class="mt-2 text-center text-xs text-gray-500">Four-way flow distribution</p>
+		<p class="mt-2 text-center text-xs text-[var(--color-text-muted)]">Four-way flow distribution</p>
 	</div>
 
 	<NumberInput
@@ -76,9 +76,9 @@
 		onchange={(value) => onUpdate('elevation', value)}
 	/>
 
-	<div class="border-t border-gray-200 pt-4">
-		<span class="block text-sm font-medium text-gray-700">Port Sizes</span>
-		<p class="mt-1 text-xs text-gray-500">Configure the nominal pipe size for each connection</p>
+	<div class="border-t border-[var(--color-border)] pt-4">
+		<span class="block text-sm font-medium text-[var(--color-text)]">Port Sizes</span>
+		<p class="mt-1 text-xs text-[var(--color-text-muted)]">Configure the nominal pipe size for each connection</p>
 	</div>
 
 	<NumberInput
@@ -102,11 +102,11 @@
 	/>
 
 	<!-- Individual port override if needed -->
-	<details class="rounded-md border border-gray-200">
-		<summary class="cursor-pointer px-3 py-2 text-sm text-gray-600 hover:bg-gray-50">
+	<details class="rounded-md border border-[var(--color-border)]">
+		<summary class="cursor-pointer px-3 py-2 text-sm text-[var(--color-text-muted)] hover:bg-[var(--color-surface-elevated)]">
 			Configure ports individually
 		</summary>
-		<div class="space-y-3 border-t border-gray-200 p-3">
+		<div class="space-y-3 border-t border-[var(--color-border)] p-3">
 			<NumberInput
 				id="run_inlet_size"
 				label="Run Inlet"

--- a/apps/web/src/lib/components/forms/FittingsTable.svelte
+++ b/apps/web/src/lib/components/forms/FittingsTable.svelte
@@ -39,12 +39,12 @@
 
 <div class="space-y-3">
 	<div class="flex items-center justify-between">
-		<h4 class="text-sm font-medium text-gray-900">Fittings</h4>
+		<h4 class="text-sm font-medium text-[var(--color-text)]">Fittings</h4>
 		<div class="relative">
 			<button
 				type="button"
 				onclick={() => (showSelector = !showSelector)}
-				class="inline-flex items-center gap-1 text-sm font-medium text-blue-600 hover:text-blue-700"
+				class="inline-flex items-center gap-1 text-sm font-medium text-[var(--color-accent)] hover:opacity-80"
 			>
 				<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
@@ -60,18 +60,18 @@
 					onclick={() => (showSelector = false)}
 					aria-label="Close menu"
 				></button>
-				<div class="absolute right-0 z-50 mt-2 w-64 rounded-lg border border-gray-200 bg-white shadow-lg">
+				<div class="absolute right-0 z-50 mt-2 w-64 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] shadow-lg">
 					<div class="max-h-64 overflow-y-auto p-2">
 						{#each Object.entries(FITTING_CATEGORIES) as [category, types]}
 							<div class="py-1">
-								<p class="px-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+								<p class="px-2 text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
 									{category}
 								</p>
 								{#each types as type}
 									<button
 										type="button"
 										onclick={() => addFitting(type)}
-										class="block w-full px-2 py-1.5 text-left text-sm text-gray-700 hover:bg-gray-100 rounded"
+										class="block w-full px-2 py-1.5 text-left text-sm text-[var(--color-text)] hover:bg-[var(--color-surface-elevated)] rounded"
 									>
 										{FITTING_TYPE_LABELS[type]}
 									</button>
@@ -85,29 +85,29 @@
 	</div>
 
 	{#if fittings.length === 0}
-		<p class="text-sm text-gray-500 italic">No fittings added</p>
+		<p class="text-sm text-[var(--color-text-muted)] italic">No fittings added</p>
 	{:else}
-		<div class="overflow-hidden rounded-md border border-gray-200">
-			<table class="min-w-full divide-y divide-gray-200">
-				<thead class="bg-gray-50">
+		<div class="overflow-hidden rounded-md border border-[var(--color-border)]">
+			<table class="min-w-full divide-y divide-[var(--color-border)]">
+				<thead class="bg-[var(--color-surface-elevated)]">
 					<tr>
-						<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+						<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 							Type
 						</th>
-						<th class="w-20 px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+						<th class="w-20 px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 							Qty
 						</th>
-						<th class="w-24 px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+						<th class="w-24 px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 							K-Factor
 						</th>
 						<th class="w-20 px-3 py-2"></th>
 					</tr>
 				</thead>
-				<tbody class="divide-y divide-gray-200 bg-white">
+				<tbody class="divide-y divide-[var(--color-border)] bg-[var(--color-surface)]">
 					{#each fittings as fitting, index}
 						<tr>
 							<td class="px-3 py-2">
-								<span class="text-sm text-gray-900">{FITTING_TYPE_LABELS[fitting.type]}</span>
+								<span class="text-sm text-[var(--color-text)]">{FITTING_TYPE_LABELS[fitting.type]}</span>
 							</td>
 							<td class="px-3 py-2">
 								<input
@@ -117,7 +117,7 @@
 									max={99}
 									onchange={(e) => updateFitting(index, 'quantity', parseInt((e.target as HTMLInputElement).value) || 1)}
 									aria-label="Quantity for {FITTING_TYPE_LABELS[fitting.type]}"
-									class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+									class="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
 								/>
 							</td>
 							<td class="px-3 py-2">
@@ -132,7 +132,7 @@
 										updateFitting(index, 'k_factor_override', val ? parseFloat(val) : undefined);
 									}}
 									aria-label="K-factor for {FITTING_TYPE_LABELS[fitting.type]}"
-									class="w-full rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+									class="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
 								/>
 							</td>
 							<td class="px-3 py-2">
@@ -140,7 +140,7 @@
 									<button
 										type="button"
 										onclick={() => duplicateFitting(index)}
-										class="text-gray-400 hover:text-gray-600"
+										class="text-[var(--color-text-subtle)] hover:text-[var(--color-text)]"
 										title="Duplicate"
 									>
 										<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -150,7 +150,7 @@
 									<button
 										type="button"
 										onclick={() => removeFitting(index)}
-										class="text-gray-400 hover:text-red-500"
+										class="text-[var(--color-text-subtle)] hover:text-[var(--color-error)]"
 										title="Remove"
 									>
 										<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -164,7 +164,7 @@
 				</tbody>
 			</table>
 		</div>
-		<p class="text-xs text-gray-500">
+		<p class="text-xs text-[var(--color-text-muted)]">
 			K-Factor: Leave blank to use standard values based on diameter
 		</p>
 	{/if}

--- a/apps/web/src/lib/components/forms/PipeForm.svelte
+++ b/apps/web/src/lib/components/forms/PipeForm.svelte
@@ -16,12 +16,12 @@
 <div class="space-y-4">
 	<div class="grid grid-cols-2 gap-3">
 		<div>
-			<label for="material" class="block text-sm font-medium text-gray-700">Material</label>
+			<label for="material" class="block text-sm font-medium text-[var(--color-text)]">Material</label>
 			<select
 				id="material"
 				value={pipe.material}
 				onchange={(e) => onUpdate('material', (e.target as HTMLSelectElement).value)}
-				class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+				class="mt-1 block w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] shadow-sm focus:border-[var(--color-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
 			>
 				{#each Object.entries(PIPE_MATERIAL_LABELS) as [value, label]}
 					<option {value}>{label}</option>
@@ -30,12 +30,12 @@
 		</div>
 
 		<div>
-			<label for="schedule" class="block text-sm font-medium text-gray-700">Schedule</label>
+			<label for="schedule" class="block text-sm font-medium text-[var(--color-text)]">Schedule</label>
 			<select
 				id="schedule"
 				value={pipe.schedule}
 				onchange={(e) => onUpdate('schedule', (e.target as HTMLSelectElement).value)}
-				class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+				class="mt-1 block w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] shadow-sm focus:border-[var(--color-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
 			>
 				{#each Object.entries(PIPE_SCHEDULE_LABELS) as [value, label]}
 					<option {value}>{label}</option>

--- a/apps/web/src/lib/components/forms/PlugForm.svelte
+++ b/apps/web/src/lib/components/forms/PlugForm.svelte
@@ -21,8 +21,8 @@
 </script>
 
 <div class="space-y-4">
-	<div class="rounded-md bg-gray-50 p-3">
-		<p class="text-sm text-gray-700">
+	<div class="rounded-md bg-[var(--color-surface-elevated)] p-3">
+		<p class="text-sm text-[var(--color-text)]">
 			<strong>Plug/Cap:</strong> Dead-end boundary condition. Flow is zero at this point.
 		</p>
 	</div>

--- a/apps/web/src/lib/components/forms/PumpForm.svelte
+++ b/apps/web/src/lib/components/forms/PumpForm.svelte
@@ -243,13 +243,13 @@
 
 	<!-- Pump Curve Selection -->
 	<div>
-		<label for="curve_id" class="block text-sm font-medium text-gray-700">Pump Curve</label>
+		<label for="curve_id" class="block text-sm font-medium text-[var(--color-text)]">Pump Curve</label>
 		<div class="mt-1 flex gap-2">
 			<select
 				id="curve_id"
 				value={component.curve_id}
 				onchange={(e) => onUpdate('curve_id', (e.target as HTMLSelectElement).value)}
-				class="block flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+				class="block flex-1 rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] shadow-sm focus:border-[var(--color-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
 			>
 				<option value="">Select a curve...</option>
 				{#each $pumpLibrary as curve}
@@ -259,7 +259,7 @@
 			<button
 				type="button"
 				onclick={startNewCurve}
-				class="rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200"
+				class="rounded-md bg-[var(--color-surface-elevated)] px-3 py-2 text-sm font-medium text-[var(--color-text)] hover:bg-[var(--color-border)]"
 				title="Create new curve"
 			>
 				+
@@ -268,7 +268,7 @@
 				<button
 					type="button"
 					onclick={editExistingCurve}
-					class="rounded-md bg-gray-100 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-200"
+					class="rounded-md bg-[var(--color-surface-elevated)] px-3 py-2 text-sm font-medium text-[var(--color-text)] hover:bg-[var(--color-border)]"
 					title="Edit selected curve"
 				>
 					Edit
@@ -279,11 +279,11 @@
 
 	<!-- Curve Preview -->
 	{#if selectedCurve}
-		<div class="rounded-md border border-gray-200 bg-gray-50 p-3">
-			<p class="text-xs font-medium text-gray-500">Curve Points</p>
+		<div class="rounded-md border border-[var(--color-border)] bg-[var(--color-surface-elevated)] p-3">
+			<p class="text-xs font-medium text-[var(--color-text-muted)]">Curve Points</p>
 			<div class="mt-1 flex flex-wrap gap-2">
 				{#each selectedCurve.points as point}
-					<span class="rounded bg-white px-2 py-1 text-xs text-gray-700 shadow-sm">
+					<span class="rounded bg-[var(--color-surface)] px-2 py-1 text-xs text-[var(--color-text)] shadow-sm">
 						{point.flow} GPM @ {point.head} ft
 					</span>
 				{/each}
@@ -305,7 +305,7 @@
 
 	<!-- Status -->
 	<fieldset>
-		<legend class="block text-sm font-medium text-gray-700">Status</legend>
+		<legend class="block text-sm font-medium text-[var(--color-text)]">Status</legend>
 		<div class="mt-2 flex gap-4">
 			<label class="flex items-center">
 				<input
@@ -314,9 +314,9 @@
 					value="on"
 					checked={component.status === 'on'}
 					onchange={() => onUpdate('status', 'on')}
-					class="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+					class="h-4 w-4 border-[var(--color-border)] text-[var(--color-accent)] focus:ring-[var(--color-accent)]"
 				/>
-				<span class="ml-2 text-sm text-gray-700">On</span>
+				<span class="ml-2 text-sm text-[var(--color-text)]">On</span>
 			</label>
 			<label class="flex items-center">
 				<input
@@ -325,9 +325,9 @@
 					value="off"
 					checked={component.status === 'off'}
 					onchange={() => onUpdate('status', 'off')}
-					class="h-4 w-4 border-gray-300 text-blue-600 focus:ring-blue-500"
+					class="h-4 w-4 border-[var(--color-border)] text-[var(--color-accent)] focus:ring-[var(--color-accent)]"
 				/>
-				<span class="ml-2 text-sm text-gray-700">Off</span>
+				<span class="ml-2 text-sm text-[var(--color-text)]">Off</span>
 			</label>
 		</div>
 	</fieldset>
@@ -345,13 +345,13 @@
 	>
 		<div
 			bind:this={modalRef}
-			class="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg bg-white p-6 shadow-xl"
+			class="max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-lg bg-[var(--color-surface)] p-6 shadow-xl"
 		>
-			<h3 id="modal-title" class="text-lg font-semibold text-gray-900">Edit Pump Curve</h3>
+			<h3 id="modal-title" class="text-lg font-semibold text-[var(--color-text)]">Edit Pump Curve</h3>
 
 			<div class="mt-4 space-y-4">
 				<div>
-					<label for="curve_name" class="block text-sm font-medium text-gray-700">Curve Name</label>
+					<label for="curve_name" class="block text-sm font-medium text-[var(--color-text)]">Curve Name</label>
 					<input
 						type="text"
 						id="curve_name"
@@ -359,27 +359,27 @@
 						oninput={(e) => {
 							if (editingCurve) editingCurve.name = (e.target as HTMLInputElement).value;
 						}}
-						class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+						class="mt-1 block w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
 					/>
 				</div>
 
 				<!-- Points Table -->
 				<div>
-					<p class="text-sm font-medium text-gray-700">Flow-Head Points</p>
-					<div class="mt-2 overflow-hidden rounded-md border border-gray-200">
-						<table class="min-w-full divide-y divide-gray-200">
-							<thead class="bg-gray-50">
+					<p class="text-sm font-medium text-[var(--color-text)]">Flow-Head Points</p>
+					<div class="mt-2 overflow-hidden rounded-md border border-[var(--color-border)]">
+						<table class="min-w-full divide-y divide-[var(--color-border)]">
+							<thead class="bg-[var(--color-surface-elevated)]">
 								<tr>
-									<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+									<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 										Flow (GPM)
 									</th>
-									<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+									<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 										Head (ft)
 									</th>
 									<th class="w-12 px-3 py-2"></th>
 								</tr>
 							</thead>
-							<tbody class="divide-y divide-gray-200 bg-white">
+							<tbody class="divide-y divide-[var(--color-border)] bg-[var(--color-surface)]">
 								{#each editingCurve.points as point, index}
 									<tr>
 										<td class="px-3 py-2">
@@ -389,7 +389,7 @@
 												min={0}
 												oninput={(e) =>
 													updatePoint(index, 'flow', parseFloat((e.target as HTMLInputElement).value) || 0)}
-												class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+												class="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)]"
 											/>
 										</td>
 										<td class="px-3 py-2">
@@ -399,14 +399,14 @@
 												min={0}
 												oninput={(e) =>
 													updatePoint(index, 'head', parseFloat((e.target as HTMLInputElement).value) || 0)}
-												class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+												class="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)]"
 											/>
 										</td>
 										<td class="px-3 py-2">
 											<button
 												type="button"
 												onclick={() => removePoint(index)}
-												class="text-red-500 hover:text-red-700"
+												class="text-[var(--color-error)] hover:opacity-80"
 												disabled={editingCurve.points.length <= 2}
 												aria-label="Remove point"
 											>
@@ -418,14 +418,14 @@
 									</tr>
 								{/each}
 								<!-- Add new point row -->
-								<tr class="bg-gray-50">
+								<tr class="bg-[var(--color-surface-elevated)]">
 									<td class="px-3 py-2">
 										<input
 											type="number"
 											placeholder="Flow"
 											bind:value={newPoint.flow}
 											min={0}
-											class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+											class="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)]"
 										/>
 									</td>
 									<td class="px-3 py-2">
@@ -434,14 +434,14 @@
 											placeholder="Head"
 											bind:value={newPoint.head}
 											min={0}
-											class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+											class="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)]"
 										/>
 									</td>
 									<td class="px-3 py-2">
 										<button
 											type="button"
 											onclick={addPoint}
-											class="text-blue-500 hover:text-blue-700"
+											class="text-[var(--color-accent)] hover:opacity-80"
 											aria-label="Add point"
 										>
 											<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -453,27 +453,27 @@
 							</tbody>
 						</table>
 					</div>
-					<p class="mt-1 text-xs text-gray-500">Minimum 2 points required</p>
+					<p class="mt-1 text-xs text-[var(--color-text-muted)]">Minimum 2 points required</p>
 				</div>
 
 				<!-- Efficiency Curve Table (optional) -->
 				<div>
-					<p class="text-sm font-medium text-gray-700">Efficiency Curve (optional)</p>
-					<p class="text-xs text-gray-500">Used to determine Best Efficiency Point (BEP)</p>
-					<div class="mt-2 overflow-hidden rounded-md border border-gray-200">
-						<table class="min-w-full divide-y divide-gray-200">
-							<thead class="bg-gray-50">
+					<p class="text-sm font-medium text-[var(--color-text)]">Efficiency Curve (optional)</p>
+					<p class="text-xs text-[var(--color-text-muted)]">Used to determine Best Efficiency Point (BEP)</p>
+					<div class="mt-2 overflow-hidden rounded-md border border-[var(--color-border)]">
+						<table class="min-w-full divide-y divide-[var(--color-border)]">
+							<thead class="bg-[var(--color-surface-elevated)]">
 								<tr>
-									<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+									<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 										Flow (GPM)
 									</th>
-									<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+									<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 										Efficiency (%)
 									</th>
 									<th class="w-12 px-3 py-2"></th>
 								</tr>
 							</thead>
-							<tbody class="divide-y divide-gray-200 bg-white">
+							<tbody class="divide-y divide-[var(--color-border)] bg-[var(--color-surface)]">
 								{#if editingCurve.efficiency_curve}
 									{#each editingCurve.efficiency_curve as point, index}
 										<tr>
@@ -484,7 +484,7 @@
 													min={0}
 													oninput={(e) =>
 														updateEfficiencyPoint(index, 'flow', parseFloat((e.target as HTMLInputElement).value) || 0)}
-													class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+													class="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)]"
 												/>
 											</td>
 											<td class="px-3 py-2">
@@ -495,14 +495,14 @@
 													max={100}
 													oninput={(e) =>
 														updateEfficiencyPoint(index, 'efficiency', parseFloat((e.target as HTMLInputElement).value) || 0)}
-													class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+													class="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)]"
 												/>
 											</td>
 											<td class="px-3 py-2">
 												<button
 													type="button"
 													onclick={() => removeEfficiencyPoint(index)}
-													class="text-red-500 hover:text-red-700"
+													class="text-[var(--color-error)] hover:opacity-80"
 													aria-label="Remove efficiency point"
 												>
 													<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -514,14 +514,14 @@
 									{/each}
 								{/if}
 								<!-- Add new efficiency point row -->
-								<tr class="bg-gray-50">
+								<tr class="bg-[var(--color-surface-elevated)]">
 									<td class="px-3 py-2">
 										<input
 											type="number"
 											placeholder="Flow"
 											bind:value={newEfficiencyPoint.flow}
 											min={0}
-											class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+											class="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)]"
 										/>
 									</td>
 									<td class="px-3 py-2">
@@ -531,14 +531,14 @@
 											bind:value={newEfficiencyPoint.efficiency}
 											min={0}
 											max={100}
-											class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+											class="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)]"
 										/>
 									</td>
 									<td class="px-3 py-2">
 										<button
 											type="button"
 											onclick={addEfficiencyPoint}
-											class="text-blue-500 hover:text-blue-700"
+											class="text-[var(--color-accent)] hover:opacity-80"
 											aria-label="Add efficiency point"
 										>
 											<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -554,22 +554,22 @@
 
 				<!-- NPSH Required Curve Table (optional) -->
 				<div>
-					<p class="text-sm font-medium text-gray-700">NPSH Required Curve (optional)</p>
-					<p class="text-xs text-gray-500">Used for cavitation margin calculations</p>
-					<div class="mt-2 overflow-hidden rounded-md border border-gray-200">
-						<table class="min-w-full divide-y divide-gray-200">
-							<thead class="bg-gray-50">
+					<p class="text-sm font-medium text-[var(--color-text)]">NPSH Required Curve (optional)</p>
+					<p class="text-xs text-[var(--color-text-muted)]">Used for cavitation margin calculations</p>
+					<div class="mt-2 overflow-hidden rounded-md border border-[var(--color-border)]">
+						<table class="min-w-full divide-y divide-[var(--color-border)]">
+							<thead class="bg-[var(--color-surface-elevated)]">
 								<tr>
-									<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+									<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 										Flow (GPM)
 									</th>
-									<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+									<th class="px-3 py-2 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 										NPSHr (ft)
 									</th>
 									<th class="w-12 px-3 py-2"></th>
 								</tr>
 							</thead>
-							<tbody class="divide-y divide-gray-200 bg-white">
+							<tbody class="divide-y divide-[var(--color-border)] bg-[var(--color-surface)]">
 								{#if editingCurve.npshr_curve}
 									{#each editingCurve.npshr_curve as point, index}
 										<tr>
@@ -580,7 +580,7 @@
 													min={0}
 													oninput={(e) =>
 														updateNpshrPoint(index, 'flow', parseFloat((e.target as HTMLInputElement).value) || 0)}
-													class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+													class="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)]"
 												/>
 											</td>
 											<td class="px-3 py-2">
@@ -590,14 +590,14 @@
 													min={0}
 													oninput={(e) =>
 														updateNpshrPoint(index, 'npsh_required', parseFloat((e.target as HTMLInputElement).value) || 0)}
-													class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+													class="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)]"
 												/>
 											</td>
 											<td class="px-3 py-2">
 												<button
 													type="button"
 													onclick={() => removeNpshrPoint(index)}
-													class="text-red-500 hover:text-red-700"
+													class="text-[var(--color-error)] hover:opacity-80"
 													aria-label="Remove NPSHr point"
 												>
 													<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -609,14 +609,14 @@
 									{/each}
 								{/if}
 								<!-- Add new NPSHr point row -->
-								<tr class="bg-gray-50">
+								<tr class="bg-[var(--color-surface-elevated)]">
 									<td class="px-3 py-2">
 										<input
 											type="number"
 											placeholder="Flow"
 											bind:value={newNpshrPoint.flow}
 											min={0}
-											class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+											class="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)]"
 										/>
 									</td>
 									<td class="px-3 py-2">
@@ -625,14 +625,14 @@
 											placeholder="NPSHr"
 											bind:value={newNpshrPoint.npsh_required}
 											min={0}
-											class="w-full rounded border border-gray-300 px-2 py-1 text-sm"
+											class="w-full rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)]"
 										/>
 									</td>
 									<td class="px-3 py-2">
 										<button
 											type="button"
 											onclick={addNpshrPoint}
-											class="text-blue-500 hover:text-blue-700"
+											class="text-[var(--color-accent)] hover:opacity-80"
 											aria-label="Add NPSHr point"
 										>
 											<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -651,7 +651,7 @@
 				<button
 					type="button"
 					onclick={cancelCurveEdit}
-					class="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50"
+					class="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-4 py-2 text-sm font-medium text-[var(--color-text)] hover:bg-[var(--color-surface-elevated)]"
 				>
 					Cancel
 				</button>
@@ -659,7 +659,7 @@
 					type="button"
 					onclick={saveCurve}
 					disabled={editingCurve.points.length < 2}
-					class="rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:bg-gray-400"
+					class="rounded-md bg-[var(--color-accent)] px-4 py-2 text-sm font-medium text-[var(--color-accent-text)] hover:bg-[var(--color-accent-hover)] disabled:opacity-50"
 				>
 					Save Curve
 				</button>

--- a/apps/web/src/lib/components/forms/ReferenceNodeForm.svelte
+++ b/apps/web/src/lib/components/forms/ReferenceNodeForm.svelte
@@ -78,7 +78,7 @@
 <div class="space-y-4">
 	<!-- Type Selector -->
 	<fieldset>
-		<legend class="block text-sm font-medium text-gray-700 mb-2">Reference Node Type</legend>
+		<legend class="block text-sm font-medium text-[var(--color-text)] mb-2">Reference Node Type</legend>
 		<div class="flex gap-2" role="group" aria-label="Reference Node Type">
 			<button
 				type="button"
@@ -86,8 +86,8 @@
 				aria-pressed={isIdeal}
 				class="flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors
 					{isIdeal
-					? 'bg-blue-600 text-white'
-					: 'bg-gray-100 text-gray-700 hover:bg-gray-200'}"
+					? 'bg-[var(--color-accent)] text-[var(--color-accent-text)]'
+					: 'bg-[var(--color-surface-elevated)] text-[var(--color-text)] hover:bg-[var(--color-border)]'}"
 			>
 				Ideal
 			</button>
@@ -97,13 +97,13 @@
 				aria-pressed={!isIdeal}
 				class="flex-1 rounded-md px-3 py-2 text-sm font-medium transition-colors
 					{!isIdeal
-					? 'bg-amber-600 text-white'
-					: 'bg-gray-100 text-gray-700 hover:bg-gray-200'}"
+					? 'bg-[var(--color-accent)] text-[var(--color-accent-text)]'
+					: 'bg-[var(--color-surface-elevated)] text-[var(--color-text)] hover:bg-[var(--color-border)]'}"
 			>
 				Non-Ideal
 			</button>
 		</div>
-		<p class="mt-1 text-xs text-gray-500">
+		<p class="mt-1 text-xs text-[var(--color-text-muted)]">
 			{isIdeal ? 'Constant pressure boundary' : 'Pressure varies with flow'}
 		</p>
 	</fieldset>
@@ -128,8 +128,8 @@
 
 	{#if isIdeal}
 		<!-- Ideal Reference Node: Fixed Pressure -->
-		<div class="rounded-md bg-blue-50 p-3">
-			<p class="text-sm text-blue-800">
+		<div class="rounded-md bg-[var(--color-accent-muted)] p-3">
+			<p class="text-sm text-[var(--color-accent)]">
 				<strong>Ideal Reference Node:</strong> Maintains constant pressure regardless of flow.
 			</p>
 		</div>
@@ -144,38 +144,38 @@
 		/>
 	{:else}
 		<!-- Non-Ideal Reference Node: Pressure-Flow Curve -->
-		<div class="rounded-md bg-amber-50 p-3">
-			<p class="text-sm text-amber-800">
+		<div class="rounded-md bg-[var(--color-accent-muted)] p-3">
+			<p class="text-sm text-[var(--color-accent)]">
 				<strong>Non-Ideal Reference Node:</strong> Pressure varies with flow rate.
 			</p>
 		</div>
 
 		<div class="space-y-2">
 			<div class="flex items-center justify-between">
-				<span class="block text-sm font-medium text-gray-700">Pressure-Flow Curve</span>
+				<span class="block text-sm font-medium text-[var(--color-text)]">Pressure-Flow Curve</span>
 				<button
 					type="button"
 					onclick={addCurvePoint}
-					class="inline-flex items-center rounded-md bg-blue-600 px-2 py-1 text-xs font-medium text-white hover:bg-blue-700"
+					class="inline-flex items-center rounded-md bg-[var(--color-accent)] px-2 py-1 text-xs font-medium text-[var(--color-accent-text)] hover:bg-[var(--color-accent-hover)]"
 				>
 					Add Point
 				</button>
 			</div>
 
 			{#if curveError()}
-				<p class="text-xs text-red-600">{curveError()}</p>
+				<p class="text-xs text-[var(--color-error)]">{curveError()}</p>
 			{/if}
 
 			<div class="overflow-x-auto">
-				<table class="min-w-full divide-y divide-gray-200 text-sm">
-					<thead class="bg-gray-50">
+				<table class="min-w-full divide-y divide-[var(--color-border)] text-sm">
+					<thead class="bg-[var(--color-surface-elevated)]">
 						<tr>
-							<th class="px-3 py-2 text-left font-medium text-gray-500">Flow (GPM)</th>
-							<th class="px-3 py-2 text-left font-medium text-gray-500">Pressure (psi)</th>
-							<th class="px-3 py-2 text-left font-medium text-gray-500"></th>
+							<th class="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Flow (GPM)</th>
+							<th class="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]">Pressure (psi)</th>
+							<th class="px-3 py-2 text-left font-medium text-[var(--color-text-muted)]"></th>
 						</tr>
 					</thead>
-					<tbody class="divide-y divide-gray-200">
+					<tbody class="divide-y divide-[var(--color-border)]">
 						{#each curvePoints as point, index}
 							<tr>
 								<td class="px-1 py-1">
@@ -184,7 +184,7 @@
 										value={point.flow}
 										min={0}
 										step="any"
-										class="w-20 rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none"
+										class="w-20 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
 										oninput={(e) =>
 											updateCurvePoint(index, 'flow', parseFloat(e.currentTarget.value))}
 									/>
@@ -194,7 +194,7 @@
 										type="number"
 										value={point.pressure}
 										step="any"
-										class="w-20 rounded border border-gray-300 px-2 py-1 text-sm focus:border-blue-500 focus:outline-none"
+										class="w-20 rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1 text-sm text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none"
 										oninput={(e) =>
 											updateCurvePoint(index, 'pressure', parseFloat(e.currentTarget.value))}
 									/>
@@ -204,7 +204,7 @@
 										<button
 											type="button"
 											onclick={() => removeCurvePoint(index)}
-											class="text-red-600 hover:text-red-800"
+											class="text-[var(--color-error)] hover:opacity-80"
 											title="Remove point"
 										>
 											<svg class="h-4 w-4" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -224,7 +224,7 @@
 				</table>
 			</div>
 
-			<p class="text-xs text-gray-500">
+			<p class="text-xs text-[var(--color-text-muted)]">
 				Enter flow-pressure pairs in ascending flow order. Pressure will be interpolated between
 				points.
 			</p>

--- a/apps/web/src/lib/components/forms/TeeBranchForm.svelte
+++ b/apps/web/src/lib/components/forms/TeeBranchForm.svelte
@@ -29,15 +29,15 @@
 </script>
 
 <div class="space-y-4">
-	<div class="rounded-md bg-blue-50 p-3">
-		<p class="text-sm text-blue-800">
+	<div class="rounded-md bg-[var(--color-accent-muted)] p-3">
+		<p class="text-sm text-[var(--color-accent)]">
 			<strong>Tee Branch:</strong> 90° fitting for flow splitting or combining. Run ports are the main
 			flow path, branch port is perpendicular.
 		</p>
 	</div>
 
 	<!-- Visual diagram -->
-	<div class="rounded-md border border-gray-200 bg-gray-50 p-4">
+	<div class="rounded-md border border-[var(--color-border)] bg-[var(--color-surface-elevated)] p-4">
 		<div class="flex items-center justify-center">
 			<svg viewBox="0 0 120 80" class="h-16 w-24">
 				<!-- Run line (horizontal) -->
@@ -45,16 +45,16 @@
 				<!-- Branch line (vertical up) -->
 				<line x1="60" y1="40" x2="60" y2="10" stroke="currentColor" stroke-width="4" />
 				<!-- Port labels -->
-				<text x="15" y="55" class="fill-gray-600 text-[8px]">Run In</text>
-				<text x="85" y="55" class="fill-gray-600 text-[8px]">Run Out</text>
-				<text x="65" y="20" class="fill-gray-600 text-[8px]">Branch</text>
+				<text x="15" y="55" class="fill-current text-[8px] opacity-60">Run In</text>
+				<text x="85" y="55" class="fill-current text-[8px] opacity-60">Run Out</text>
+				<text x="65" y="20" class="fill-current text-[8px] opacity-60">Branch</text>
 				<!-- Flow arrows -->
 				<polygon points="30,37 40,40 30,43" fill="currentColor" />
 				<polygon points="90,37 100,40 90,43" fill="currentColor" />
 				<polygon points="57,25 60,15 63,25" fill="currentColor" />
 			</svg>
 		</div>
-		<p class="mt-2 text-center text-xs text-gray-500">Flow direction shown for diverging flow</p>
+		<p class="mt-2 text-center text-xs text-[var(--color-text-muted)]">Flow direction shown for diverging flow</p>
 	</div>
 
 	<NumberInput
@@ -77,9 +77,9 @@
 		onchange={(value) => onUpdate('branch_angle', value)}
 	/>
 
-	<div class="border-t border-gray-200 pt-4">
-		<span class="block text-sm font-medium text-gray-700">Port Sizes</span>
-		<p class="mt-1 text-xs text-gray-500">Configure the nominal pipe size for each connection</p>
+	<div class="border-t border-[var(--color-border)] pt-4">
+		<span class="block text-sm font-medium text-[var(--color-text)]">Port Sizes</span>
+		<p class="mt-1 text-xs text-[var(--color-text-muted)]">Configure the nominal pipe size for each connection</p>
 	</div>
 
 	<NumberInput
@@ -102,8 +102,8 @@
 	/>
 
 	{#if branch && runInlet && branch.nominal_size > runInlet.nominal_size}
-		<div class="rounded-md border border-amber-200 bg-amber-50 p-2">
-			<p class="text-xs text-amber-800">
+		<div class="rounded-md border border-[var(--color-warning)]/30 bg-[var(--color-warning)]/10 p-2">
+			<p class="text-xs text-[var(--color-warning)]">
 				Branch size larger than run is unusual. Typically branch is same size or smaller.
 			</p>
 		</div>

--- a/apps/web/src/lib/components/forms/ValveForm.svelte
+++ b/apps/web/src/lib/components/forms/ValveForm.svelte
@@ -23,12 +23,12 @@
 	/>
 
 	<div>
-		<label for="valve_type" class="block text-sm font-medium text-gray-700">Valve Type</label>
+		<label for="valve_type" class="block text-sm font-medium text-[var(--color-text)]">Valve Type</label>
 		<select
 			id="valve_type"
 			value={component.valve_type}
 			onchange={(e) => onUpdate('valve_type', (e.target as HTMLSelectElement).value)}
-			class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+			class="mt-1 block w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] shadow-sm focus:border-[var(--color-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
 		>
 			{#each Object.entries(VALVE_TYPE_LABELS) as [value, label]}
 				<option {value}>{label}</option>

--- a/apps/web/src/lib/components/forms/WyeBranchForm.svelte
+++ b/apps/web/src/lib/components/forms/WyeBranchForm.svelte
@@ -29,15 +29,15 @@
 </script>
 
 <div class="space-y-4">
-	<div class="rounded-md bg-green-50 p-3">
-		<p class="text-sm text-green-800">
+	<div class="rounded-md bg-[var(--color-success)]/10 p-3">
+		<p class="text-sm text-[var(--color-success)]">
 			<strong>Wye Branch:</strong> Angled fitting (typically 45°) for smoother flow transitions.
 			Lower head loss than standard tee.
 		</p>
 	</div>
 
 	<!-- Visual diagram -->
-	<div class="rounded-md border border-gray-200 bg-gray-50 p-4">
+	<div class="rounded-md border border-[var(--color-border)] bg-[var(--color-surface-elevated)] p-4">
 		<div class="flex items-center justify-center">
 			<svg viewBox="0 0 120 80" class="h-16 w-24">
 				<!-- Run line (horizontal) -->
@@ -45,15 +45,15 @@
 				<!-- Branch line (angled up at 45°) -->
 				<line x1="60" y1="50" x2="85" y2="15" stroke="currentColor" stroke-width="4" />
 				<!-- Port labels -->
-				<text x="15" y="65" class="fill-gray-600 text-[8px]">Run In</text>
-				<text x="85" y="65" class="fill-gray-600 text-[8px]">Run Out</text>
-				<text x="75" y="20" class="fill-gray-600 text-[8px]">Branch</text>
+				<text x="15" y="65" class="fill-current text-[8px] opacity-60">Run In</text>
+				<text x="85" y="65" class="fill-current text-[8px] opacity-60">Run Out</text>
+				<text x="75" y="20" class="fill-current text-[8px] opacity-60">Branch</text>
 				<!-- Angle indicator -->
-				<path d="M 60,50 L 70,50 A 10,10 0 0,0 67,40" fill="none" stroke="gray" stroke-width="1" />
-				<text x="68" y="48" class="fill-gray-500 text-[6px]">45°</text>
+				<path d="M 60,50 L 70,50 A 10,10 0 0,0 67,40" fill="none" stroke="currentColor" stroke-width="1" class="opacity-50" />
+				<text x="68" y="48" class="fill-current text-[6px] opacity-50">45°</text>
 			</svg>
 		</div>
-		<p class="mt-2 text-center text-xs text-gray-500">Lower pressure drop than 90° tee</p>
+		<p class="mt-2 text-center text-xs text-[var(--color-text-muted)]">Lower pressure drop than 90° tee</p>
 	</div>
 
 	<NumberInput
@@ -76,9 +76,9 @@
 		onchange={(value) => onUpdate('branch_angle', value)}
 	/>
 
-	<div class="border-t border-gray-200 pt-4">
-		<span class="block text-sm font-medium text-gray-700">Port Sizes</span>
-		<p class="mt-1 text-xs text-gray-500">Configure the nominal pipe size for each connection</p>
+	<div class="border-t border-[var(--color-border)] pt-4">
+		<span class="block text-sm font-medium text-[var(--color-text)]">Port Sizes</span>
+		<p class="mt-1 text-xs text-[var(--color-text-muted)]">Configure the nominal pipe size for each connection</p>
 	</div>
 
 	<NumberInput
@@ -101,8 +101,8 @@
 	/>
 
 	{#if branch && runInlet && branch.nominal_size > runInlet.nominal_size}
-		<div class="rounded-md border border-amber-200 bg-amber-50 p-2">
-			<p class="text-xs text-amber-800">
+		<div class="rounded-md border border-[var(--color-warning)]/30 bg-[var(--color-warning)]/10 p-2">
+			<p class="text-xs text-[var(--color-warning)]">
 				Branch size larger than run is unusual. Typically branch is same size or smaller.
 			</p>
 		</div>

--- a/apps/web/src/lib/components/panel/DownstreamPipingPanel.svelte
+++ b/apps/web/src/lib/components/panel/DownstreamPipingPanel.svelte
@@ -57,9 +57,9 @@
 <div class="space-y-4">
 	{#if !firstConnection}
 		<!-- No downstream connection -->
-		<div class="rounded-lg border-2 border-dashed border-gray-300 p-6 text-center">
+		<div class="rounded-lg border-2 border-dashed border-[var(--color-border)] p-6 text-center">
 			<svg
-				class="mx-auto h-12 w-12 text-gray-400"
+				class="mx-auto h-12 w-12 text-[var(--color-text-subtle)]"
 				fill="none"
 				stroke="currentColor"
 				viewBox="0 0 24 24"
@@ -71,16 +71,16 @@
 					d="M13 7l5 5m0 0l-5 5m5-5H6"
 				/>
 			</svg>
-			<p class="mt-2 text-sm text-gray-600">No downstream connection</p>
-			<p class="mt-1 text-xs text-gray-400">
+			<p class="mt-2 text-sm text-[var(--color-text-muted)]">No downstream connection</p>
+			<p class="mt-1 text-xs text-[var(--color-text-subtle)]">
 				Add a component after this element to configure piping.
 			</p>
 		</div>
 	{:else if !piping}
 		<!-- Connection exists but no piping configured -->
-		<div class="rounded-lg border-2 border-dashed border-gray-300 p-6 text-center">
+		<div class="rounded-lg border-2 border-dashed border-[var(--color-border)] p-6 text-center">
 			<svg
-				class="mx-auto h-12 w-12 text-gray-400"
+				class="mx-auto h-12 w-12 text-[var(--color-text-subtle)]"
 				fill="none"
 				stroke="currentColor"
 				viewBox="0 0 24 24"
@@ -92,40 +92,40 @@
 					d="M12 6v6m0 0v6m0-6h6m-6 0H6"
 				/>
 			</svg>
-			<p class="mt-2 text-sm text-gray-600">
+			<p class="mt-2 text-sm text-[var(--color-text-muted)]">
 				No piping to {targetComponent?.name ?? 'downstream'}
 			</p>
 			<button
 				type="button"
 				onclick={initializePiping}
-				class="mt-3 inline-flex items-center rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+				class="mt-3 inline-flex items-center rounded-md bg-[var(--color-accent)] px-3 py-2 text-sm font-medium text-[var(--color-accent-text)] hover:bg-[var(--color-accent-hover)]"
 			>
 				Add Piping
 			</button>
 		</div>
 	{:else}
 		<!-- Target label -->
-		<div class="rounded-md bg-gray-50 px-3 py-2 text-sm text-gray-600">
-			Piping to: <span class="font-medium text-gray-900">{targetComponent?.name ?? 'downstream'}</span>
+		<div class="rounded-md bg-[var(--color-surface-elevated)] px-3 py-2 text-sm text-[var(--color-text-muted)]">
+			Piping to: <span class="font-medium text-[var(--color-text)]">{targetComponent?.name ?? 'downstream'}</span>
 		</div>
 
 		<!-- Pipe Configuration -->
 		<div class="space-y-3">
-			<h4 class="text-sm font-medium text-gray-900">Pipe</h4>
+			<h4 class="text-sm font-medium text-[var(--color-text)]">Pipe</h4>
 			<PipeForm pipe={piping.pipe} onUpdate={updatePipeField} />
 		</div>
 
 		<!-- Fittings -->
-		<div class="border-t border-gray-200 pt-4">
+		<div class="border-t border-[var(--color-border)] pt-4">
 			<FittingsTable fittings={piping.fittings} onUpdate={updateFittings} />
 		</div>
 
 		<!-- Remove Piping Button -->
-		<div class="border-t border-gray-200 pt-4">
+		<div class="border-t border-[var(--color-border)] pt-4">
 			<button
 				type="button"
 				onclick={removePiping}
-				class="text-sm text-red-600 hover:text-red-700 hover:underline"
+				class="text-sm text-[var(--color-error)] hover:opacity-80 hover:underline"
 			>
 				Remove piping
 			</button>

--- a/apps/web/src/lib/components/panel/ElementPanel.svelte
+++ b/apps/web/src/lib/components/panel/ElementPanel.svelte
@@ -105,26 +105,26 @@
 
 <div class="space-y-4">
 	<!-- Component Header -->
-	<div class="border-b border-gray-200 pb-3">
-		<span class="text-xs font-medium uppercase tracking-wide text-gray-500">
+	<div class="border-b border-[var(--color-border)] pb-3">
+		<span class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
 			{COMPONENT_TYPE_LABELS[component.type]}
 		</span>
 	</div>
 
 	<!-- Common Fields -->
 	<div>
-		<label for="name" class="block text-sm font-medium text-gray-700">Name</label>
+		<label for="name" class="block text-sm font-medium text-[var(--color-text)]">Name</label>
 		<input
 			type="text"
 			id="name"
 			value={component.name}
 			oninput={(e) => handleTextInput('name', e)}
-			class="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+			class="mt-1 block w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] shadow-sm focus:border-[var(--color-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
 		/>
 	</div>
 
 	<!-- Type-specific Fields -->
-	<div class="border-t border-gray-200 pt-4">
+	<div class="border-t border-[var(--color-border)] pt-4">
 		{#if isReservoir(component)}
 			<ReservoirForm {component} onUpdate={updateField} />
 		{:else if isTank(component)}
@@ -157,23 +157,23 @@
 	</div>
 
 	<!-- Delete Button -->
-	<div class="border-t border-gray-200 pt-4">
+	<div class="border-t border-[var(--color-border)] pt-4">
 		{#if showDeleteConfirm}
-			<div class="rounded-md border border-red-200 bg-red-50 p-3">
-				<p class="text-sm font-medium text-red-800">Delete "{component.name}"?</p>
-				<p class="mt-1 text-xs text-red-600">This action cannot be undone.</p>
+			<div class="rounded-md border border-[var(--color-error)]/30 bg-[var(--color-error)]/10 p-3">
+				<p class="text-sm font-medium text-[var(--color-error)]">Delete "{component.name}"?</p>
+				<p class="mt-1 text-xs text-[var(--color-error)]/80">This action cannot be undone.</p>
 				<div class="mt-3 flex gap-2">
 					<button
 						type="button"
 						onclick={confirmDelete}
-						class="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700"
+						class="rounded-md bg-[var(--color-error)] px-3 py-1.5 text-sm font-medium text-white hover:opacity-90"
 					>
 						Delete
 					</button>
 					<button
 						type="button"
 						onclick={cancelDelete}
-						class="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+						class="rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-1.5 text-sm font-medium text-[var(--color-text)] hover:bg-[var(--color-surface-elevated)]"
 					>
 						Cancel
 					</button>
@@ -183,7 +183,7 @@
 			<button
 				type="button"
 				onclick={handleDeleteClick}
-				class="text-sm text-red-600 hover:text-red-700 hover:underline"
+				class="text-sm text-[var(--color-error)] hover:opacity-80 hover:underline"
 			>
 				Delete this component
 			</button>

--- a/apps/web/src/lib/components/panel/ElementTypeSelector.svelte
+++ b/apps/web/src/lib/components/panel/ElementTypeSelector.svelte
@@ -40,15 +40,15 @@
 
 	<!-- Dropdown -->
 	<div
-		class="absolute right-0 top-full z-50 mt-2 w-80 rounded-lg border border-gray-200 bg-white shadow-lg"
+		class="absolute right-0 top-full z-50 mt-2 w-80 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] shadow-lg"
 	>
 		<div class="p-4">
-			<h3 class="mb-3 text-sm font-semibold text-gray-900">Add Component</h3>
+			<h3 class="mb-3 text-sm font-semibold text-[var(--color-text)]">Add Component</h3>
 
 			<div class="space-y-4">
 				{#each Object.entries(COMPONENT_CATEGORIES) as [category, types]}
 					<div>
-						<h4 class="mb-2 text-xs font-medium uppercase tracking-wide text-gray-500">
+						<h4 class="mb-2 text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">
 							{category}
 						</h4>
 						<div class="flex flex-wrap gap-2">
@@ -56,7 +56,7 @@
 								<button
 									type="button"
 									onclick={() => handleSelect(type)}
-									class="whitespace-nowrap rounded-md border border-gray-200 bg-white px-3 py-2 text-sm text-gray-900 transition-colors hover:border-blue-500 hover:bg-blue-50"
+									class="whitespace-nowrap rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] transition-colors hover:border-[var(--color-accent)] hover:bg-[var(--color-accent-muted)]"
 								>
 									{COMPONENT_TYPE_LABELS[type]}
 								</button>

--- a/apps/web/src/lib/components/panel/PipingPanel.svelte
+++ b/apps/web/src/lib/components/panel/PipingPanel.svelte
@@ -41,9 +41,9 @@
 <div class="space-y-4">
 	{#if !piping}
 		<!-- No piping configured -->
-		<div class="rounded-lg border-2 border-dashed border-gray-300 p-6 text-center">
+		<div class="rounded-lg border-2 border-dashed border-[var(--color-border)] p-6 text-center">
 			<svg
-				class="mx-auto h-12 w-12 text-gray-400"
+				class="mx-auto h-12 w-12 text-[var(--color-text-subtle)]"
 				fill="none"
 				stroke="currentColor"
 				viewBox="0 0 24 24"
@@ -55,11 +55,11 @@
 					d="M12 6v6m0 0v6m0-6h6m-6 0H6"
 				/>
 			</svg>
-			<p class="mt-2 text-sm text-gray-600">No upstream piping configured</p>
+			<p class="mt-2 text-sm text-[var(--color-text-muted)]">No upstream piping configured</p>
 			<button
 				type="button"
 				onclick={initializePiping}
-				class="mt-3 inline-flex items-center rounded-md bg-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-blue-700"
+				class="mt-3 inline-flex items-center rounded-md bg-[var(--color-accent)] px-3 py-2 text-sm font-medium text-[var(--color-accent-text)] hover:bg-[var(--color-accent-hover)]"
 			>
 				Add Piping
 			</button>
@@ -67,21 +67,21 @@
 	{:else}
 		<!-- Pipe Configuration -->
 		<div class="space-y-3">
-			<h4 class="text-sm font-medium text-gray-900">Pipe</h4>
+			<h4 class="text-sm font-medium text-[var(--color-text)]">Pipe</h4>
 			<PipeForm pipe={piping.pipe} onUpdate={updatePipeField} />
 		</div>
 
 		<!-- Fittings -->
-		<div class="border-t border-gray-200 pt-4">
+		<div class="border-t border-[var(--color-border)] pt-4">
 			<FittingsTable fittings={piping.fittings} onUpdate={updateFittings} />
 		</div>
 
 		<!-- Remove Piping Button -->
-		<div class="border-t border-gray-200 pt-4">
+		<div class="border-t border-[var(--color-border)] pt-4">
 			<button
 				type="button"
 				onclick={removePiping}
-				class="text-sm text-red-600 hover:text-red-700 hover:underline"
+				class="text-sm text-[var(--color-error)] hover:opacity-80 hover:underline"
 			>
 				Remove piping
 			</button>

--- a/apps/web/src/lib/components/results/ComponentTable.svelte
+++ b/apps/web/src/lib/components/results/ComponentTable.svelte
@@ -103,63 +103,63 @@
 </script>
 
 <div class="overflow-x-auto">
-	<table class="min-w-full divide-y divide-gray-200">
-		<thead class="bg-gray-50">
+	<table class="min-w-full divide-y divide-[var(--color-border)]">
+		<thead class="bg-[var(--color-surface-elevated)]">
 			<tr>
-				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 					Component
 				</th>
-				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 					Type
 				</th>
-				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 					Port
 				</th>
-				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 					Pressure (psi)
 				</th>
-				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 					HGL (ft)
 				</th>
-				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 					EGL (ft)
 				</th>
 			</tr>
 		</thead>
-		<tbody class="divide-y divide-gray-200 bg-white">
+		<tbody class="divide-y divide-[var(--color-border)] bg-[var(--color-surface)]">
 			{#each portData as row}
-				<tr class="hover:bg-gray-50">
+				<tr class="hover:bg-[var(--color-surface-elevated)]">
 					{#if row.isFirstPort}
 						<td
-							class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900"
+							class="whitespace-nowrap px-4 py-3 text-sm font-medium text-[var(--color-text)]"
 							rowspan={row.portCount}
 						>
 							{row.componentName}
 						</td>
 						<td
-							class="whitespace-nowrap px-4 py-3 text-sm text-gray-500"
+							class="whitespace-nowrap px-4 py-3 text-sm text-[var(--color-text-muted)]"
 							rowspan={row.portCount}
 						>
 							{COMPONENT_TYPE_LABELS[row.componentType]}
 						</td>
 					{/if}
-					<td class="whitespace-nowrap px-4 py-3 text-sm text-gray-500">
+					<td class="whitespace-nowrap px-4 py-3 text-sm text-[var(--color-text-muted)]">
 						{formatPortName(row.port)}
 					</td>
-					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
+					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-[var(--color-text)]">
 						{formatNumber(row.result?.pressure)}
 					</td>
-					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
+					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-[var(--color-text)]">
 						{formatNumber(row.result?.hgl)}
 					</td>
-					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
+					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-[var(--color-text)]">
 						{formatNumber(row.result?.egl)}
 					</td>
 				</tr>
 			{/each}
 			{#if portData.length === 0}
 				<tr>
-					<td colspan="6" class="px-4 py-8 text-center text-sm text-gray-500">
+					<td colspan="6" class="px-4 py-8 text-center text-sm text-[var(--color-text-muted)]">
 						No component results available
 					</td>
 				</tr>

--- a/apps/web/src/lib/components/results/PipingTable.svelte
+++ b/apps/web/src/lib/components/results/PipingTable.svelte
@@ -53,43 +53,43 @@
 </script>
 
 <div class="overflow-x-auto">
-	<table class="min-w-full divide-y divide-gray-200">
-		<thead class="bg-gray-50">
+	<table class="min-w-full divide-y divide-[var(--color-border)]">
+		<thead class="bg-[var(--color-surface-elevated)]">
 			<tr>
-				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-500">
+				<th class="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 					Piping
 				</th>
-				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 					Flow (GPM)
 				</th>
-				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 					Velocity (ft/s)
 				</th>
-				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-gray-500">
+				<th class="px-4 py-3 text-right text-xs font-medium uppercase tracking-wider text-[var(--color-text-muted)]">
 					Head Loss (ft)
 				</th>
 			</tr>
 		</thead>
-		<tbody class="divide-y divide-gray-200 bg-white">
+		<tbody class="divide-y divide-[var(--color-border)] bg-[var(--color-surface)]">
 			{#each pipingData as piping}
-				<tr class="hover:bg-gray-50">
-					<td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-gray-900">
+				<tr class="hover:bg-[var(--color-surface-elevated)]">
+					<td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-[var(--color-text)]">
 						{piping.name}
 					</td>
-					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
+					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-[var(--color-text)]">
 						{formatNumber(piping.result?.flow)}
 					</td>
-					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
+					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-[var(--color-text)]">
 						{formatNumber(piping.result?.velocity)}
 					</td>
-					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-gray-900">
+					<td class="whitespace-nowrap px-4 py-3 text-right text-sm text-[var(--color-text)]">
 						{formatNumber(piping.result?.head_loss)}
 					</td>
 				</tr>
 			{/each}
 			{#if pipingData.length === 0}
 				<tr>
-					<td colspan="4" class="px-4 py-8 text-center text-sm text-gray-500">
+					<td colspan="4" class="px-4 py-8 text-center text-sm text-[var(--color-text-muted)]">
 						No piping results available
 					</td>
 				</tr>

--- a/apps/web/src/lib/components/results/ResultsPanel.svelte
+++ b/apps/web/src/lib/components/results/ResultsPanel.svelte
@@ -65,13 +65,13 @@
 	{#if isLoading}
 		<!-- Loading State -->
 		<div class="flex flex-1 flex-col items-center justify-center p-8">
-			<div class="h-12 w-12 animate-spin rounded-full border-4 border-blue-500 border-t-transparent"></div>
-			<p class="mt-4 text-sm text-gray-600">Solving network...</p>
+			<div class="h-12 w-12 animate-spin rounded-full border-4 border-[var(--color-accent)] border-t-transparent"></div>
+			<p class="mt-4 text-sm text-[var(--color-text-muted)]">Solving network...</p>
 		</div>
 	{:else if !$solvedState}
 		<!-- No Results State -->
 		<div class="flex flex-1 flex-col items-center justify-center p-8 text-center">
-			<svg class="h-16 w-16 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+			<svg class="h-16 w-16 text-[var(--color-text-subtle)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 				<path
 					stroke-linecap="round"
 					stroke-linejoin="round"
@@ -79,14 +79,14 @@
 					d="M9 19v-6a2 2 0 00-2-2H5a2 2 0 00-2 2v6a2 2 0 002 2h2a2 2 0 002-2zm0 0V9a2 2 0 012-2h2a2 2 0 012 2v10m-6 0a2 2 0 002 2h2a2 2 0 002-2m0 0V5a2 2 0 012-2h2a2 2 0 012 2v14a2 2 0 01-2 2h-2a2 2 0 01-2-2z"
 				/>
 			</svg>
-			<h3 class="mt-4 text-lg font-medium text-gray-900">No results yet</h3>
-			<p class="mt-2 text-sm text-gray-500">
+			<h3 class="mt-4 text-lg font-medium text-[var(--color-text)]">No results yet</h3>
+			<p class="mt-2 text-sm text-[var(--color-text-muted)]">
 				Click "Solve" to calculate pressures and flows in your network.
 			</p>
 		</div>
 	{:else}
 		<!-- Tab Navigation -->
-		<div class="border-b border-gray-200 bg-gray-50">
+		<div class="border-b border-[var(--color-border)] bg-[var(--color-surface-elevated)]">
 			<nav class="flex -mb-px" aria-label="Tabs">
 				{#each tabs as tab}
 					<button
@@ -94,8 +94,8 @@
 						onclick={() => (activeTab = tab.id)}
 						class="flex-1 border-b-2 py-3 text-center text-sm font-medium transition-colors
 							{activeTab === tab.id
-							? 'border-blue-500 text-blue-600'
-							: 'border-transparent text-gray-500 hover:border-gray-300 hover:text-gray-700'}"
+							? 'border-[var(--color-accent)] text-[var(--color-accent)]'
+							: 'border-transparent text-[var(--color-text-muted)] hover:border-[var(--color-border)] hover:text-[var(--color-text)]'}"
 					>
 						{tab.label}
 					</button>
@@ -109,26 +109,26 @@
 				<!-- Convergence Status -->
 				<div
 					class="rounded-lg border p-4
-						{$solvedState.converged ? 'border-green-200 bg-green-50' : 'border-red-200 bg-red-50'}"
+						{$solvedState.converged ? 'border-[var(--color-success)]/30 bg-[var(--color-success)]/10' : 'border-[var(--color-error)]/30 bg-[var(--color-error)]/10'}"
 				>
 					<div class="flex items-center gap-3">
 						{#if $solvedState.converged}
-							<svg class="h-6 w-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<svg class="h-6 w-6 text-[var(--color-success)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
 							</svg>
 							<div>
-								<p class="font-medium text-green-800">Solution Converged</p>
-								<p class="text-sm text-green-600">
+								<p class="font-medium text-[var(--color-success)]">Solution Converged</p>
+								<p class="text-sm text-[var(--color-success)]/80">
 									{$solvedState.iterations} iterations in {formatDuration($solvedState.solve_time_seconds)}
 								</p>
 							</div>
 						{:else}
-							<svg class="h-6 w-6 text-red-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<svg class="h-6 w-6 text-[var(--color-error)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 								<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" />
 							</svg>
 							<div>
-								<p class="font-medium text-red-800">Solution Failed</p>
-								<p class="text-sm text-red-600">
+								<p class="font-medium text-[var(--color-error)]">Solution Failed</p>
+								<p class="text-sm text-[var(--color-error)]/80">
 									{$solvedState.error || 'Unknown error'}
 								</p>
 							</div>
@@ -139,40 +139,40 @@
 				<!-- Warnings -->
 				{#if $solvedState.warnings.length > 0}
 					<div class="mt-4 space-y-3">
-						<h4 class="text-sm font-medium text-gray-900">Warnings & Messages</h4>
+						<h4 class="text-sm font-medium text-[var(--color-text)]">Warnings & Messages</h4>
 
 						{#each errorWarnings as warning}
-							<div class="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 p-3">
-								<svg class="h-5 w-5 flex-shrink-0 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<div class="flex items-start gap-3 rounded-lg border border-[var(--color-error)]/30 bg-[var(--color-error)]/10 p-3">
+								<svg class="h-5 w-5 flex-shrink-0 text-[var(--color-error)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={getWarningIcon('error')} />
 								</svg>
 								<div>
-									<p class="text-sm font-medium text-red-800">{warning.message}</p>
-									<p class="text-xs text-red-600">{WARNING_CATEGORY_LABELS[warning.category]}</p>
+									<p class="text-sm font-medium text-[var(--color-error)]">{warning.message}</p>
+									<p class="text-xs text-[var(--color-error)]/80">{WARNING_CATEGORY_LABELS[warning.category]}</p>
 								</div>
 							</div>
 						{/each}
 
 						{#each warningWarnings as warning}
-							<div class="flex items-start gap-3 rounded-lg border border-yellow-200 bg-yellow-50 p-3">
-								<svg class="h-5 w-5 flex-shrink-0 text-yellow-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<div class="flex items-start gap-3 rounded-lg border border-[var(--color-warning)]/30 bg-[var(--color-warning)]/10 p-3">
+								<svg class="h-5 w-5 flex-shrink-0 text-[var(--color-warning)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={getWarningIcon('warning')} />
 								</svg>
 								<div>
-									<p class="text-sm font-medium text-yellow-800">{warning.message}</p>
-									<p class="text-xs text-yellow-600">{WARNING_CATEGORY_LABELS[warning.category]}</p>
+									<p class="text-sm font-medium text-[var(--color-warning)]">{warning.message}</p>
+									<p class="text-xs text-[var(--color-warning)]/80">{WARNING_CATEGORY_LABELS[warning.category]}</p>
 								</div>
 							</div>
 						{/each}
 
 						{#each infoWarnings as warning}
-							<div class="flex items-start gap-3 rounded-lg border border-blue-200 bg-blue-50 p-3">
-								<svg class="h-5 w-5 flex-shrink-0 text-blue-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<div class="flex items-start gap-3 rounded-lg border border-[var(--color-accent)]/30 bg-[var(--color-accent)]/10 p-3">
+								<svg class="h-5 w-5 flex-shrink-0 text-[var(--color-accent)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 									<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d={getWarningIcon('info')} />
 								</svg>
 								<div>
-									<p class="text-sm font-medium text-blue-800">{warning.message}</p>
-									<p class="text-xs text-blue-600">{WARNING_CATEGORY_LABELS[warning.category]}</p>
+									<p class="text-sm font-medium text-[var(--color-accent)]">{warning.message}</p>
+									<p class="text-xs text-[var(--color-accent)]/80">{WARNING_CATEGORY_LABELS[warning.category]}</p>
 								</div>
 							</div>
 						{/each}
@@ -182,27 +182,27 @@
 				<!-- Quick Stats -->
 				{#if $solvedState.converged}
 					<div class="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-4">
-						<div class="rounded-lg bg-gray-50 p-3">
-							<p class="text-xs font-medium uppercase tracking-wide text-gray-500">Components</p>
-							<p class="mt-1 text-2xl font-semibold text-gray-900">
+						<div class="rounded-lg bg-[var(--color-surface-elevated)] p-3">
+							<p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">Components</p>
+							<p class="mt-1 text-2xl font-semibold text-[var(--color-text)]">
 								{Object.keys($solvedState.component_results).length}
 							</p>
 						</div>
-						<div class="rounded-lg bg-gray-50 p-3">
-							<p class="text-xs font-medium uppercase tracking-wide text-gray-500">Piping</p>
-							<p class="mt-1 text-2xl font-semibold text-gray-900">
+						<div class="rounded-lg bg-[var(--color-surface-elevated)] p-3">
+							<p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">Piping</p>
+							<p class="mt-1 text-2xl font-semibold text-[var(--color-text)]">
 								{Object.keys($solvedState.piping_results).length}
 							</p>
 						</div>
-						<div class="rounded-lg bg-gray-50 p-3">
-							<p class="text-xs font-medium uppercase tracking-wide text-gray-500">Pumps</p>
-							<p class="mt-1 text-2xl font-semibold text-gray-900">
+						<div class="rounded-lg bg-[var(--color-surface-elevated)] p-3">
+							<p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">Pumps</p>
+							<p class="mt-1 text-2xl font-semibold text-[var(--color-text)]">
 								{Object.keys($solvedState.pump_results).length}
 							</p>
 						</div>
-						<div class="rounded-lg bg-gray-50 p-3">
-							<p class="text-xs font-medium uppercase tracking-wide text-gray-500">Warnings</p>
-							<p class="mt-1 text-2xl font-semibold text-gray-900">
+						<div class="rounded-lg bg-[var(--color-surface-elevated)] p-3">
+							<p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">Warnings</p>
+							<p class="mt-1 text-2xl font-semibold text-[var(--color-text)]">
 								{$solvedState.warnings.length}
 							</p>
 						</div>
@@ -215,7 +215,7 @@
 			{:else if activeTab === 'pumps'}
 				{#if pumpData.length === 0}
 					<div class="flex flex-col items-center justify-center py-12 text-center">
-						<svg class="h-12 w-12 text-gray-300" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<svg class="h-12 w-12 text-[var(--color-text-subtle)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 							<path
 								stroke-linecap="round"
 								stroke-linejoin="round"
@@ -223,20 +223,20 @@
 								d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
 							/>
 						</svg>
-						<p class="mt-4 text-sm text-gray-500">No pumps in this network</p>
+						<p class="mt-4 text-sm text-[var(--color-text-muted)]">No pumps in this network</p>
 					</div>
 				{:else}
 					<div class="space-y-6">
 						{#each pumpData as { pump, curve, result }}
-							<div class="rounded-lg border border-gray-200 p-4">
-								<h4 class="text-sm font-medium text-gray-900">{pump.name}</h4>
+							<div class="rounded-lg border border-[var(--color-border)] p-4">
+								<h4 class="text-sm font-medium text-[var(--color-text)]">{pump.name}</h4>
 								{#if curve}
-									<p class="text-xs text-gray-500">{curve.name}</p>
+									<p class="text-xs text-[var(--color-text-muted)]">{curve.name}</p>
 									<div class="mt-4">
 										<PumpCurveChart {curve} {result} />
 									</div>
 								{:else}
-									<p class="mt-2 text-sm text-yellow-600">No pump curve assigned</p>
+									<p class="mt-2 text-sm text-[var(--color-warning)]">No pump curve assigned</p>
 								{/if}
 							</div>
 						{/each}

--- a/apps/web/src/routes/p/[...encoded]/+page.svelte
+++ b/apps/web/src/routes/p/[...encoded]/+page.svelte
@@ -151,7 +151,7 @@
 	<title>{projectName} - OpenSolve Pipe</title>
 </svelte:head>
 
-<div class="flex min-h-screen flex-col bg-gray-50">
+<div class="flex min-h-screen flex-col bg-[var(--color-bg)]">
 	<Header
 		{projectName}
 		{viewMode}
@@ -165,18 +165,18 @@
 	<!-- Toast Messages -->
 	{#if solveError}
 		<div class="fixed right-4 top-20 z-50 max-w-md transition-all duration-150 ease-out" role="alert" aria-live="assertive">
-			<div class="flex items-start gap-3 rounded-lg border border-red-200 bg-red-50 p-4 shadow-lg">
-				<svg class="h-5 w-5 flex-shrink-0 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+			<div class="flex items-start gap-3 rounded-lg border border-[var(--color-error)]/30 bg-[var(--color-error)]/10 p-4 shadow-lg">
+				<svg class="h-5 w-5 flex-shrink-0 text-[var(--color-error)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 8v4m0 4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
 				</svg>
 				<div class="flex-1">
-					<p class="text-sm font-medium text-red-800">Solve Failed</p>
-					<p class="mt-1 text-sm text-red-600">{solveError}</p>
+					<p class="text-sm font-medium text-[var(--color-error)]">Solve Failed</p>
+					<p class="mt-1 text-sm text-[var(--color-error)]/80">{solveError}</p>
 				</div>
 				<button
 					type="button"
 					onclick={() => (solveError = null)}
-					class="text-red-400 hover:text-red-600"
+					class="text-[var(--color-error)]/60 hover:text-[var(--color-error)]"
 					aria-label="Dismiss error"
 				>
 					<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -189,20 +189,20 @@
 
 	{#if solveSuccess}
 		<div class="fixed right-4 top-20 z-50 max-w-md transition-all duration-150 ease-out" role="status" aria-live="polite">
-			<div class="flex items-start gap-3 rounded-lg border border-green-200 bg-green-50 p-4 shadow-lg">
-				<svg class="h-5 w-5 flex-shrink-0 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+			<div class="flex items-start gap-3 rounded-lg border border-[var(--color-success)]/30 bg-[var(--color-success)]/10 p-4 shadow-lg">
+				<svg class="h-5 w-5 flex-shrink-0 text-[var(--color-success)]" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
 				</svg>
 				<div class="flex-1">
-					<p class="text-sm font-medium text-green-800">Solution Converged</p>
-					<p class="mt-1 text-sm text-green-600">
+					<p class="text-sm font-medium text-[var(--color-success)]">Solution Converged</p>
+					<p class="mt-1 text-sm text-[var(--color-success)]/80">
 						{solveSuccess.iterations} iterations in {solveSuccess.time < 1 ? `${(solveSuccess.time * 1000).toFixed(0)} ms` : `${solveSuccess.time.toFixed(2)} s`}
 					</p>
 				</div>
 				<button
 					type="button"
 					onclick={() => (solveSuccess = null)}
-					class="text-green-400 hover:text-green-600"
+					class="text-[var(--color-success)]/60 hover:text-[var(--color-success)]"
 					aria-label="Dismiss message"
 				>
 					<svg class="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -225,19 +225,19 @@
 							bind:value={editedName}
 							onkeydown={handleNameKeydown}
 							onblur={saveProjectName}
-							class="w-full rounded-md border border-blue-300 px-2 py-1 text-xl font-semibold text-gray-900 focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+							class="w-full rounded-md border border-[var(--color-accent)] bg-[var(--color-surface)] px-2 py-1 text-xl font-semibold text-[var(--color-text)] focus:border-[var(--color-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
 							autofocus
 						/>
 					{:else}
 						<button
 							type="button"
 							onclick={startEditingName}
-							class="group flex items-center gap-2 rounded-md px-2 py-1 text-left hover:bg-gray-100"
+							class="group flex items-center gap-2 rounded-md px-2 py-1 text-left hover:bg-[var(--color-surface-elevated)]"
 							title="Click to edit project name"
 						>
-							<h1 class="text-xl font-semibold text-gray-900">{projectName}</h1>
+							<h1 class="text-xl font-semibold text-[var(--color-text)]">{projectName}</h1>
 							<svg
-								class="h-4 w-4 text-gray-400 opacity-0 transition-opacity group-hover:opacity-100"
+								class="h-4 w-4 text-[var(--color-text-subtle)] opacity-0 transition-opacity group-hover:opacity-100"
 								fill="none"
 								stroke="currentColor"
 								viewBox="0 0 24 24"
@@ -259,7 +259,7 @@
 		{:else}
 			<!-- Results View -->
 			<div class="mx-auto max-w-4xl p-4">
-				<div class="rounded-lg bg-white shadow">
+				<div class="rounded-lg bg-[var(--color-surface)] shadow">
 					<ResultsPanel isLoading={isSolving} />
 				</div>
 			</div>
@@ -267,7 +267,7 @@
 	</main>
 
 	<!-- Mobile-friendly bottom navigation hint -->
-	<div class="border-t border-gray-200 bg-white p-4 text-center text-sm text-gray-500 md:hidden">
+	<div class="border-t border-[var(--color-border)] bg-[var(--color-surface)] p-4 text-center text-sm text-[var(--color-text-muted)] md:hidden">
 		{#if viewMode === 'panel'}
 			Use arrow keys or navigation buttons to move between components
 		{:else}


### PR DESCRIPTION
## Summary

Fixes the dark theme bug where backgrounds remained white on the project page and form components. All components now use CSS custom properties that respond to theme changes.

**Files updated (17 files):**
- Project page (`+page.svelte`): Main container, toasts, project name editor
- Panel components: `ElementPanel`, `ElementTypeSelector`, `DownstreamPipingPanel`, `PipingPanel`
- Form components: `PipeForm`, `ValveForm`, `FittingsTable`, `PumpForm`, `ReferenceNodeForm`, `PlugForm`, `TeeBranchForm`, `WyeBranchForm`, `CrossBranchForm`
- Results components: `ResultsPanel`, `ComponentTable`, `PipingTable`

## Changes

- Replaced all `bg-gray-*`, `border-gray-*`, `text-gray-*` with `bg-[var(--color-surface)]`, `border-[var(--color-border)]`, `text-[var(--color-text)]` etc.
- Replaced all `bg-blue-*`, `text-blue-*` accent colors with `bg-[var(--color-accent)]`, `text-[var(--color-accent)]`
- Replaced `bg-red-*`, `text-red-*` error colors with `var(--color-error)`
- Replaced `bg-green-*`, `text-green-*` success colors with `var(--color-success)`
- Replaced `bg-yellow-*`, `bg-amber-*` warning colors with `var(--color-warning)`

## Test plan

- [x] `pnpm check` passes (0 errors, 0 warnings)
- [x] `pnpm lint` passes
- [ ] Manual testing: Navigate to project page in dark mode, verify dark background
- [ ] Manual testing: Add components, verify all form fields have dark theme
- [ ] Manual testing: Check results panel in dark mode

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)