### PR TITLE
fix: resolve CI lint failures across frontend and backend

### DIFF
--- a/apps/api/src/opensolve_pipe/models/branch.py
+++ b/apps/api/src/opensolve_pipe/models/branch.py
@@ -5,7 +5,7 @@ at specific points in the network. They have multiple ports and handle
 the hydraulic relationships between the connected flows.
 """
 
-from enum import Enum
+from enum import StrEnum
 from typing import Literal
 
 from pydantic import Field, field_validator, model_validator
@@ -19,7 +19,7 @@ from .piping import PipingSegment
 from .ports import Port, PortDirection
 
 
-class BranchType(str, Enum):
+class BranchType(StrEnum):
     """Type of branch fitting."""
 
     TEE = "tee"

--- a/apps/api/src/opensolve_pipe/models/components.py
+++ b/apps/api/src/opensolve_pipe/models/components.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import math
-from enum import Enum
+from enum import StrEnum
 from typing import TYPE_CHECKING, Annotated, Literal
 
 from pydantic import Field, ValidationInfo, field_validator, model_validator
@@ -33,7 +33,7 @@ from .ports import (
 )
 
 
-class ComponentType(str, Enum):
+class ComponentType(StrEnum):
     """Types of network components."""
 
     RESERVOIR = "reservoir"
@@ -53,7 +53,7 @@ class ComponentType(str, Enum):
     CROSS_BRANCH = "cross_branch"
 
 
-class ValveType(str, Enum):
+class ValveType(StrEnum):
     """Types of control valves."""
 
     GATE = "gate"
@@ -69,7 +69,7 @@ class ValveType(str, Enum):
     RELIEF = "relief"
 
 
-class PumpOperatingMode(str, Enum):
+class PumpOperatingMode(StrEnum):
     """Operating modes for pumps.
 
     Defines how the pump speed/operation is controlled.
@@ -83,7 +83,7 @@ class PumpOperatingMode(str, Enum):
     OFF = "off"  # Not running
 
 
-class PumpStatus(str, Enum):
+class PumpStatus(StrEnum):
     """Status options for pumps.
 
     Defines the current operational state of the pump.
@@ -94,7 +94,7 @@ class PumpStatus(str, Enum):
     OFF_WITH_CHECK = "off_check"  # Zero flow, check valve prevents reverse
 
 
-class ValveStatus(str, Enum):
+class ValveStatus(StrEnum):
     """Status options for valves.
 
     Defines the current operational state of the valve.

--- a/apps/api/src/opensolve_pipe/models/fluids.py
+++ b/apps/api/src/opensolve_pipe/models/fluids.py
@@ -1,13 +1,13 @@
 """Fluid definition and properties models."""
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field, model_validator
 
 from .base import NonNegativeFloat, OpenSolvePipeBaseModel, PositiveFloat
 
 
-class FluidType(str, Enum):
+class FluidType(StrEnum):
     """Available fluid types."""
 
     WATER = "water"

--- a/apps/api/src/opensolve_pipe/models/piping.py
+++ b/apps/api/src/opensolve_pipe/models/piping.py
@@ -1,13 +1,13 @@
 """Piping, pipe definition, and fitting models."""
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field
 
 from .base import OpenSolvePipeBaseModel, PositiveFloat, PositiveInt
 
 
-class PipeMaterial(str, Enum):
+class PipeMaterial(StrEnum):
     """Available pipe materials."""
 
     CARBON_STEEL = "carbon_steel"
@@ -21,7 +21,7 @@ class PipeMaterial(str, Enum):
     GRP = "grp"  # Glass Reinforced Plastic (Fiberglass)
 
 
-class PipeSchedule(str, Enum):
+class PipeSchedule(StrEnum):
     """Common pipe schedules."""
 
     SCH_5 = "5"
@@ -34,7 +34,7 @@ class PipeSchedule(str, Enum):
     XXS = "XXS"
 
 
-class FittingType(str, Enum):
+class FittingType(StrEnum):
     """Types of pipe fittings."""
 
     # Elbows

