### PR TITLE
feat(api): implement HeadSource Protocol for source components

### DIFF
--- a/apps/api/src/opensolve_pipe/models/reference_node.py
+++ b/apps/api/src/opensolve_pipe/models/reference_node.py
@@ -110,6 +110,16 @@ class IdealReferenceNode(BaseReferenceNode):
             self.ports = create_reference_node_port()
         return self
 
+    @property
+    def total_head(self) -> float:
+        """Total head in feet, converting pressure from psi.
+
+        Converts pressure (psi) to feet of water head using the standard
+        conversion factor of 0.433 psi/ft.
+        """
+        # pressure / 0.433 converts psi to feet of water
+        return self.elevation + self.pressure / 0.433
+
 
 class NonIdealReferenceNode(BaseReferenceNode):
     """Non-ideal reference node with pressure that varies with flow.
@@ -163,6 +173,19 @@ class NonIdealReferenceNode(BaseReferenceNode):
         if not self.ports:
             self.ports = create_reference_node_port()
         return self
+
+    @property
+    def total_head(self) -> float:
+        """Total head in feet at zero flow condition.
+
+        Uses the pressure-flow curve to find the pressure at the point
+        closest to zero flow, then converts to feet of water head.
+        """
+        if self.pressure_flow_curve:
+            # Find point closest to zero flow
+            min_flow_point = min(self.pressure_flow_curve, key=lambda p: abs(p.flow))
+            return self.elevation + min_flow_point.pressure / 0.433
+        return self.elevation
 
     def interpolate_pressure(self, flow: float) -> float:
         """Interpolate pressure from curve at given flow.

--- a/apps/api/src/opensolve_pipe/protocols/components.py
+++ b/apps/api/src/opensolve_pipe/protocols/components.py
@@ -4,13 +4,11 @@ Defines structural contracts for component behaviors:
 - HasPorts: Components with connection ports
 - HeadSource: Components that provide hydraulic head (reservoirs, tanks)
 - HeadLossCalculator: Components that calculate head loss
-
-Protocol method signatures will be added in Phase 2.
 """
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Protocol, runtime_checkable
 
 
 class HasPorts(Protocol):
@@ -22,15 +20,30 @@ class HasPorts(Protocol):
     ...
 
 
+@runtime_checkable
 class HeadSource(Protocol):
-    """Protocol for components that provide hydraulic head.
+    """Components that provide a fixed head boundary condition.
 
-    Examples: Reservoir, Tank, IdealReferenceNode
+    Implementors:
+    - Reservoir: elevation + water_level
+    - Tank: elevation + initial_level
+    - IdealReferenceNode: elevation + pressure/0.433
+    - NonIdealReferenceNode: elevation + interpolated pressure at zero flow
 
-    Method signatures will be defined in Phase 2.
+    The solver uses HeadSource components to establish starting pressures
+    for network traversal. All head values are in feet of fluid.
     """
 
-    ...
+    elevation: float
+
+    @property
+    def total_head(self) -> float:
+        """Total hydraulic head at this source in feet.
+
+        For open sources (reservoir, tank): elevation + liquid_level
+        For pressure sources: elevation + pressure_head
+        """
+        ...
 
 
 class HeadLossCalculator(Protocol):

