### PR TITLE
fix: solver API connectivity for Vercel deployment

### DIFF
--- a/apps/api/.env.example
+++ b/apps/api/.env.example
@@ -6,6 +6,8 @@ PORT=8000
 DEBUG=true
 
 # CORS (comma-separated origins)
+# For deployment, add your frontend domain, e.g.:
+#   CORS_ORIGINS=http://localhost:5173,http://localhost:4173,https://your-app.vercel.app
 CORS_ORIGINS=http://localhost:5173,http://localhost:4173
 
 # Database (optional, for large projects)

--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -1,4 +1,8 @@
 # OpenSolve Pipe Web Configuration
 
-# API URL
+# API URL - used for server-side rendering (SSR) requests to the backend.
+# In the browser, requests use relative URL /api/v1 (proxied by Vite in dev,
+# rewritten by vercel.json in production).
+# For Vercel deployment, set this to your deployed backend URL, e.g.:
+#   PUBLIC_API_URL=https://opensolve-pipe-api.railway.app
 PUBLIC_API_URL=http://localhost:8000

--- a/apps/web/src/lib/api/client.ts
+++ b/apps/web/src/lib/api/client.ts
@@ -11,14 +11,18 @@ import { browser } from '$app/environment';
 
 /**
  * Get the API base URL from environment or use default.
+ *
+ * - Browser: uses relative URL `/api/v1` (proxied by Vite in dev, rewritten by Vercel in prod)
+ * - SSR: uses PUBLIC_API_URL env var if set, otherwise falls back to localhost:8000
  */
 function getBaseUrl(): string {
-	// In browser, use relative URL (proxied by SvelteKit)
+	// In browser, use relative URL (proxied by Vite dev server or Vercel rewrites)
 	if (browser) {
 		return '/api/v1';
 	}
-	// In SSR, call the backend directly
-	return 'http://localhost:8000/api/v1';
+	// In SSR, use environment variable or fall back to localhost for local dev
+	const apiUrl = import.meta.env.PUBLIC_API_URL || 'http://localhost:8000';
+	return `${apiUrl.replace(/\/$/, '')}/api/v1`;
 }
 
 /** Default request timeout in milliseconds. */

--- a/apps/web/src/routes/p/[encoded]/+page.svelte
+++ b/apps/web/src/routes/p/[encoded]/+page.svelte
@@ -17,7 +17,7 @@
 	import { goto } from '$app/navigation';
 	import { get } from 'svelte/store';
 	import { projectStore, components, metadata, navigationStore, workspaceStore, currentElementId } from '$lib/stores';
-	import { solveNetwork, ApiError } from '$lib/api';
+	import { solveNetwork, ApiError, NetworkError, TimeoutError } from '$lib/api';
 	import { encodeProject, tryDecodeProject } from '$lib/utils';
 
 	// Get encoded project data from URL
@@ -129,7 +129,11 @@
 				solveError = result.error || 'Solution did not converge';
 			}
 		} catch (error) {
-			if (error instanceof ApiError) {
+			if (error instanceof NetworkError) {
+				solveError = 'Could not reach the solver API. Please check your connection and try again.';
+			} else if (error instanceof TimeoutError) {
+				solveError = 'The solver request timed out. Try simplifying the network or try again later.';
+			} else if (error instanceof ApiError) {
 				solveError = error.message;
 			} else {
 				solveError = 'An unexpected error occurred while solving';


### PR DESCRIPTION
## Summary
- SSR requests now use `PUBLIC_API_URL` env var instead of hardcoded `localhost:8000`
- Browser requests unchanged (relative `/api/v1`, proxied by Vite/Vercel)
- Added specific error messages for `NetworkError` and `TimeoutError` in solve handler
- Updated `.env.example` files with Vercel deployment guidance

## Test plan
- [x] All 17 E2E tests pass
- [ ] Set `PUBLIC_API_URL` in Vercel project settings to deployed backend URL
- [ ] Verify solve works on Vercel deployment

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)