### PR TITLE
feat(models): add ValveStatus enum for valve operational states

### DIFF
--- a/apps/api/src/opensolve_pipe/models/__init__.py
+++ b/apps/api/src/opensolve_pipe/models/__init__.py
@@ -46,6 +46,7 @@ from .components import (
     Strainer,
     Tank,
     ValveComponent,
+    ValveStatus,
     ValveType,
 )
 from .connections import (
@@ -169,6 +170,7 @@ __all__ = [
     "UnitPreferences",
     "UnitSystem",
     "ValveComponent",
+    "ValveStatus",
     "ValveType",
     "Velocity",
     "Warning",

--- a/apps/api/src/opensolve_pipe/models/components.py
+++ b/apps/api/src/opensolve_pipe/models/components.py
@@ -90,6 +90,20 @@ class PumpStatus(str, Enum):
     LOCKED_OUT = "locked_out"  # Treated as closed valve (LOTO)
 
 
+class ValveStatus(str, Enum):
+    """Status options for valves.
+
+    Defines the current operational state of the valve.
+    See PRD Section 3.1.2.2 for details.
+    """
+
+    ACTIVE = "active"  # Normal operation per position/setpoint
+    ISOLATED = "isolated"  # Zero flow through valve (closed for isolation)
+    FAILED_OPEN = "failed_open"  # Full open position, no control action
+    FAILED_CLOSED = "failed_closed"  # Zero flow, treated as closed
+    LOCKED_OPEN = "locked_open"  # Fixed at current position, no control action
+
+
 class Connection(OpenSolvePipeBaseModel):
     """Connection to a downstream component."""
 
@@ -341,6 +355,10 @@ class ValveComponent(BaseComponent):
 
     type: Literal[ComponentType.VALVE] = ComponentType.VALVE
     valve_type: ValveType = Field(description="Type of valve")
+    status: ValveStatus = Field(
+        default=ValveStatus.ACTIVE,
+        description="Valve operational status (see PRD Section 3.1.2.2)",
+    )
     setpoint: float | None = Field(
         default=None,
         description="Setpoint for control valves (pressure or flow depending on type)",

--- a/apps/api/tests/test_models/test_components.py
+++ b/apps/api/tests/test_models/test_components.py
@@ -17,6 +17,7 @@ from opensolve_pipe.models import (
     Strainer,
     Tank,
     ValveComponent,
+    ValveStatus,
     ValveType,
 )
 
@@ -353,6 +354,75 @@ class TestValveComponent:
                 valve_type=ValveType.GATE,
                 position=1.5,  # Invalid: > 1
             )
+
+    def test_valve_default_status_active(self):
+        """Test that valve defaults to ACTIVE status."""
+        valve = ValveComponent(
+            id="V1",
+            name="Gate Valve",
+            elevation=30.0,
+            valve_type=ValveType.GATE,
+        )
+        assert valve.status == ValveStatus.ACTIVE
+
+    def test_valve_isolated_status(self):
+        """Test valve with ISOLATED status (zero flow, closed for isolation)."""
+        valve = ValveComponent(
+            id="V1",
+            name="Isolation Valve",
+            elevation=30.0,
+            valve_type=ValveType.GATE,
+            status=ValveStatus.ISOLATED,
+        )
+        assert valve.status == ValveStatus.ISOLATED
+
+    def test_valve_failed_open_status(self):
+        """Test valve with FAILED_OPEN status (full open, no control action)."""
+        valve = ValveComponent(
+            id="V1",
+            name="Failed PRV",
+            elevation=30.0,
+            valve_type=ValveType.PRV,
+            status=ValveStatus.FAILED_OPEN,
+            setpoint=50.0,  # Setpoint ignored when failed open
+        )
+        assert valve.status == ValveStatus.FAILED_OPEN
+
+    def test_valve_failed_closed_status(self):
+        """Test valve with FAILED_CLOSED status (zero flow)."""
+        valve = ValveComponent(
+            id="V1",
+            name="Failed Check Valve",
+            elevation=30.0,
+            valve_type=ValveType.CHECK,
+            status=ValveStatus.FAILED_CLOSED,
+        )
+        assert valve.status == ValveStatus.FAILED_CLOSED
+
+    def test_valve_locked_open_status(self):
+        """Test valve with LOCKED_OPEN status (fixed position, no control)."""
+        valve = ValveComponent(
+            id="V1",
+            name="Locked Valve",
+            elevation=30.0,
+            valve_type=ValveType.BUTTERFLY,
+            status=ValveStatus.LOCKED_OPEN,
+            position=0.75,  # Position at which valve is locked
+        )
+        assert valve.status == ValveStatus.LOCKED_OPEN
+        assert valve.position == 0.75
+
+    def test_valve_all_status_values(self):
+        """Test that all ValveStatus enum values are valid."""
+        for status in ValveStatus:
+            valve = ValveComponent(
+                id="V1",
+                name=f"Valve with {status.value}",
+                elevation=30.0,
+                valve_type=ValveType.GATE,
+                status=status,
+            )
+            assert valve.status == status
 
 
 class TestOtherComponents:


### PR DESCRIPTION
## Summary
- Add `ValveStatus` enum with 5 operational states: ACTIVE, ISOLATED, FAILED_OPEN, FAILED_CLOSED, LOCKED_OPEN
- Add `status` field to `ValveComponent` model with ACTIVE as default
- Export `ValveStatus` from models package
- Add comprehensive tests for all valve status values

## Changes
- `src/opensolve_pipe/models/components.py`: Add ValveStatus enum and status field to ValveComponent
- `src/opensolve_pipe/models/__init__.py`: Export ValveStatus
- `tests/test_models/test_components.py`: Add tests for ValveStatus

## Test plan
- [x] All 635 existing tests pass
- [x] New tests for each ValveStatus value
- [x] Ruff linting passes
- [x] MyPy type checking passes

Closes #104

🤖 Generated with [Claude Code](https://claude.com/claude-code)