--- a/apps/api/tests/test_protocols/test_head_source.py
+++ b/apps/api/tests/test_protocols/test_head_source.py
@@ -1,0 +1,251 @@
+"""Tests for HeadSource Protocol and implementations."""
+
+import pytest
+
+from opensolve_pipe.models.components import Reservoir, Tank
+from opensolve_pipe.models.reference_node import (
+    FlowPressurePoint,
+    IdealReferenceNode,
+    NonIdealReferenceNode,
+)
+from opensolve_pipe.protocols import HeadSource
+
+
+class TestHeadSourceProtocol:
+    """Verify HeadSource Protocol definition."""
+
+    def test_protocol_is_runtime_checkable(self) -> None:
+        """Verify Protocol is runtime_checkable for isinstance checks."""
+        reservoir = Reservoir(
+            id="res-1",
+            name="Test Reservoir",
+            elevation=100.0,
+            water_level=10.0,
+        )
+        # runtime_checkable allows isinstance checks
+        assert isinstance(reservoir, HeadSource)
+
+
+class TestReservoirHeadSource:
+    """Tests for Reservoir satisfying HeadSource protocol."""
+
+    def test_reservoir_satisfies_protocol(self) -> None:
+        """Reservoir has total_head property."""
+        reservoir = Reservoir(
+            id="res-1",
+            name="Test Reservoir",
+            elevation=100.0,
+            water_level=10.0,
+        )
+        assert isinstance(reservoir, HeadSource)
+        assert hasattr(reservoir, "total_head")
+        assert hasattr(reservoir, "elevation")
+
+    def test_reservoir_total_head_calculation(self) -> None:
+        """Reservoir total_head = elevation + water_level."""
+        reservoir = Reservoir(
+            id="res-1",
+            name="Test Reservoir",
+            elevation=100.0,
+            water_level=10.0,
+        )
+        assert reservoir.total_head == 110.0
+
+    def test_reservoir_total_head_zero_level(self) -> None:
+        """Reservoir with zero water level."""
+        reservoir = Reservoir(
+            id="res-1",
+            name="Test Reservoir",
+            elevation=50.0,
+            water_level=0.0,
+        )
+        assert reservoir.total_head == 50.0
+
+
+class TestTankHeadSource:
+    """Tests for Tank satisfying HeadSource protocol."""
+
+    def test_tank_satisfies_protocol(self) -> None:
+        """Tank has total_head property."""
+        tank = Tank(
+            id="tank-1",
+            name="Test Tank",
+            elevation=50.0,
+            diameter=10.0,
+            min_level=0.0,
+            max_level=20.0,
+            initial_level=15.0,
+        )
+        assert isinstance(tank, HeadSource)
+        assert hasattr(tank, "total_head")
+        assert hasattr(tank, "elevation")
+
+    def test_tank_total_head_calculation(self) -> None:
+        """Tank total_head = elevation + initial_level."""
+        tank = Tank(
+            id="tank-1",
+            name="Test Tank",
+            elevation=50.0,
+            diameter=10.0,
+            min_level=0.0,
+            max_level=20.0,
+            initial_level=15.0,
+        )
+        assert tank.total_head == 65.0
+
+
+class TestIdealReferenceNodeHeadSource:
+    """Tests for IdealReferenceNode satisfying HeadSource protocol."""
+
+    def test_ideal_reference_node_satisfies_protocol(self) -> None:
+        """IdealReferenceNode has total_head property."""
+        node = IdealReferenceNode(
+            id="ref-1",
+            name="Test Reference",
+            elevation=0.0,
+            pressure=43.3,  # psi
+        )
+        assert isinstance(node, HeadSource)
+        assert hasattr(node, "total_head")
+        assert hasattr(node, "elevation")
+
+    def test_ideal_reference_node_total_head_calculation(self) -> None:
+        """IdealReferenceNode total_head = elevation + pressure/0.433."""
+        node = IdealReferenceNode(
+            id="ref-1",
+            name="Test Reference",
+            elevation=0.0,
+            pressure=43.3,  # psi -> ~100 ft of water
+        )
+        # 43.3 / 0.433 ≈ 100 ft
+        assert node.total_head == pytest.approx(100.0, rel=0.01)
+
+    def test_ideal_reference_node_with_elevation(self) -> None:
+        """IdealReferenceNode with non-zero elevation."""
+        node = IdealReferenceNode(
+            id="ref-1",
+            name="Test Reference",
+            elevation=50.0,
+            pressure=21.65,  # psi -> ~50 ft of water
+        )
+        # 50 + (21.65 / 0.433) ≈ 100 ft
+        assert node.total_head == pytest.approx(100.0, rel=0.01)
+
+
+class TestNonIdealReferenceNodeHeadSource:
+    """Tests for NonIdealReferenceNode satisfying HeadSource protocol."""
+
+    def test_non_ideal_reference_node_satisfies_protocol(self) -> None:
+        """NonIdealReferenceNode has total_head property."""
+        node = NonIdealReferenceNode(
+            id="ref-1",
+            name="Test Reference",
+            elevation=0.0,
+            pressure_flow_curve=[
+                FlowPressurePoint(flow=0.0, pressure=50.0),
+                FlowPressurePoint(flow=100.0, pressure=40.0),
+            ],
+        )
+        assert isinstance(node, HeadSource)
+        assert hasattr(node, "total_head")
+        assert hasattr(node, "elevation")
+
+    def test_non_ideal_reference_node_total_head_at_zero_flow(self) -> None:
+        """NonIdealReferenceNode uses pressure at zero flow."""
+        node = NonIdealReferenceNode(
+            id="ref-1",
+            name="Test Reference",
+            elevation=0.0,
+            pressure_flow_curve=[
+                FlowPressurePoint(flow=0.0, pressure=43.3),  # psi
+                FlowPressurePoint(flow=100.0, pressure=30.0),
+            ],
+        )
+        # At zero flow, pressure is 43.3 psi -> ~100 ft of water
+        assert node.total_head == pytest.approx(100.0, rel=0.01)
+
+    def test_non_ideal_reference_node_with_elevation(self) -> None:
+        """NonIdealReferenceNode with non-zero elevation."""
+        node = NonIdealReferenceNode(
+            id="ref-1",
+            name="Test Reference",
+            elevation=25.0,
+            pressure_flow_curve=[
+                FlowPressurePoint(flow=0.0, pressure=32.475),  # psi -> ~75 ft
+                FlowPressurePoint(flow=100.0, pressure=20.0),
+            ],
+        )
+        # 25 + (32.475 / 0.433) ≈ 100 ft
+        assert node.total_head == pytest.approx(100.0, rel=0.01)
+
+    def test_non_ideal_reference_node_finds_closest_to_zero(self) -> None:
+        """NonIdealReferenceNode finds point closest to zero flow."""
+        node = NonIdealReferenceNode(
+            id="ref-1",
+            name="Test Reference",
+            elevation=0.0,
+            pressure_flow_curve=[
+                FlowPressurePoint(flow=5.0, pressure=43.3),  # Closest to zero
+                FlowPressurePoint(flow=100.0, pressure=30.0),
+            ],
+        )
+        # Uses pressure at flow=5 (closest to zero)
+        assert node.total_head == pytest.approx(100.0, rel=0.01)
+
+
+class TestGetSourceHeadWithProtocol:
+    """Tests for get_source_head using HeadSource protocol."""
+
+    def test_get_source_head_reservoir(self) -> None:
+        """get_source_head works with Reservoir."""
+        from opensolve_pipe.services.solver.network import get_source_head
+
+        reservoir = Reservoir(
+            id="res-1",
+            name="Test",
+            elevation=100.0,
+            water_level=10.0,
+        )
+        assert get_source_head(reservoir) == 110.0
+
+    def test_get_source_head_tank(self) -> None:
+        """get_source_head works with Tank."""
+        from opensolve_pipe.services.solver.network import get_source_head
+
+        tank = Tank(
+            id="tank-1",
+            name="Test",
+            elevation=50.0,
+            diameter=10.0,
+            min_level=0.0,
+            max_level=20.0,
+            initial_level=15.0,
+        )
+        assert get_source_head(tank) == 65.0
+
+    def test_get_source_head_ideal_reference_node(self) -> None:
+        """get_source_head works with IdealReferenceNode."""
+        from opensolve_pipe.services.solver.network import get_source_head
+
+        node = IdealReferenceNode(
+            id="ref-1",
+            name="Test",
+            elevation=0.0,
+            pressure=43.3,
+        )
+        assert get_source_head(node) == pytest.approx(100.0, rel=0.01)
+
+    def test_get_source_head_non_ideal_reference_node(self) -> None:
+        """get_source_head works with NonIdealReferenceNode."""
+        from opensolve_pipe.services.solver.network import get_source_head
+
+        node = NonIdealReferenceNode(
+            id="ref-1",
+            name="Test",
+            elevation=0.0,
+            pressure_flow_curve=[
+                FlowPressurePoint(flow=0.0, pressure=43.3),
+                FlowPressurePoint(flow=100.0, pressure=30.0),
+            ],
+        )
+        assert get_source_head(node) == pytest.approx(100.0, rel=0.01)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -67,14 +67,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Validation for controlled modes requiring setpoints
   - VFD (Variable Frequency Drive) support for pressure/flow control modes
 
