### PR TITLE
feat(web): add schematic viewer component with zoom/pan support

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -24,6 +24,9 @@
     "@sveltejs/kit": "^2.15.0",
     "@sveltejs/vite-plugin-svelte": "^4.0.0",
     "@tailwindcss/vite": "^4.0.0",
+    "@types/d3-selection": "^3.0.11",
+    "@types/d3-transition": "^3.0.9",
+    "@types/d3-zoom": "^3.0.8",
     "@types/pako": "^2.0.3",
     "@vitest/coverage-v8": "^2.0.0",
     "eslint": "^9.17.0",
@@ -45,6 +48,9 @@
   },
   "dependencies": {
     "chart.js": "^4.4.0",
+    "d3-selection": "^3.0.0",
+    "d3-transition": "^3.0.1",
+    "d3-zoom": "^3.0.0",
     "pako": "^2.1.0"
   }
 }

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -11,6 +11,15 @@ importers:
       chart.js:
         specifier: ^4.4.0
         version: 4.5.1
+      d3-selection:
+        specifier: ^3.0.0
+        version: 3.0.0
+      d3-transition:
+        specifier: ^3.0.1
+        version: 3.0.1(d3-selection@3.0.0)
+      d3-zoom:
+        specifier: ^3.0.0
+        version: 3.0.0
       pako:
         specifier: ^2.1.0
         version: 2.1.0
@@ -33,6 +42,15 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.0.0
         version: 4.1.18(vite@6.4.1(jiti@2.6.1)(lightningcss@1.30.2))
+      '@types/d3-selection':
+        specifier: ^3.0.11
+        version: 3.0.11
+      '@types/d3-transition':
+        specifier: ^3.0.9
+        version: 3.0.9
+      '@types/d3-zoom':
+        specifier: ^3.0.8
+        version: 3.0.8
       '@types/pako':
         specifier: ^2.0.3
         version: 2.0.4
