### PR TITLE
feat: undo/redo keyboard shortcuts (#177)

### DIFF
--- a/apps/web/src/routes/p/[encoded]/+page.svelte
+++ b/apps/web/src/routes/p/[encoded]/+page.svelte
@@ -154,6 +154,24 @@
 
 	// Keyboard shortcuts
 	function handleKeydown(event: KeyboardEvent) {
+		// Ctrl+Z / Cmd+Z for undo, Ctrl+Shift+Z / Cmd+Shift+Z for redo
+		if ((event.ctrlKey || event.metaKey) && event.key === 'z') {
+			event.preventDefault();
+			if (event.shiftKey) {
+				projectStore.redo();
+			} else {
+				projectStore.undo();
+			}
+			return;
+		}
+
+		// Ctrl+Y / Cmd+Y for redo (alternative)
+		if ((event.ctrlKey || event.metaKey) && event.key === 'y') {
+			event.preventDefault();
+			projectStore.redo();
+			return;
+		}
+
 		// Ctrl+Enter or Cmd+Enter to solve
 		if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
 			event.preventDefault();


### PR DESCRIPTION
## Summary
- Add Ctrl+Z / Cmd+Z for undo
- Add Ctrl+Shift+Z / Cmd+Shift+Z for redo
- Add Ctrl+Y / Cmd+Y as alternative redo
- Uses existing historyStore (50-state undo stack already implemented)

Closes #177

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>