-- **Protocol Interfaces Module** (PR #118, #119)
+- **Protocol Interfaces Module** (PR #118, #119, #121)
   - `protocols/` module for type-safe structural contracts
   - `NetworkSolver` protocol for solver strategies with method signatures
-  - `HasPorts`, `HeadSource`, `HeadLossCalculator` protocols for component interfaces
+  - `HeadSource` protocol for components with fixed head boundary conditions
+  - `HasPorts`, `HeadLossCalculator` protocols for component interfaces
   - `FluidPropertyProvider` protocol for fluid property services
   - `SimpleSolver` and `BranchingSolver` strategy classes implementing NetworkSolver
   - `SolverRegistry` for selecting appropriate solver by network topology
   - `solve_project()` refactored to use registry pattern
+  - `get_source_head()` simplified using HeadSource protocol
+  - `total_head` property added to IdealReferenceNode and NonIdealReferenceNode
   - ADR-008: Protocol-based interfaces decision
 
 - **Valve Status States** (PR #115)


### PR DESCRIPTION
## Summary

Implements Issue #121 - HeadSource Protocol for components providing fixed head boundary conditions.

### Changes

- **Protocol Definition** (`protocols/components.py`):
  - Added `@runtime_checkable` decorator to `HeadSource`
  - Added `elevation` attribute requirement
  - Added `total_head` property returning hydraulic head in feet

- **Component Updates**:
  - `IdealReferenceNode.total_head`: elevation + pressure/0.433 (psi → ft conversion)
  - `NonIdealReferenceNode.total_head`: elevation + pressure at zero flow from curve
  - `Reservoir.total_head` and `Tank.total_head` already existed

- **Solver Simplification** (`services/solver/network.py`):
  - `get_source_head()` now uses `isinstance(component, HeadSource)` check
  - Removed verbose type-checking chains with `isinstance` and `hasattr`
  - Falls back to `component.elevation` for non-HeadSource components

### Before vs After

**Before:**
```python
def get_source_head(component: Component) -> float:
    if isinstance(component, Reservoir):
        return component.elevation + component.water_level
    elif isinstance(component, Tank):
        return component.elevation + component.initial_level
    elif component.type == ComponentType.IDEAL_REFERENCE_NODE:
        return component.elevation + component.pressure / 0.433
    elif component.type == ComponentType.NON_IDEAL_REFERENCE_NODE:
        if hasattr(component, "pressure_flow_curve") and component.pressure_flow_curve:
            min_flow_point = min(component.pressure_flow_curve, key=lambda p: abs(p.flow))
            return component.elevation + min_flow_point.pressure / 0.433
        return component.elevation
    else:
        return component.elevation
```

**After:**
```python
def get_source_head(component: Component) -> float:
    if isinstance(component, HeadSource):
        return component.total_head
    return component.elevation
```

### Test Plan

- [x] All 693 tests pass (17 new HeadSource tests)
- [x] ruff check passes
- [x] mypy passes
- [x] Pre-commit hooks pass

Closes #121

---
🤖 Generated with [Claude Code](https://claude.ai/code)