--- a/apps/api/src/opensolve_pipe/models/ports.py
+++ b/apps/api/src/opensolve_pipe/models/ports.py
@@ -1,13 +1,13 @@
 """Port model for component connection points."""
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field
 
 from .base import Elevation, OpenSolvePipeBaseModel, PositiveFloat
 
 
-class PortDirection(str, Enum):
+class PortDirection(StrEnum):
     """Direction of flow through a port."""
 
     INLET = "inlet"

--- a/apps/api/src/opensolve_pipe/models/reference_node.py
+++ b/apps/api/src/opensolve_pipe/models/reference_node.py
@@ -1,6 +1,6 @@
 """Reference node models for pressure boundary conditions."""
 
-from enum import Enum
+from enum import StrEnum
 from typing import Literal
 
 from pydantic import Field, field_validator, model_validator
@@ -15,7 +15,7 @@ from .piping import PipingSegment
 from .ports import Port, PortDirection
 
 
-class ReferenceType(str, Enum):
+class ReferenceType(StrEnum):
     """Type of reference node."""
 
     IDEAL = "ideal"

--- a/apps/api/src/opensolve_pipe/models/results.py
+++ b/apps/api/src/opensolve_pipe/models/results.py
@@ -5,7 +5,7 @@ instead of the EPANET-derived "Nodes" and "Links".
 """
 
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import Field
@@ -20,7 +20,7 @@ from .components import PumpStatus, ValveStatus
 from .pump import FlowHeadPoint
 
 
-class FlowRegime(str, Enum):
+class FlowRegime(StrEnum):
     """Flow regime classification."""
 
     LAMINAR = "laminar"
@@ -173,7 +173,7 @@ class ControlValveResult(OpenSolvePipeBaseModel):
     flow: float = Field(description="Flow rate through the valve in project units")
 
 
-class WarningCategory(str, Enum):
+class WarningCategory(StrEnum):
     """Categories of warnings and design check results."""
 
     VELOCITY = "velocity"
@@ -185,7 +185,7 @@ class WarningCategory(str, Enum):
     OPERATING_POINT = "operating_point"
 
 
-class WarningSeverity(str, Enum):
+class WarningSeverity(StrEnum):
     """Warning severity levels."""
 
     INFO = "info"

--- a/apps/api/src/opensolve_pipe/models/units.py
+++ b/apps/api/src/opensolve_pipe/models/units.py
@@ -1,13 +1,13 @@
 """Unit system and solver configuration models."""
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field, field_validator
 
 from .base import NonNegativeFloat, OpenSolvePipeBaseModel, PositiveFloat, PositiveInt
 
 
-class UnitSystem(str, Enum):
+class UnitSystem(StrEnum):
     """Available unit systems."""
 
     IMPERIAL = "imperial"

--- a/apps/api/src/opensolve_pipe/services/solver/network.py
+++ b/apps/api/src/opensolve_pipe/services/solver/network.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 from time import perf_counter
 from typing import TYPE_CHECKING, Any
 
@@ -63,7 +63,7 @@ if TYPE_CHECKING:
     from ...models.project import Project
 
 
-class NetworkType(str, Enum):
+class NetworkType(StrEnum):
     """Classification of network topology."""
 
     SIMPLE = "simple"  # Single path from source to sink
@@ -986,6 +986,8 @@ def solve_branching_network(
     Returns:
         Tuple of (SolverState, converged, error_message)
     """
+    from ...models.components import PumpComponent
+
     state = SolverState()
 
     # For now, we only support tree-structured branching (no loops)
@@ -1139,7 +1141,7 @@ def solve_branching_network(
                 )
 
                 # Check if next component is a pump
-                if next_comp.type == ComponentType.PUMP:
+                if isinstance(next_comp, PumpComponent):
                     # Get pump curve and find operating point
                     pump_curve = project.get_pump_curve(next_comp.curve_id)
                     if pump_curve:

