### PR TITLE
feat(web): add valve status controls to ValveForm

### DIFF
--- a/apps/web/src/lib/components/forms/ValveForm.svelte
+++ b/apps/web/src/lib/components/forms/ValveForm.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
-	import type { ValveComponent } from '$lib/models';
-	import { VALVE_TYPE_LABELS } from '$lib/models';
+	import type { ValveComponent, ValveStatus } from '$lib/models';
+	import { VALVE_TYPE_LABELS, VALVE_STATUS_LABELS } from '$lib/models';
 	import NumberInput from './NumberInput.svelte';
 
 	interface Props {
@@ -11,6 +11,18 @@
 	}
 
 	let { component, onUpdate }: Props = $props();
+
+	// Determine if valve is in a non-active state
+	let isIsolated = $derived(
+		component.status === 'isolated' || component.status === 'failed_closed'
+	);
+	let isFailedOpen = $derived(component.status === 'failed_open');
+	let isLockedOpen = $derived(component.status === 'locked_open');
+	let isControlValve = $derived(
+		component.valve_type === 'prv' ||
+			component.valve_type === 'psv' ||
+			component.valve_type === 'fcv'
+	);
 </script>
 
 <div class="space-y-4">
@@ -23,7 +35,9 @@
 	/>
 
 	<div>
-		<label for="valve_type" class="block text-sm font-medium text-[var(--color-text)]">Valve Type</label>
+		<label for="valve_type" class="block text-sm font-medium text-[var(--color-text)]"
+			>Valve Type</label
+		>
 		<select
 			id="valve_type"
 			value={component.valve_type}
@@ -36,37 +50,162 @@
 		</select>
 	</div>
 