@@ -816,6 +834,21 @@ packages:
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -1044,6 +1077,44 @@ packages:
   cssstyle@5.3.7:
     resolution: {integrity: sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==}
     engines: {node: '>=20'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   data-urls@6.0.0:
     resolution: {integrity: sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==}
@@ -2569,6 +2640,23 @@ snapshots:
 
   '@types/cookie@0.6.0': {}
 
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2830,6 +2918,42 @@ snapshots:
       '@csstools/css-syntax-patches-for-csstree': 1.0.25
       css-tree: 3.1.0
       lru-cache: 11.2.4
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   data-urls@6.0.0:
     dependencies:

--- a/apps/web/src/lib/components/schematic/SchematicCanvas.svelte
+++ b/apps/web/src/lib/components/schematic/SchematicCanvas.svelte
@@ -1,0 +1,149 @@
+<script lang="ts">
+	import { onMount, onDestroy } from 'svelte';
+	import { select } from 'd3-selection';
+	import { zoom, zoomIdentity, type ZoomBehavior, type D3ZoomEvent } from 'd3-zoom';
+	import 'd3-transition'; // Augments Selection with .transition()
+
+	interface Props {
+		/** Minimum zoom scale. Default: 0.1 */
+		minZoom?: number;
+		/** Maximum zoom scale. Default: 4 */
+		maxZoom?: number;
+		/** Current zoom level (read-only, for display). */
+		zoomLevel?: number;
+		/** Callback when zoom level changes. */
+		onZoomChange?: (level: number) => void;
+		/** Children to render inside the zoomed/panned group. */
+		children?: import('svelte').Snippet;
+	}
+
+	let {
+		minZoom = 0.1,
+		maxZoom = 4,
+		zoomLevel = $bindable(1),
+		onZoomChange,
+		children
+	}: Props = $props();
+
+	let svgElement: SVGSVGElement | undefined = $state();
+	let contentGroup: SVGGElement | undefined = $state();
+	let zoomBehavior: ZoomBehavior<SVGSVGElement, unknown> | null = null;
+	let currentTransform = $state({ x: 0, y: 0, k: 1 });
+
+	// Initialize zoom behavior when SVG is mounted
+	onMount(() => {
+		if (!svgElement) return;
+
+		const svg = select(svgElement);
+
+		// Create zoom behavior
+		zoomBehavior = zoom<SVGSVGElement, unknown>()
+			.scaleExtent([minZoom, maxZoom])
+			.on('zoom', (event: D3ZoomEvent<SVGSVGElement, unknown>) => {
+				const { x, y, k } = event.transform;
+				currentTransform = { x, y, k };
+				zoomLevel = k;
+				onZoomChange?.(k);
+			});
+
+		// Apply zoom behavior to SVG
+		svg.call(zoomBehavior);
+
+		// Enable touch support for mobile pinch-to-zoom
+		svg.on('touchstart.zoom', null); // Let d3-zoom handle touch events
+	});
+
+	onDestroy(() => {
+		if (svgElement) {
+			select(svgElement).on('.zoom', null);
+		}
+	});
+
+	/**
+	 * Reset zoom to identity (1:1 scale, no pan).
+	 */
+	export function resetZoom(): void {
+		if (!svgElement || !zoomBehavior) return;
+		select(svgElement)
+			.transition()
+			.duration(300)
+			.call(zoomBehavior.transform, zoomIdentity);
+	}
+
+	/**
+	 * Zoom to fit content within the viewport.
+	 * @param contentBounds - The bounding box of the content to fit.
+	 * @param padding - Padding around the content (default: 40px).
+	 */
+	export function fitToView(
+		contentBounds: { x: number; y: number; width: number; height: number },
+		padding = 40
+	): void {
+		if (!svgElement || !zoomBehavior) return;
+
+		const svgRect = svgElement.getBoundingClientRect();
+		const viewWidth = svgRect.width - padding * 2;
+		const viewHeight = svgRect.height - padding * 2;
+
+		if (viewWidth <= 0 || viewHeight <= 0) return;
+		if (contentBounds.width <= 0 || contentBounds.height <= 0) return;
+
+		// Calculate scale to fit content
+		const scale = Math.min(
+			viewWidth / contentBounds.width,
+			viewHeight / contentBounds.height,
+			maxZoom
+		);
+
+		// Calculate center offset
+		const centerX = (svgRect.width - contentBounds.width * scale) / 2 - contentBounds.x * scale;
+		const centerY = (svgRect.height - contentBounds.height * scale) / 2 - contentBounds.y * scale;
+
+		const transform = zoomIdentity.translate(centerX, centerY).scale(scale);
+
+		select(svgElement)
+			.transition()
+			.duration(300)
+			.call(zoomBehavior.transform, transform);
+	}
+
+	/**
+	 * Set zoom level programmatically.
+	 * @param level - The zoom level to set.
+	 */
+	export function setZoom(level: number): void {
+		if (!svgElement || !zoomBehavior) return;
+		const clampedLevel = Math.max(minZoom, Math.min(maxZoom, level));
+		select(svgElement)
+			.transition()
+			.duration(200)
+			.call(zoomBehavior.scaleTo, clampedLevel);
+	}
+
+	/**
+	 * Zoom in by a factor.
+	 */
+	export function zoomIn(): void {
+		setZoom(currentTransform.k * 1.25);
+	}
+
+	/**
+	 * Zoom out by a factor.
+	 */
+	export function zoomOut(): void {
+		setZoom(currentTransform.k / 1.25);
+	}
+</script>
+
+<svg
+	bind:this={svgElement}
+	class="h-full w-full touch-none"
+	style="background: var(--color-surface);"
+>
+	<g
+		bind:this={contentGroup}
+		transform="translate({currentTransform.x}, {currentTransform.y}) scale({currentTransform.k})"
+	>
+		{@render children?.()}
+	</g>
+</svg>

--- a/apps/web/src/lib/components/schematic/SchematicViewer.svelte
+++ b/apps/web/src/lib/components/schematic/SchematicViewer.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+	import { components } from '$lib/stores';
+	import SchematicCanvas from './SchematicCanvas.svelte';
+
+	interface Props {
+		/** Called when a component is clicked. */
+		onComponentClick?: (componentId: string) => void;
+		/** Custom content to render (for now, placeholder). */
+		children?: import('svelte').Snippet;
+	}
+
+	let { onComponentClick, children }: Props = $props();
+
+	let canvas: SchematicCanvas | undefined = $state();
+	let zoomLevel = $state(1);
+	let containerElement: HTMLDivElement | undefined = $state();
+
+	// Format zoom level for display
+	let zoomPercent = $derived(Math.round(zoomLevel * 100));
+
+	/**
+	 * Fit the schematic to the viewport.
+	 */
+	function handleFitToView(): void {
+		// For now, use a default content area since we don't have actual components yet
+		// This will be updated when we add component symbols
+		const defaultBounds = { x: 0, y: 0, width: 800, height: 400 };
+		canvas?.fitToView(defaultBounds);
+	}
+
+	/**
+	 * Reset zoom to 100%.
+	 */
+	function handleResetZoom(): void {
+		canvas?.resetZoom();
+	}
+
+	/**
+	 * Zoom in.
+	 */
+	function handleZoomIn(): void {
+		canvas?.zoomIn();
+	}
+
+	/**
+	 * Zoom out.
+	 */
+	function handleZoomOut(): void {
+		canvas?.zoomOut();
+	}
+
+	// Handle resize observer to auto-fit on container size change
+	$effect(() => {
+		if (!containerElement) return;
+
+		const resizeObserver = new ResizeObserver(() => {
+			// Optionally auto-fit on resize
+			// handleFitToView();
+		});
+
+		resizeObserver.observe(containerElement);
+
+		return () => {
+			resizeObserver.disconnect();
+		};
+	});
+</script>
+
+<div
+	bind:this={containerElement}
+	class="relative h-full w-full overflow-hidden rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]"
+>
+	<!-- Canvas -->
+	<SchematicCanvas
+		bind:this={canvas}
+		bind:zoomLevel
+		minZoom={0.1}
+		maxZoom={4}
+	>
+		{#if children}
+			{@render children()}
+		{:else}
+			<!-- Default placeholder content -->
+			<g class="schematic-content">
+				{#if $components.length === 0}
+					<!-- Empty state placeholder -->
+					<text
+						x="400"
+						y="200"
+						text-anchor="middle"
+						class="fill-[var(--color-text-muted)] text-sm"
+					>
+						Add components to see the schematic
+					</text>
+				{:else}
+					<!-- Placeholder: show component count -->
+					<text
+						x="400"
+						y="180"
+						text-anchor="middle"
+						class="fill-[var(--color-text)] text-lg font-medium"
+					>
+						Schematic View
+					</text>
+					<text
+						x="400"
+						y="210"
+						text-anchor="middle"
+						class="fill-[var(--color-text-muted)] text-sm"
+					>
+						{$components.length} components
+					</text>
+					<text
+						x="400"
+						y="240"
+						text-anchor="middle"
+						class="fill-[var(--color-text-subtle)] text-xs"
+					>
+						Component symbols coming soon
+					</text>
+				{/if}
+			</g>
+		{/if}
+	</SchematicCanvas>
+
+	<!-- Zoom Controls -->
+	<div class="absolute bottom-4 right-4 flex items-center gap-2">
+		<!-- Zoom level indicator -->
+		<span class="rounded bg-[var(--color-surface-elevated)] px-2 py-1 text-xs font-medium text-[var(--color-text-muted)]">
+			{zoomPercent}%
+		</span>
+
+		<!-- Zoom buttons -->
+		<div class="flex rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-elevated)] shadow-sm">
+			<button
+				type="button"
+				onclick={handleZoomOut}
+				class="px-3 py-2 text-[var(--color-text)] hover:bg-[var(--color-surface)] transition-colors"
+				title="Zoom out"
+			>
+				<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20 12H4" />
+				</svg>
+			</button>
+			<button
+				type="button"
+				onclick={handleResetZoom}
+				class="border-x border-[var(--color-border)] px-3 py-2 text-xs font-medium text-[var(--color-text)] hover:bg-[var(--color-surface)] transition-colors"
+				title="Reset to 100%"
+			>
+				100%
+			</button>
+			<button
+				type="button"
+				onclick={handleZoomIn}
+				class="px-3 py-2 text-[var(--color-text)] hover:bg-[var(--color-surface)] transition-colors"
+				title="Zoom in"
+			>
+				<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 4v16m8-8H4" />
+				</svg>
+			</button>
+		</div>
+	</div>
+
+	<!-- Fit to View button -->
+	<div class="absolute left-4 bottom-4">
+		<button
+			type="button"
+			onclick={handleFitToView}
+			class="flex items-center gap-2 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface-elevated)] px-3 py-2 text-sm font-medium text-[var(--color-text)] shadow-sm hover:bg-[var(--color-surface)] transition-colors"
+			title="Fit schematic to view"
+		>
+			<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+				<path
+					stroke-linecap="round"
+					stroke-linejoin="round"
+					stroke-width="2"
+					d="M4 8V4m0 0h4M4 4l5 5m11-1V4m0 0h-4m4 0l-5 5M4 16v4m0 0h4m-4 0l5-5m11 5l-5-5m5 5v-4m0 4h-4"
+				/>
+			</svg>
+			Fit
+		</button>
+	</div>
+
+	<!-- Keyboard shortcuts hint (optional, can be removed) -->
+	<div class="absolute left-4 top-4 hidden lg:block">
+		<div class="rounded bg-[var(--color-surface-elevated)]/80 px-2 py-1 text-xs text-[var(--color-text-muted)]">
+			Scroll to zoom • Drag to pan
+		</div>
+	</div>
+</div>

--- a/apps/web/src/lib/components/schematic/index.ts
+++ b/apps/web/src/lib/components/schematic/index.ts
@@ -1,0 +1,2 @@
+export { default as SchematicViewer } from './SchematicViewer.svelte';
+export { default as SchematicCanvas } from './SchematicCanvas.svelte';


### PR DESCRIPTION
## Summary

- Create SchematicCanvas component with D3.js zoom/pan behavior
- Create SchematicViewer container with controls
- Add zoom in/out buttons and zoom level indicator
- Add "Fit to View" button for centering content
- Support mouse scroll zoom, drag pan, mobile pinch-to-zoom
- Add keyboard shortcuts hint

## Components Created

**SchematicCanvas.svelte:**
- SVG canvas with D3.js zoom behavior
- Configurable min/max zoom (0.1x - 4x)
- Smooth animated transitions
- Exposes API: resetZoom, fitToView, setZoom, zoomIn, zoomOut

**SchematicViewer.svelte:**
- Main container with zoom controls
- Zoom level indicator
- Fit to View button
- Placeholder content for empty state

## Dependencies Added

- `d3-zoom` - Zoom and pan behavior
- `d3-selection` - DOM manipulation  
- `d3-transition` - Smooth animations

## Test plan

- [x] Svelte check passes (0 errors, 0 warnings)
- [x] ESLint passes
- [x] Prettier passes
- [ ] Manual testing: verify scroll zoom works
- [ ] Manual testing: verify drag pan works
- [ ] Manual testing: verify zoom buttons work
- [ ] Manual testing: verify fit to view works
- [ ] Manual testing: verify mobile pinch-to-zoom (if device available)

Closes #132

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)