### PR TITLE
fix(ui): fix theme initialization and pump chart dark mode

### DIFF
--- a/apps/web/src/app.html
+++ b/apps/web/src/app.html
@@ -5,6 +5,19 @@
     <link rel="icon" href="%sveltekit.assets%/favicon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>OpenSolve Pipe</title>
+    <!-- Set theme before page renders to prevent flash of wrong theme -->
+    <script>
+      (function() {
+        const STORAGE_KEY = 'opensolve-pipe-theme';
+        const stored = localStorage.getItem(STORAGE_KEY);
+        let theme = stored;
+        if (theme !== 'light' && theme !== 'dark') {
+          // Default to light, but respect system dark preference
+          theme = window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+        }
+        document.documentElement.setAttribute('data-theme', theme);
+      })();
+    </script>
     %sveltekit.head%
   </head>
   <body data-sveltekit-preload-data="hover">

--- a/apps/web/src/lib/stores/theme.ts
+++ b/apps/web/src/lib/stores/theme.ts
@@ -15,7 +15,7 @@ const STORAGE_KEY = 'opensolve-pipe-theme';
  * Get the initial theme from localStorage or system preference.
  */
 function getInitialTheme(): Theme {
-	if (!browser) return 'dark';
+	if (!browser) return 'light';
 
 	// Check localStorage first
 	const stored = localStorage.getItem(STORAGE_KEY);
@@ -23,12 +23,12 @@ function getInitialTheme(): Theme {
 		return stored;
 	}
 
-	// Fall back to system preference
-	if (window.matchMedia('(prefers-color-scheme: light)').matches) {
-		return 'light';
+	// Default to light, but respect system dark preference
+	if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+		return 'dark';
 	}
 
-	return 'dark';
+	return 'light';
 }
 
 /**


### PR DESCRIPTION
## Summary
- Fix theme not being applied on initial page load by adding inline script to set `data-theme` before Svelte hydrates
- Add full dark theme support to PumpCurveChart component (chart colors, stat cards, BEP info box)
- Change default theme from dark to light (still respects system dark mode preference)

## Test plan
- [ ] Verify homepage loads with correct theme on first visit (no flash of wrong colors)
- [ ] Verify theme toggle works correctly
- [ ] Verify pump results chart displays properly in both light and dark modes
- [ ] Verify stat cards and BEP info box are readable in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)