### PR TITLE
feat: #195 - Add Library tab for pump curves and future extensibility

### DIFF
--- a/apps/web/src/lib/components/workspace/LibraryTab.svelte
+++ b/apps/web/src/lib/components/workspace/LibraryTab.svelte
@@ -1,0 +1,120 @@
+<script lang="ts">
+	import { pumpLibrary } from '$lib/stores';
+	import PumpCurveList from './PumpCurveList.svelte';
+
+	// Collapsible section state
+	let pumpCurvesOpen = $state(true);
+	let lossCurvesOpen = $state(false);
+	let refProfilesOpen = $state(false);
+</script>
+
+<div class="flex h-full flex-col bg-[var(--color-surface)]">
+	<!-- Header -->
+	<div class="flex items-center justify-between border-b border-[var(--color-border)] px-3 py-2">
+		<span class="text-[0.6875rem] font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+			Library
+		</span>
+	</div>
+
+	<!-- Sections -->
+	<div class="flex-1 overflow-y-auto">
+		<!-- Pump Curves Section -->
+		<div class="border-b border-[var(--color-border)]">
+			<button
+				type="button"
+				onclick={() => pumpCurvesOpen = !pumpCurvesOpen}
+				class="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-[var(--color-tree-hover)]"
+			>
+				<svg
+					class="h-3 w-3 flex-shrink-0 text-[var(--color-text-subtle)] transition-transform {pumpCurvesOpen ? 'rotate-90' : ''}"
+					fill="none"
+					stroke="currentColor"
+					viewBox="0 0 24 24"
+					stroke-width="2"
+				>
+					<path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+				</svg>
+				<svg class="h-3.5 w-3.5 flex-shrink-0 text-[var(--color-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941" />
+				</svg>
+				<span class="text-xs font-medium text-[var(--color-text)]">Pump Curves</span>
+				<span class="ml-auto text-[0.625rem] text-[var(--color-text-subtle)]">
+					{$pumpLibrary.length}
+				</span>
+			</button>
+			{#if pumpCurvesOpen}
+				<div class="px-2 pb-2">
+					<PumpCurveList />
+				</div>
+			{/if}
+		</div>
+
+		<!-- Loss Curves Section (Coming Soon) -->
+		<div class="border-b border-[var(--color-border)]">
+			<button
+				type="button"
+				onclick={() => lossCurvesOpen = !lossCurvesOpen}
+				class="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-[var(--color-tree-hover)]"
+			>
+				<svg
+					class="h-3 w-3 flex-shrink-0 text-[var(--color-text-subtle)] transition-transform {lossCurvesOpen ? 'rotate-90' : ''}"
+					fill="none"
+					stroke="currentColor"
+					viewBox="0 0 24 24"
+					stroke-width="2"
+				>
+					<path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+				</svg>
+				<svg class="h-3.5 w-3.5 flex-shrink-0 text-[var(--color-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 013 19.875v-6.75zM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V8.625zM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 01-1.125-1.125V4.125z" />
+				</svg>
+				<span class="text-xs font-medium text-[var(--color-text)]">Loss Curves</span>
+				<span class="ml-auto rounded bg-[var(--color-surface-elevated)] px-1.5 py-0.5 text-[0.5625rem] text-[var(--color-text-subtle)]">
+					Coming Soon
+				</span>
+			</button>
+			{#if lossCurvesOpen}
+				<div class="px-3 pb-3">
+					<p class="text-[0.6875rem] leading-relaxed text-[var(--color-text-subtle)]">
+						Define custom K-factor or Cv curves for orifices, specialty valves, or other components
+						where the loss characteristic is not a simple constant.
+					</p>
+				</div>
+			{/if}
+		</div>
+
+		<!-- Reference Profiles Section (Coming Soon) -->
+		<div class="border-b border-[var(--color-border)]">
+			<button
+				type="button"
+				onclick={() => refProfilesOpen = !refProfilesOpen}
+				class="flex w-full items-center gap-2 px-3 py-2 text-left transition-colors hover:bg-[var(--color-tree-hover)]"
+			>
+				<svg
+					class="h-3 w-3 flex-shrink-0 text-[var(--color-text-subtle)] transition-transform {refProfilesOpen ? 'rotate-90' : ''}"
+					fill="none"
+					stroke="currentColor"
+					viewBox="0 0 24 24"
+					stroke-width="2"
+				>
+					<path stroke-linecap="round" stroke-linejoin="round" d="M8.25 4.5l7.5 7.5-7.5 7.5" />
+				</svg>
+				<svg class="h-3.5 w-3.5 flex-shrink-0 text-[var(--color-text-muted)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M19.5 14.25v-2.625a3.375 3.375 0 00-3.375-3.375h-1.5A1.125 1.125 0 0113.5 7.125v-1.5a3.375 3.375 0 00-3.375-3.375H8.25m0 12.75h7.5m-7.5 3H12M10.5 2.25H5.625c-.621 0-1.125.504-1.125 1.125v17.25c0 .621.504 1.125 1.125 1.125h12.75c.621 0 1.125-.504 1.125-1.125V11.25a9 9 0 00-9-9z" />
+				</svg>
+				<span class="text-xs font-medium text-[var(--color-text)]">Reference Profiles</span>
+				<span class="ml-auto rounded bg-[var(--color-surface-elevated)] px-1.5 py-0.5 text-[0.5625rem] text-[var(--color-text-subtle)]">
+					Coming Soon
+				</span>
+			</button>
+			{#if refProfilesOpen}
+				<div class="px-3 pb-3">
+					<p class="text-[0.6875rem] leading-relaxed text-[var(--color-text-subtle)]">
+						Define pressure, head, or level profiles for reservoirs, tanks, or boundary conditions
+						such as time-varying supply pressures or tank level profiles.
+					</p>
+				</div>
+			{/if}
+		</div>
+	</div>
+</div>

--- a/apps/web/src/lib/components/workspace/PumpCurveEditor.svelte
+++ b/apps/web/src/lib/components/workspace/PumpCurveEditor.svelte
@@ -1,0 +1,192 @@
+<script lang="ts">
+	import type { PumpCurve, FlowHeadPoint } from '$lib/models';
+
+	interface Props {
+		curve: PumpCurve;
+		onSave: (curve: PumpCurve) => void;
+		onCancel: () => void;
+	}
+
+	let { curve, onSave, onCancel }: Props = $props();
+
+	// Local editable copy - intentionally captures initial value
+	// svelte-ignore state_referenced_locally
+	let name = $state(curve.name);
+	// svelte-ignore state_referenced_locally
+	let manufacturer = $state(curve.manufacturer ?? '');
+	// svelte-ignore state_referenced_locally
+	let model = $state(curve.model ?? '');
+	// svelte-ignore state_referenced_locally
+	let points = $state<FlowHeadPoint[]>(curve.points.map((p) => ({ ...p })));
+	let error = $state<string | null>(null);
+
+	function addPoint() {
+		const lastPoint = points[points.length - 1];
+		const newFlow = lastPoint ? lastPoint.flow + 50 : 0;
+		const newHead = lastPoint ? Math.max(0, lastPoint.head - 10) : 100;
+		points = [...points, { flow: newFlow, head: newHead }];
+	}
+
+	function removePoint(index: number) {
+		if (points.length <= 2) {
+			error = 'Minimum 2 data points required';
+			return;
+		}
+		points = points.filter((_, i) => i !== index);
+		error = null;
+	}
+
+	function updatePoint(index: number, field: 'flow' | 'head', value: number) {
+		points = points.map((p, i) => (i === index ? { ...p, [field]: value } : p));
+	}
+
+	function handleSave() {
+		if (!name.trim()) {
+			error = 'Name is required';
+			return;
+		}
+		if (points.length < 2) {
+			error = 'Minimum 2 data points required';
+			return;
+		}
+
+		// Sort points by flow
+		const sorted = [...points].sort((a, b) => a.flow - b.flow);
+
+		// Check for negative values
+		for (const p of sorted) {
+			if (p.flow < 0 || p.head < 0) {
+				error = 'Flow and head values must be non-negative';
+				return;
+			}
+		}
+
+		error = null;
+		onSave({
+			...curve,
+			name: name.trim(),
+			manufacturer: manufacturer.trim() || undefined,
+			model: model.trim() || undefined,
+			points: sorted
+		});
+	}
+</script>
+
+<div class="flex flex-col gap-3 rounded border border-[var(--color-border)] bg-[var(--color-surface)] p-3">
+	<!-- Name -->
+	<div>
+		<label class="mb-1 block text-[0.6875rem] font-medium text-[var(--color-text-muted)]">
+			Name
+			<input
+				type="text"
+				bind:value={name}
+				class="form-input"
+				placeholder="Pump curve name"
+			/>
+		</label>
+	</div>
+
+	<!-- Manufacturer / Model (inline) -->
+	<div class="grid grid-cols-2 gap-2">
+		<label class="block text-[0.6875rem] font-medium text-[var(--color-text-muted)]">
+			Manufacturer
+			<input
+				type="text"
+				bind:value={manufacturer}
+				class="form-input mt-1"
+				placeholder="Optional"
+			/>
+		</label>
+		<label class="block text-[0.6875rem] font-medium text-[var(--color-text-muted)]">
+			Model
+			<input
+				type="text"
+				bind:value={model}
+				class="form-input mt-1"
+				placeholder="Optional"
+			/>
+		</label>
+	</div>
+
+	<!-- Data Points -->
+	<div>
+		<div class="mb-1 flex items-center justify-between">
+			<span class="text-[0.6875rem] font-medium text-[var(--color-text-muted)]">
+				Curve Points ({points.length})
+			</span>
+			<button
+				type="button"
+				onclick={addPoint}
+				class="rounded px-1.5 py-0.5 text-[0.625rem] font-medium text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent-muted)]"
+			>
+				+ Add Point
+			</button>
+		</div>
+
+		<!-- Header -->
+		<div class="grid grid-cols-[1fr_1fr_2rem] gap-1 text-[0.625rem] font-semibold uppercase tracking-wider text-[var(--color-text-subtle)]">
+			<span class="px-1">Flow</span>
+			<span class="px-1">Head</span>
+			<span></span>
+		</div>
+
+		<!-- Points -->
+		<div class="flex max-h-48 flex-col gap-0.5 overflow-y-auto">
+			{#each points as point, i}
+				<div class="grid grid-cols-[1fr_1fr_2rem] gap-1">
+					<input
+						type="number"
+						value={point.flow}
+						oninput={(e) => updatePoint(i, 'flow', parseFloat(e.currentTarget.value) || 0)}
+						class="form-input mono-value text-xs"
+						min="0"
+						step="any"
+						aria-label="Flow point {i + 1}"
+					/>
+					<input
+						type="number"
+						value={point.head}
+						oninput={(e) => updatePoint(i, 'head', parseFloat(e.currentTarget.value) || 0)}
+						class="form-input mono-value text-xs"
+						min="0"
+						step="any"
+						aria-label="Head point {i + 1}"
+					/>
+					<button
+						type="button"
+						onclick={() => removePoint(i)}
+						class="flex h-full items-center justify-center rounded text-[var(--color-text-subtle)] transition-colors hover:text-[var(--color-error)]"
+						title="Remove point"
+					>
+						<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+						</svg>
+					</button>
+				</div>
+			{/each}
+		</div>
+	</div>
+
+	<!-- Error -->
+	{#if error}
+		<p class="text-[0.6875rem] text-[var(--color-error)]">{error}</p>
+	{/if}
+
+	<!-- Actions -->
+	<div class="flex items-center justify-end gap-2">
+		<button
+			type="button"
+			onclick={onCancel}
+			class="rounded border border-[var(--color-border)] px-3 py-1 text-xs text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)]"
+		>
+			Cancel
+		</button>
+		<button
+			type="button"
+			onclick={handleSave}
+			class="rounded bg-[var(--color-accent)] px-3 py-1 text-xs font-medium text-[var(--color-accent-text)] transition-colors hover:opacity-90"
+		>
+			Save
+		</button>
+	</div>
+</div>

--- a/apps/web/src/lib/components/workspace/PumpCurveList.svelte
+++ b/apps/web/src/lib/components/workspace/PumpCurveList.svelte
@@ -1,0 +1,140 @@
+<script lang="ts">
+	import { pumpLibrary, projectStore } from '$lib/stores';
+	import { createDefaultPumpCurve } from '$lib/models';
+	import type { PumpCurve } from '$lib/models';
+	import PumpCurveEditor from './PumpCurveEditor.svelte';
+
+	let editingCurveId = $state<string | null>(null);
+	let pendingDeleteId = $state<string | null>(null);
+
+	function handleAdd() {
+		const id = `curve_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`;
+		const curve = createDefaultPumpCurve(id);
+		projectStore.addPumpCurve(curve);
+		editingCurveId = id;
+	}
+
+	function handleEdit(curveId: string) {
+		editingCurveId = editingCurveId === curveId ? null : curveId;
+		pendingDeleteId = null;
+	}
+
+	function handleSave(updated: PumpCurve) {
+		projectStore.updatePumpCurve(updated.id, updated);
+		editingCurveId = null;
+	}
+
+	function handleCancelEdit() {
+		editingCurveId = null;
+	}
+
+	function handleDelete(e: Event, curveId: string) {
+		e.stopPropagation();
+		pendingDeleteId = curveId;
+	}
+
+	function confirmDelete(e: Event) {
+		e.stopPropagation();
+		if (pendingDeleteId) {
+			projectStore.removePumpCurve(pendingDeleteId);
+			if (editingCurveId === pendingDeleteId) {
+				editingCurveId = null;
+			}
+			pendingDeleteId = null;
+		}
+	}
+
+	function cancelDelete(e: Event) {
+		e.stopPropagation();
+		pendingDeleteId = null;
+	}
+</script>
+
+<div class="flex flex-col gap-1">
+	{#if $pumpLibrary.length === 0}
+		<p class="px-1 py-2 text-center text-[0.6875rem] text-[var(--color-text-subtle)]">
+			No pump curves defined
+		</p>
+	{:else}
+		{#each $pumpLibrary as curve}
+			<div class="flex flex-col">
+				<!-- Curve Row -->
+				<div
+					onclick={() => handleEdit(curve.id)}
+					onkeydown={(e) => e.key === 'Enter' && handleEdit(curve.id)}
+					role="button"
+					tabindex="0"
+					class="group flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-left text-xs transition-colors
+						{editingCurveId === curve.id
+						? 'bg-[var(--color-tree-selected)] text-[var(--color-text)]'
+						: 'text-[var(--color-text-muted)] hover:bg-[var(--color-tree-hover)] hover:text-[var(--color-text)]'}"
+				>
+					<!-- Icon -->
+					<svg class="h-3.5 w-3.5 flex-shrink-0 text-[var(--color-text-subtle)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941" />
+					</svg>
+
+					<!-- Name + Details -->
+					<div class="min-w-0 flex-1">
+						<span class="block truncate">{curve.name}</span>
+						<span class="block text-[0.625rem] text-[var(--color-text-subtle)]">
+							{curve.points.length} pts{curve.manufacturer ? ` - ${curve.manufacturer}` : ''}
+						</span>
+					</div>
+
+					<!-- Delete -->
+					{#if pendingDeleteId === curve.id}
+						<div class="flex flex-shrink-0 items-center gap-1">
+							<button
+								type="button"
+								onclick={confirmDelete}
+								class="flex h-4 items-center rounded bg-[var(--color-error)] px-1.5 text-[0.5625rem] font-semibold text-white"
+								title="Confirm delete"
+							>Del</button>
+							<button
+								type="button"
+								onclick={cancelDelete}
+								class="flex h-4 items-center rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-1 text-[0.5625rem] text-[var(--color-text-muted)]"
+								title="Cancel"
+							>
+								<svg class="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+									<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+								</svg>
+							</button>
+						</div>
+					{:else}
+						<button
+							type="button"
+							onclick={(e) => handleDelete(e, curve.id)}
+							class="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded opacity-0 transition-opacity group-hover:opacity-100 hover:text-[var(--color-error)]"
+							title="Delete pump curve"
+						>
+							<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+								<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+							</svg>
+						</button>
+					{/if}
+				</div>
+
+				<!-- Inline Editor -->
+				{#if editingCurveId === curve.id}
+					<div class="mt-1 px-1">
+						<PumpCurveEditor {curve} onSave={handleSave} onCancel={handleCancelEdit} />
+					</div>
+				{/if}
+			</div>
+		{/each}
+	{/if}
+
+	<!-- Add Button -->
+	<button
+		type="button"
+		onclick={handleAdd}
+		class="flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent-muted)]"
+	>
+		<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+			<path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+		</svg>
+		Add Pump Curve
+	</button>
+</div>

--- a/apps/web/src/lib/components/workspace/SidebarTabs.svelte
+++ b/apps/web/src/lib/components/workspace/SidebarTabs.svelte
@@ -3,6 +3,7 @@
 	import ComponentTree from './ComponentTree.svelte';
 	import ProjectConfigPanel from './ProjectConfigPanel.svelte';
 	import SystemResultsPanel from './SystemResultsPanel.svelte';
+	import LibraryTab from './LibraryTab.svelte';
 	import SidebarFooter from './SidebarFooter.svelte';
 
 	interface Props {
@@ -16,6 +17,7 @@
 
 	const tabs: { id: SidebarTab; label: string }[] = [
 		{ id: 'tree', label: 'Tree' },
+		{ id: 'library', label: 'Library' },
 		{ id: 'config', label: 'Config' },
 		{ id: 'results', label: 'Results' }
 	];
@@ -24,7 +26,7 @@
 		workspaceStore.setSidebarTab(tab);
 	}
 
-	// Keyboard shortcuts: Ctrl+1/2/3 for tabs
+	// Keyboard shortcuts: Ctrl+1/2/3/4 for tabs
 	function handleKeydown(event: KeyboardEvent) {
 		if (event.ctrlKey || event.metaKey) {
 			const tabIndex = parseInt(event.key) - 1;
@@ -60,6 +62,10 @@
 					<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M3.75 6A2.25 2.25 0 016 3.75h2.25A2.25 2.25 0 0110.5 6v2.25a2.25 2.25 0 01-2.25 2.25H6a2.25 2.25 0 01-2.25-2.25V6zM3.75 15.75A2.25 2.25 0 016 13.5h2.25a2.25 2.25 0 012.25 2.25V18a2.25 2.25 0 01-2.25 2.25H6A2.25 2.25 0 013.75 18v-2.25zM13.5 6a2.25 2.25 0 012.25-2.25H18A2.25 2.25 0 0120.25 6v2.25A2.25 2.25 0 0118 10.5h-2.25a2.25 2.25 0 01-2.25-2.25V6z" />
 					</svg>
+				{:else if tab.id === 'library'}
+					<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M12 6.042A8.967 8.967 0 006 3.75c-1.052 0-2.062.18-3 .512v14.25A8.987 8.987 0 016 18c2.305 0 4.408.867 6 2.292m0-14.25a8.966 8.966 0 016-2.292c1.052 0 2.062.18 3 .512v14.25A8.987 8.987 0 0018 18a8.967 8.967 0 00-6 2.292m0-14.25v14.25" />
+					</svg>
 				{:else if tab.id === 'config'}
 					<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
 						<path stroke-linecap="round" stroke-linejoin="round" d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.324.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 011.37.49l1.296 2.247a1.125 1.125 0 01-.26 1.431l-1.003.827c-.293.24-.438.613-.431.992a6.759 6.759 0 010 .255c-.007.378.138.75.43.99l1.005.828c.424.35.534.954.26 1.43l-1.298 2.247a1.125 1.125 0 01-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.57 6.57 0 01-.22.128c-.331.183-.581.495-.644.869l-.213 1.28c-.09.543-.56.941-1.11.941h-2.594c-.55 0-1.02-.398-1.11-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 01-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 01-1.369-.49l-1.297-2.247a1.125 1.125 0 01.26-1.431l1.004-.827c.292-.24.437-.613.43-.992a6.932 6.932 0 010-.255c.007-.378-.138-.75-.43-.99l-1.004-.828a1.125 1.125 0 01-.26-1.43l1.297-2.247a1.125 1.125 0 011.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.087.22-.128.332-.183.582-.495.644-.869l.214-1.281z" />
@@ -79,6 +85,8 @@
 		<div class="min-h-0 flex-1 overflow-y-auto overflow-x-hidden">
 			{#if $activeSidebarTab === 'tree'}
 				<ComponentTree {onOpenCommandPalette} />
+			{:else if $activeSidebarTab === 'library'}
+				<LibraryTab />
 			{:else if $activeSidebarTab === 'config'}
 				<ProjectConfigPanel />
 			{:else if $activeSidebarTab === 'results'}

--- a/apps/web/src/lib/components/workspace/index.ts
+++ b/apps/web/src/lib/components/workspace/index.ts
@@ -5,6 +5,7 @@ export { default as CommandPalette } from './CommandPalette.svelte';
 export { default as StatusBar } from './StatusBar.svelte';
 export { default as SidebarTabs } from './SidebarTabs.svelte';
 export { default as SidebarFooter } from './SidebarFooter.svelte';
+export { default as LibraryTab } from './LibraryTab.svelte';
 export { default as ProjectConfigPanel } from './ProjectConfigPanel.svelte';
 export { default as SystemResultsPanel } from './SystemResultsPanel.svelte';
 export { default as MetricsStrip } from './MetricsStrip.svelte';

--- a/apps/web/src/lib/stores/workspace.ts
+++ b/apps/web/src/lib/stores/workspace.ts
@@ -9,7 +9,7 @@ import { writable, derived } from 'svelte/store';
 import { browser } from '$app/environment';
 
 /** Sidebar tab options. */
-export type SidebarTab = 'tree' | 'config' | 'results';
+export type SidebarTab = 'tree' | 'config' | 'results' | 'library';
 
 /** Inspector tab options. */
 export type InspectorTab = 'properties' | 'piping' | 'results';

--- a/docs/plans/issue-195-plan.md
+++ b/docs/plans/issue-195-plan.md
@@ -1,0 +1,78 @@
+# Issue #195: Add Library Tab to Navigation Panel
+
+## Overview
+
+Add a "Library" tab to the sidebar navigation panel for managing reusable data definitions: pump curves (fully functional), loss curves and reference profiles (placeholder UI with "Coming Soon" labels).
+
+## Scope (Minimal Viable Implementation)
+
+### In Scope
+
+1. Add "Library" tab to sidebar (next to Tree/Config/Results)
+2. Display existing `pump_library` items in the Library tab
+3. Pump curve CRUD: create, edit (name + data points), delete
+4. Placeholder sections for "Loss Curves" and "Reference Profiles" (Coming Soon UI)
+5. Backend pump curve validation (already exists via `PumpCurve` model with `min_length=2`)
+
+### Out of Scope (Future Work)
+
+- Chart.js pump curve visualization
+- Full loss curve data model and editor
+- Full reference profile data model and editor
+- Component property panels referencing library items via dropdown
+- Usage indicators (which components reference library items)
+
+## Implementation Plan
+
+### Step 1: Extend SidebarTab Type
+
+**File:** `apps/web/src/lib/stores/workspace.ts`
+
+- Add `'library'` to `SidebarTab` union type
+
+### Step 2: Add Library Tab Icon to SidebarTabs
+
+**File:** `apps/web/src/lib/components/workspace/SidebarTabs.svelte`
+
+- Add `{ id: 'library', label: 'Library' }` to tabs array
+- Add a book/library SVG icon for the new tab
+- Wire up the tab content to render `LibraryTab` component
+
+### Step 3: Create LibraryTab Component
+
+**New File:** `apps/web/src/lib/components/workspace/LibraryTab.svelte`
+
+- Main container with three collapsible sections:
+  - Pump Curves (functional)
+  - Loss Curves (Coming Soon placeholder)
+  - Reference Profiles (Coming Soon placeholder)
+
+### Step 4: Create PumpCurveList Component
+
+**New File:** `apps/web/src/lib/components/workspace/PumpCurveList.svelte`
+
+- List of pump curves from `pumpLibrary` store
+- "Add Pump Curve" button
+- Each item shows name + point count + delete button
+- Click item to expand inline editor
+
+### Step 5: Create PumpCurveEditor Component
+
+**New File:** `apps/web/src/lib/components/workspace/PumpCurveEditor.svelte`
+
+- Form fields: name, manufacturer, model (optional)
+- Data points table: flow/head pairs with add/remove rows
+- Validate minimum 2 points
+- Save/cancel buttons
+
+### Step 6: Export New Components
+
+**File:** `apps/web/src/lib/components/workspace/index.ts`
+
+- Add exports for LibraryTab
+
+### Step 7: Validate
+
+- `pnpm svelte-check` passes
+- `pnpm build` passes
+- Backend validation already in place (PumpCurve Pydantic model)


### PR DESCRIPTION
## Summary
- Added Library tab to sidebar navigation (book icon, Ctrl+2 shortcut)
- Pump curve CRUD: create, edit, and delete pump curves from the library
- Inline pump curve editor with name, manufacturer, model, and flow/head data points
- Placeholder sections for Loss Curves and Reference Profiles (Coming Soon)
- Collapsible sections with item counts

## Changes

### New Files
- `apps/web/src/lib/components/workspace/LibraryTab.svelte` - Main library tab with three collapsible sections
- `apps/web/src/lib/components/workspace/PumpCurveList.svelte` - Pump curve list with add/edit/delete
- `apps/web/src/lib/components/workspace/PumpCurveEditor.svelte` - Inline form for editing pump curve data
- `docs/plans/issue-195-plan.md` - Implementation plan

### Modified Files
- `apps/web/src/lib/stores/workspace.ts` - Added `'library'` to `SidebarTab` union type
- `apps/web/src/lib/components/workspace/SidebarTabs.svelte` - Added Library tab icon and content rendering
- `apps/web/src/lib/components/workspace/index.ts` - Added LibraryTab export

## Test Plan
- [x] `svelte-check` passes with 0 errors, 0 warnings
- [x] `pnpm build` succeeds
- [x] All 10 Playwright E2E tests pass
- [x] Backend `ruff check` and `mypy` pass
- [x] Pre-commit hooks pass (formatting, linting, type checking)

## Future Work
- Chart.js pump curve visualization
- Loss curve data model and editor
- Reference profile data model and editor
- Component property panels referencing library items via dropdown
- Usage indicators (which components reference library items)

Closes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)