--- a/apps/api/src/opensolve_pipe/utils/units.py
+++ b/apps/api/src/opensolve_pipe/utils/units.py
@@ -17,10 +17,10 @@ Example:
     20.0
 """
 
-from enum import Enum
+from enum import StrEnum
 
 
-class UnitCategory(str, Enum):
+class UnitCategory(StrEnum):
     """Categories of physical quantities for unit conversion."""
 
     LENGTH = "length"

--- a/apps/web/e2e/homepage.test.ts
+++ b/apps/web/e2e/homepage.test.ts
@@ -8,15 +8,15 @@ test.describe('Homepage', () => {
 		await expect(page).toHaveTitle(/OpenSolve Pipe/);
 
 		// Check main heading
-		await expect(page.getByRole('heading', { name: /Hydraulic Network Analysis/i })).toBeVisible();
+		await expect(page.getByRole('heading', { level: 1 })).toBeVisible();
 
 		// Check "New Project" button exists
 		await expect(page.getByRole('link', { name: /New Project/i })).toBeVisible();
 
 		// Check features section
-		await expect(page.getByText(/Instant Results/i)).toBeVisible();
-		await expect(page.getByText(/Shareable via URL/i)).toBeVisible();
-		await expect(page.getByText(/Mobile-Friendly/i)).toBeVisible();
+		await expect(page.getByText(/Fast Solver/i)).toBeVisible();
+		await expect(page.getByText(/URL-Encoded State/i)).toBeVisible();
+		await expect(page.getByText(/Engineering Workspace/i)).toBeVisible();
 	});
 
 	test('navigates to new project page', async ({ page }) => {
@@ -25,10 +25,10 @@ test.describe('Homepage', () => {
 		// Click "New Project" button
 		await page.getByRole('link', { name: /New Project/i }).click();
 
-		// Should navigate to /p (with optional encoded data)
+		// Should navigate to /p (new project redirect page)
 		await expect(page).toHaveURL(/\/p/);
 
-		// Should show project name (Untitled Project for empty project) - use first() to handle multiple instances
-		await expect(page.getByText('Untitled Project').first()).toBeVisible();
+		// Should show the redirect loading page with "Creating new project..." text
+		await expect(page.getByText(/Creating new project/i)).toBeVisible({ timeout: 10000 });
 	});
 });

--- a/apps/web/src/lib/components/workspace/BottomSheet.svelte
+++ b/apps/web/src/lib/components/workspace/BottomSheet.svelte
@@ -78,7 +78,6 @@
 	style="height: {sheetHeight}"
 >
 	<!-- Drag handle -->
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div
 		class="bottom-sheet-handle"
 		ontouchstart={handleTouchStart}

--- a/apps/web/src/lib/components/workspace/CommandPalette.svelte
+++ b/apps/web/src/lib/components/workspace/CommandPalette.svelte
@@ -1,11 +1,8 @@
 <script lang="ts">
-	import { onMount } from 'svelte';
 	import { projectStore, components, navigationStore } from '$lib/stores';
 	import {
 		COMPONENT_TYPE_LABELS,
-		COMPONENT_CATEGORIES,
-		type ComponentType,
-		type Component
+		COMPONENT_CATEGORIES
 	} from '$lib/models';
 
 	interface Props {
@@ -73,23 +70,12 @@
 		return results;
 	});
 
-	// Group items by category
-	let groupedItems = $derived.by(() => {
-		const groups = new Map<string, PaletteItem[]>();
-		for (const item of items) {
-			const group = groups.get(item.category) ?? [];
-			group.push(item);
-			groups.set(item.category, group);
-		}
-		return groups;
-	});
-
 	// Flat list for keyboard navigation
 	let flatItems = $derived(items);
 
 	// Reset active index when query changes
 	$effect(() => {
-		query;
+		void query;
 		activeIndex = 0;
 	});
 

--- a/apps/web/src/lib/components/workspace/ComponentTree.svelte
+++ b/apps/web/src/lib/components/workspace/ComponentTree.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { components, navigationStore, currentElementId, projectStore } from '$lib/stores';
 	import {
-		COMPONENT_TYPE_LABELS,
 		COMPONENT_CATEGORIES,
 		type Component,
 		type ComponentType
@@ -199,7 +198,6 @@
 					<div class="mx-2 h-[2px] rounded bg-[var(--color-accent)]"></div>
 				{/if}
 
-				<!-- svelte-ignore a11y_no_static_element_interactions -->
 				<div
 					data-component-id={component.id}
 					draggable="true"

--- a/apps/web/src/lib/components/workspace/MetricsStrip.svelte
+++ b/apps/web/src/lib/components/workspace/MetricsStrip.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { solvedState } from '$lib/stores';
-	import { isPump, isValve, type Component, type ValveComponent } from '$lib/models';
+	import { isPump, type Component } from '$lib/models';
 
 	interface Props {
 		component: Component;

--- a/apps/web/src/lib/components/workspace/ProjectConfigPanel.svelte
+++ b/apps/web/src/lib/components/workspace/ProjectConfigPanel.svelte
@@ -5,6 +5,8 @@
 		GLYCOL_FLUID_TYPES,
 		type FluidType,
 		type UnitSystem,
+		type UnitPreferences,
+		type SolverOptions,
 		type FluidDefinition
 	} from '$lib/models';
 
@@ -33,14 +35,14 @@
 
 	function updateUnitSystem(system: UnitSystem) {
 		projectStore.updateSettings({
-			units: { ...($settings?.units ?? {}), system } as any
+			units: { ...($settings?.units ?? {}), system } as UnitPreferences
 		});
 	}
 
 	function updateSolverOption(key: string, value: number) {
 		const current = $settings?.solver_options ?? {};
 		projectStore.updateSettings({
-			solver_options: { ...current, [key]: value } as any
+			solver_options: { ...current, [key]: value } as SolverOptions
 		});
 	}
 

--- a/apps/web/src/lib/components/workspace/PropertyPanel.svelte
+++ b/apps/web/src/lib/components/workspace/PropertyPanel.svelte
@@ -1,11 +1,10 @@
 <script lang="ts">
-	import { components, currentElementId, navigationStore, projectStore, solvedState, pumpLibrary, workspaceStore, activeInspectorTab } from '$lib/stores';
+	import { components, currentElementId, projectStore, solvedState, pumpLibrary, workspaceStore, activeInspectorTab } from '$lib/stores';
 	import type { InspectorTab } from '$lib/stores';
 	import {
 		COMPONENT_TYPE_LABELS,
 		isPump,
 		isValve,
-		type Component,
 		type ValveComponent
 	} from '$lib/models';
 	import ElementPanel from '../panel/ElementPanel.svelte';

--- a/apps/web/src/lib/components/workspace/SystemResultsPanel.svelte
+++ b/apps/web/src/lib/components/workspace/SystemResultsPanel.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
 	import { components, solvedState, isSolved } from '$lib/stores';
-	import { COMPONENT_CATEGORIES, type ComponentType } from '$lib/models';
+	import { COMPONENT_CATEGORIES } from '$lib/models';
 
 	interface Props {
 		onSolve?: () => void;

--- a/apps/web/src/lib/components/workspace/WorkspaceToolbar.svelte
+++ b/apps/web/src/lib/components/workspace/WorkspaceToolbar.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import ThemeToggle from '../ThemeToggle.svelte';
 	import { currentElementId, components, activeInspectorTab, navigationStore, isFocusMode, workspaceStore } from '$lib/stores';
-	import { COMPONENT_TYPE_LABELS } from '$lib/models';
 
 	interface Props {
 		projectName: string;


### PR DESCRIPTION
## Summary
- Fix 16 frontend ESLint errors (unused imports, `as any` casts, unnecessary svelte-ignore comments)
- Fix 18 backend ruff UP042 errors (migrate `str, Enum` to `StrEnum` for Python 3.11+)
- Fix pre-existing mypy `union-attr` error in `solve_branching_network`
- Update E2E tests to match redesigned landing page and new workspace layout

## Test plan
- [ ] CI pipeline passes (all 3 jobs: backend-test, frontend-test, frontend-e2e)
- [ ] `pnpm lint` passes with zero errors
- [ ] `ruff check src/` passes with zero errors
- [ ] `mypy --strict src/` passes with zero errors
- [ ] All 879 backend tests pass
- [ ] E2E tests match current landing page and workspace UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)