### PR TITLE
fix(web): Add null safety to ResultsPanel

### DIFF
--- a/apps/web/src/lib/components/results/ResultsPanel.svelte
+++ b/apps/web/src/lib/components/results/ResultsPanel.svelte
@@ -21,7 +21,7 @@
 		const pumps = $components.filter(isPump);
 		return pumps.map((pump) => {
 			const curve = $pumpLibrary.find((c) => c.id === pump.curve_id);
-			const result = $solvedState?.pump_results[pump.id];
+			const result = $solvedState?.pump_results?.[pump.id];
 			return { pump, curve, result };
 		});
 	});
@@ -34,20 +34,20 @@
 				isValve(c) && controlValveTypes.includes(c.valve_type)
 		);
 		return valves.map((valve) => {
-			const result = $solvedState?.control_valve_results[valve.id];
+			const result = $solvedState?.control_valve_results?.[valve.id];
 			return { valve, result };
 		});
 	});
 
 	// Group warnings by severity
 	let errorWarnings = $derived(
-		$solvedState?.warnings.filter((w) => w.severity === 'error') ?? []
+		$solvedState?.warnings?.filter((w) => w.severity === 'error') ?? []
 	);
 	let warningWarnings = $derived(
-		$solvedState?.warnings.filter((w) => w.severity === 'warning') ?? []
+		$solvedState?.warnings?.filter((w) => w.severity === 'warning') ?? []
 	);
 	let infoWarnings = $derived(
-		$solvedState?.warnings.filter((w) => w.severity === 'info') ?? []
+		$solvedState?.warnings?.filter((w) => w.severity === 'info') ?? []
 	);
 
 	// Dynamically build tabs based on what exists
@@ -165,7 +165,7 @@
 				</div>
 
 				<!-- Warnings -->
-				{#if $solvedState.warnings.length > 0}
+				{#if ($solvedState.warnings ?? []).length > 0}
 					<div class="mt-4 space-y-3">
 						<h4 class="text-sm font-medium text-[var(--color-text)]">Warnings & Messages</h4>
 
@@ -213,31 +213,31 @@
 						<div class="rounded-lg bg-[var(--color-surface-elevated)] p-3">
 							<p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">Components</p>
 							<p class="mt-1 text-2xl font-semibold text-[var(--color-text)]">
-								{Object.keys($solvedState.component_results).length}
+								{Object.keys($solvedState.component_results ?? {}).length}
 							</p>
 						</div>
 						<div class="rounded-lg bg-[var(--color-surface-elevated)] p-3">
 							<p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">Piping</p>
 							<p class="mt-1 text-2xl font-semibold text-[var(--color-text)]">
-								{Object.keys($solvedState.piping_results).length}
+								{Object.keys($solvedState.piping_results ?? {}).length}
 							</p>
 						</div>
 						<div class="rounded-lg bg-[var(--color-surface-elevated)] p-3">
 							<p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">Pumps</p>
 							<p class="mt-1 text-2xl font-semibold text-[var(--color-text)]">
-								{Object.keys($solvedState.pump_results).length}
+								{Object.keys($solvedState.pump_results ?? {}).length}
 							</p>
 						</div>
 						<div class="rounded-lg bg-[var(--color-surface-elevated)] p-3">
 							<p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">Ctrl Valves</p>
 							<p class="mt-1 text-2xl font-semibold text-[var(--color-text)]">
-								{Object.keys($solvedState.control_valve_results).length}
+								{Object.keys($solvedState.control_valve_results ?? {}).length}
 							</p>
 						</div>
 						<div class="rounded-lg bg-[var(--color-surface-elevated)] p-3">
 							<p class="text-xs font-medium uppercase tracking-wide text-[var(--color-text-muted)]">Warnings</p>
 							<p class="mt-1 text-2xl font-semibold text-[var(--color-text)]">
-								{$solvedState.warnings.length}
+								{($solvedState.warnings ?? []).length}
 							</p>
 						</div>
 					</div>


### PR DESCRIPTION
## Summary

Fixes runtime errors in the Results Panel when solver data structures are missing or incomplete.

## Problem

The Pumps tab would not load and blocked navigation to other result tabs. This happened because the code assumed `pump_results`, `control_valve_results`, and `warnings` would always be defined on the `SolvedState` object.

## Solution

Added null safety throughout `ResultsPanel.svelte`:

- Added optional chaining (`?.`) when accessing result objects
- Added null coalescing (`?? {}`) for `Object.keys()` calls
- Added null coalescing (`?? []`) for array access and `.filter()` calls

## Changes

| Before | After |
|--------|-------|
| `$solvedState?.pump_results[pump.id]` | `$solvedState?.pump_results?.[pump.id]` |
| `Object.keys($solvedState.pump_results).length` | `Object.keys($solvedState.pump_results ?? {}).length` |
| `$solvedState?.warnings.filter(...)` | `$solvedState?.warnings?.filter(...) ?? []` |

## Test plan

- [x] Svelte type checking passes
- [x] All 134 tests pass
- [x] Linting passes

---

[![Compound Engineered](https://img.shields.io/badge/Compound-Engineered-6366f1)](https://github.com/EveryInc/compound-engineering-plugin) 🤖 Generated with [Claude Code](https://claude.com/claude-code)