### PR TITLE
chore(devcontainer): add VS Code tasks for dev servers

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,69 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Frontend: Dev Server",
+      "type": "shell",
+      "command": "pnpm dev",
+      "options": {
+        "cwd": "${workspaceFolder}/apps/web"
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "pattern": {
+          "regexp": "^$"
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".",
+          "endsPattern": "Local:.*http"
+        }
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev-servers"
+      },
+      "runOptions": {
+        "runOn": "folderOpen"
+      }
+    },
+    {
+      "label": "Backend: Dev Server",
+      "type": "shell",
+      "command": "uvicorn opensolve_pipe.main:app --reload --host 0.0.0.0 --port 8000",
+      "options": {
+        "cwd": "${workspaceFolder}/apps/api"
+      },
+      "isBackground": true,
+      "problemMatcher": {
+        "pattern": {
+          "regexp": "^$"
+        },
+        "background": {
+          "activeOnStart": true,
+          "beginsPattern": ".",
+          "endsPattern": "Uvicorn running on"
+        }
+      },
+      "presentation": {
+        "reveal": "always",
+        "panel": "dedicated",
+        "group": "dev-servers"
+      },
+      "runOptions": {
+        "runOn": "folderOpen"
+      }
+    },
+    {
+      "label": "Start All Dev Servers",
+      "dependsOn": ["Frontend: Dev Server", "Backend: Dev Server"],
+      "dependsOrder": "parallel",
+      "problemMatcher": [],
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add `.vscode/tasks.json` with auto-start dev servers on folder open
- Frontend task: `pnpm dev` (SvelteKit on port 5173)
- Backend task: `uvicorn` (FastAPI on port 8000)
- Compound task to start both in parallel

## Usage
Tasks run automatically when VS Code opens the folder. First time, VS Code will ask permission to allow "Run on Folder Open" tasks.

You can also manually run via:
- `Ctrl+Shift+P` → "Tasks: Run Task" → select task
- `Ctrl+Shift+B` to run the default "Start All Dev Servers" task

🤖 Generated with [Claude Code](https://claude.com/claude-code)