### PR TITLE
fix: adjust base sizing for 100% zoom (#176)

### DIFF
--- a/apps/web/src/app.css
+++ b/apps/web/src/app.css
@@ -23,10 +23,10 @@
 	--radius-lg: 8px;
 
 	/* Layout */
-	--sidebar-width: 220px;
-	--inspector-width: 340px;
-	--toolbar-height: 40px;
-	--statusbar-height: 28px;
+	--sidebar-width: 260px;
+	--inspector-width: 380px;
+	--toolbar-height: 44px;
+	--statusbar-height: 30px;
 }
 
 /* ========================================================================
@@ -118,7 +118,7 @@
    ======================================================================== */
 html {
 	font-family: var(--font-sans);
-	font-size: 14px;
+	font-size: 16px;
 }
 
 body {


### PR DESCRIPTION
## Summary
- Increase base font-size from 14px to 16px (browser default)
- Scale layout dimensions: sidebar 220→260px, inspector 340→380px, toolbar 40→44px, statusbar 28→30px
- All rem-based sizes scale automatically with the new base
- Pages now look well-proportioned at 100% zoom

Closes #176

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>