### PR TITLE
feat: copy component with parent-child inheritance

### DIFF
--- a/apps/web/src/lib/models/components.ts
+++ b/apps/web/src/lib/models/components.ts
@@ -216,6 +216,8 @@ interface BaseComponentProps {
 	upstream_piping?: PipingSegment;
 	/** Connections to downstream components (deprecated, use Project.connections). */
 	downstream_connections: Connection[];
+	/** ID of the parent component this was copied from. Undefined = independent. */
+	parent_id?: string;
 }
 
 /** Fixed-head water source (infinite capacity). */


### PR DESCRIPTION
## Summary
- Adds right-click context menu to component tree with "Copy in Series" and "Copy in Parallel" options
- Copied components maintain a `parent_id` link to the original, inheriting type-specific property changes from the parent
- Editing a child component auto-breaks the parent link, making it independent
- Visual link chain icon indicator shows which components are linked to a parent

## Test plan
- [ ] Right-click a component in the tree → context menu appears with Copy in Series / Copy in Parallel
- [ ] Copy in Series → new component appears after original with "(Copy)" suffix and link icon
- [ ] Copy in Parallel → new component appears after original without connection rewiring
- [ ] Edit the parent → verify child inherits type-specific changes (e.g. elevation)
- [ ] Edit the child directly → verify link icon disappears (parent link broken)
- [ ] Click away from context menu → it closes

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)