### PR TITLE
fix: command palette arrow key double-jump and no scroll

### DIFF
--- a/apps/web/src/lib/components/workspace/CommandPalette.svelte
+++ b/apps/web/src/lib/components/workspace/CommandPalette.svelte
@@ -15,6 +15,7 @@
 	let query = $state('');
 	let activeIndex = $state(0);
 	let inputEl: HTMLInputElement | undefined = $state();
+	let resultsEl: HTMLDivElement | undefined = $state();
 
 	// Build searchable items
 	interface PaletteItem {
@@ -89,6 +90,17 @@
 		}
 	});
 
+	// Scroll active item into view
+	$effect(() => {
+		void activeIndex;
+		if (resultsEl) {
+			const activeEl = resultsEl.querySelector('.command-palette-item.active');
+			if (activeEl) {
+				activeEl.scrollIntoView({ block: 'nearest' });
+			}
+		}
+	});
+
 	function handleKeydown(e: KeyboardEvent) {
 		switch (e.key) {
 			case 'ArrowDown':
@@ -133,10 +145,9 @@
 				bind:value={query}
 				class="command-palette-input"
 				placeholder="Type to search components..."
-				onkeydown={handleKeydown}
 			/>
 
-			<div class="command-palette-results">
+			<div class="command-palette-results" bind:this={resultsEl}>
 				{#if flatItems.length === 0}
 					<div class="px-4 py-6 text-center text-xs text-[var(--color-text-subtle)]">
 						No matching components


### PR DESCRIPTION
## Summary
- Fixed arrow keys jumping 2 items: moved `onkeydown` from input to backdrop only (events bubble, so handler fires once)
- Added `scrollIntoView({ block: 'nearest' })` on active item when `activeIndex` changes

## Test plan
- [x] All 17 E2E tests pass
- [ ] Manual: open Ctrl+K, Down arrow moves exactly 1 item
- [ ] Manual: arrow past visible area, menu scrolls

Closes #206

🤖 Generated with [Claude Code](https://claude.com/claude-code)