-	<NumberInput
-		id="position"
-		label="Position"
-		value={(component.position ?? 1) * 100}
-		unit="%"
-		min={0}
-		max={100}
-		step={1}
-		onchange={(value) => onUpdate('position', value / 100)}
-		hint="0% = fully closed, 100% = fully open"
-	/>
+	<!-- Status Selector -->
+	<div>
+		<label for="status" class="block text-sm font-medium text-[var(--color-text)]">Status</label>
+		<select
+			id="status"
+			value={component.status}
+			onchange={(e) => onUpdate('status', (e.target as HTMLSelectElement).value as ValveStatus)}
+			class="mt-1 block w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface)] px-3 py-2 text-sm text-[var(--color-text)] shadow-sm focus:border-[var(--color-accent)] focus:outline-none focus:ring-1 focus:ring-[var(--color-accent)]"
+		>
+			{#each Object.entries(VALVE_STATUS_LABELS) as [value, label]}
+				<option {value}>{label}</option>
+			{/each}
+		</select>
+	</div>
 
-	{#if component.valve_type === 'prv' || component.valve_type === 'psv'}
-		<NumberInput
-			id="setpoint"
-			label={component.valve_type === 'prv' ? 'Downstream Pressure Setting' : 'Relief Pressure Setting'}
-			value={component.setpoint}
-			unit="psi"
-			min={0}
-			required
-			onchange={(value) => onUpdate('setpoint', value)}
-		/>
-	{:else if component.valve_type === 'fcv'}
-		<NumberInput
-			id="setpoint"
-			label="Flow Setting"
-			value={component.setpoint}
-			unit="GPM"
-			min={0}
-			required
-			onchange={(value) => onUpdate('setpoint', value)}
-		/>
+	<!-- Status Warning Messages -->
+	{#if isIsolated}
+		<div
+			class="rounded-md border border-[var(--color-error)]/30 bg-[var(--color-error)]/10 p-3 text-sm text-[var(--color-error)]"
+		>
+			<span class="font-medium">⚠ No Flow:</span>
+			{#if component.status === 'failed_closed'}
+				Valve failed closed - no flow through this path
+			{:else}
+				Valve is isolated/closed - no flow through this path
+			{/if}
+		</div>
+	{:else if isFailedOpen}
+		<div
+			class="rounded-md border border-orange-500/30 bg-orange-500/10 p-3 text-sm text-orange-600 dark:text-orange-400"
+		>
+			<span class="font-medium">⚠ Failed Open:</span>
+			Valve failed open - position locked at 100%
+			{#if isControlValve}
+				<br /><span class="text-xs">Setpoint control is disabled</span>
+			{/if}
+		</div>
+	{:else if isLockedOpen}
+		<div
+			class="rounded-md border border-blue-500/30 bg-blue-500/10 p-3 text-sm text-blue-600 dark:text-blue-400"
+		>
+			<span class="font-medium">ℹ Locked Open:</span>
+			Valve is locked at current position
+			{#if isControlValve}
+				<br /><span class="text-xs">Setpoint control is disabled</span>
+			{/if}
+		</div>
+	{/if}
+
+	<!-- Position Control -->
+	{#if !isIsolated}
+		{#if isFailedOpen}
+			<!-- Failed open: show 100% position as read-only -->
+			<div>
+				<span class="block text-sm font-medium text-[var(--color-text)]">Position</span>
+				<div
+					class="mt-1 block w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface-elevated)] px-3 py-2 text-sm text-[var(--color-text-muted)]"
+				>
+					100% (locked open)
+				</div>
+			</div>
+		{:else if isLockedOpen}
+			<!-- Locked open: show current position as read-only -->
+			<div>
+				<span class="block text-sm font-medium text-[var(--color-text)]">Position</span>
+				<div
+					class="mt-1 block w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface-elevated)] px-3 py-2 text-sm text-[var(--color-text-muted)]"
+				>
+					{Math.round((component.position ?? 1) * 100)}% (locked)
+				</div>
+			</div>
+		{:else}
+			<!-- Active: normal position control -->
+			<NumberInput
+				id="position"
+				label="Position"
+				value={(component.position ?? 1) * 100}
+				unit="%"
+				min={0}
+				max={100}
+				step={1}
+				onchange={(value) => onUpdate('position', value / 100)}
+				hint="0% = fully closed, 100% = fully open"
+			/>
+		{/if}
+	{/if}
+
+	<!-- Control Valve Setpoint -->
+	{#if isControlValve && !isIsolated}
+		{#if isFailedOpen || isLockedOpen}
+			<!-- Setpoint shown but marked as ignored -->
+			<div class="opacity-60">
+				<span class="block text-sm font-medium text-[var(--color-text)]">
+					{#if component.valve_type === 'prv'}
+						Downstream Pressure Setting
+					{:else if component.valve_type === 'psv'}
+						Relief Pressure Setting
+					{:else}
+						Flow Setting
+					{/if}
+				</span>
+				<div
+					class="mt-1 block w-full rounded-md border border-[var(--color-border)] bg-[var(--color-surface-elevated)] px-3 py-2 text-sm text-[var(--color-text-muted)]"
+				>
+					{component.setpoint ?? 0}
+					{component.valve_type === 'fcv' ? 'GPM' : 'psi'}
+					<span class="ml-2 text-xs">(ignored)</span>
+				</div>
+			</div>
+		{:else}
+			<!-- Active: normal setpoint control -->
+			{#if component.valve_type === 'prv' || component.valve_type === 'psv'}
+				<NumberInput
+					id="setpoint"
+					label={component.valve_type === 'prv'
+						? 'Downstream Pressure Setting'
+						: 'Relief Pressure Setting'}
+					value={component.setpoint}
+					unit="psi"
+					min={0}
+					required
+					onchange={(value) => onUpdate('setpoint', value)}
+				/>
+			{:else if component.valve_type === 'fcv'}
+				<NumberInput
+					id="setpoint"
+					label="Flow Setting"
+					value={component.setpoint}
+					unit="GPM"
+					min={0}
+					required
+					onchange={(value) => onUpdate('setpoint', value)}
+				/>
+			{/if}
+		{/if}
+	{/if}
+
+	<!-- Optional Cv field -->
+	{#if !isIsolated}
+		<details class="rounded-md border border-[var(--color-border)]">
+			<summary
+				class="cursor-pointer px-3 py-2 text-sm font-medium text-[var(--color-text)] hover:bg-[var(--color-surface-elevated)]"
+			>
+				Advanced
+			</summary>
+			<div class="border-t border-[var(--color-border)] p-3">
+				<NumberInput
+					id="cv"
+					label="Cv Coefficient"
+					value={component.cv}
+					min={0}
+					step={1}
+					onchange={(value) => onUpdate('cv', value)}
+					hint="Flow coefficient (optional - for detailed hydraulic model)"
+				/>
+			</div>
+		</details>
 	{/if}
 </div>


### PR DESCRIPTION
## Summary

- Add valve status dropdown with all ValveStatus options (active, isolated, failed_open, failed_closed, locked_open)
- Implement conditional UI behavior based on valve status
- Display warning messages for no-flow states (isolated, failed_closed)
- Display warning messages for failed/locked states with setpoint implications
- Show read-only position display for failed_open (100%) and locked_open states
- Show read-only setpoint display when valve is in non-controllable state
- Add Advanced section with Cv coefficient (collapsible)
- Implement conditional rendering based on control valve type (PRV, PSV, FCV)

The form now properly reflects the hydraulic behavior differences between various valve operational states. This mirrors the patterns established in PumpForm.svelte (#111).

## Test plan

- [x] Svelte check passes (0 errors, 0 warnings)
- [x] ESLint passes
- [x] Prettier passes
- [ ] Manual testing: verify all status options display correctly
- [ ] Manual testing: verify conditional fields show/hide based on status
- [ ] Manual testing: verify warning messages appear for appropriate states

Closes #112

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)