### PR TITLE
fix: landing page vertical scrolling (#175)

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -127,7 +127,6 @@ body {
 	transition:
 		background-color 0.15s ease,
 		color 0.15s ease;
-	overflow: hidden;
 }
 
 /* ========================================================================

--- a/apps/web/src/routes/+page.svelte
+++ b/apps/web/src/routes/+page.svelte
@@ -13,7 +13,7 @@
 	/>
 </svelte:head>
 
-<div class="flex min-h-screen flex-col bg-[var(--color-bg)]" style="overflow: auto;">
+<div class="flex min-h-screen flex-col bg-[var(--color-bg)]">
 	<!-- Minimal Header -->
 	<header class="fixed left-0 right-0 top-0 z-50 border-b border-[var(--color-border)]/50 bg-[var(--color-bg)]/80 backdrop-blur-md">
 		<div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-3">


### PR DESCRIPTION
## Summary
- Remove global `overflow: hidden` from body CSS
- Landing page now scrolls naturally on all viewport sizes
- Workspace layout unaffected (uses `.workspace` class with its own overflow control)

Closes #175

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>