### PR TITLE
feat: redesign sidebar footer as shortcuts help popup

### DIFF
--- a/apps/web/src/lib/components/workspace/SidebarFooter.svelte
+++ b/apps/web/src/lib/components/workspace/SidebarFooter.svelte
@@ -1,74 +1,79 @@
 <script lang="ts">
-	import { canUndo, canRedo } from '$lib/stores';
+	let showShortcuts = $state(false);
 
-	interface Props {
-		onOpenCommandPalette?: () => void;
-		onSolve?: () => void;
-		onUndo?: () => void;
-		onRedo?: () => void;
+	const shortcuts = [
+		{ keys: 'Ctrl+K', action: 'Add Component' },
+		{ keys: 'Ctrl+Enter', action: 'Solve Network' },
+		{ keys: 'Ctrl+Z', action: 'Undo' },
+		{ keys: 'Ctrl+Shift+Z', action: 'Redo' },
+		{ keys: 'Ctrl+Y', action: 'Redo (alt)' },
+		{ keys: 'Ctrl+Shift+F', action: 'Toggle Focus Mode' },
+		{ keys: 'Ctrl+1', action: 'Components Tab' },
+		{ keys: 'Ctrl+2', action: 'Config Tab' },
+		{ keys: 'Ctrl+3', action: 'Results Tab' },
+		{ keys: 'Ctrl+4', action: 'Library Tab' },
+		{ keys: 'Escape', action: 'Close Palette / Exit Focus' },
+	];
+
+	function handleKeydown(e: KeyboardEvent) {
+		if (e.key === 'Escape') {
+			showShortcuts = false;
+		}
 	}
 
-	let { onOpenCommandPalette, onSolve, onUndo, onRedo }: Props = $props();
+	function handleBackdropClick(e: MouseEvent) {
+		if (e.target === e.currentTarget) {
+			showShortcuts = false;
+		}
+	}
 </script>
 
 <div
-	class="flex items-center gap-1 border-t border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1"
-	role="toolbar"
-	aria-label="Quick actions"
+	class="flex items-center border-t border-[var(--color-border)] bg-[var(--color-surface)] px-2 py-1"
 >
-	<!-- Add Component -->
 	<button
 		type="button"
-		onclick={() => onOpenCommandPalette?.()}
-		class="flex h-7 w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-text)]"
-		title="Add component (Ctrl+K)"
-		aria-label="Add component"
+		onclick={() => (showShortcuts = !showShortcuts)}
+		class="flex h-7 items-center gap-1.5 rounded px-2 text-xs text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-text)]"
+		title="Keyboard shortcuts"
+		aria-label="Keyboard shortcuts"
 	>
-		<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-			<path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" />
+		<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+			<path stroke-linecap="round" stroke-linejoin="round" d="M9.879 7.519c1.171-1.025 3.071-1.025 4.242 0 1.172 1.025 1.172 2.687 0 3.712-.203.179-.43.326-.67.442-.745.361-1.45.999-1.45 1.827v.75M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9 5.25h.008v.008H12v-.008z" />
 		</svg>
-	</button>
-
-	<!-- Solve -->
-	<button
-		type="button"
-		onclick={() => onSolve?.()}
-		class="flex h-7 w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-text)]"
-		title="Solve network (Ctrl+Enter)"
-		aria-label="Solve network"
-	>
-		<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-			<path stroke-linecap="round" stroke-linejoin="round" d="M5.636 18.364a9 9 0 010-12.728m12.728 0a9 9 0 010 12.728M9.172 15.172a4 4 0 010-5.656m5.656 0a4 4 0 010 5.656M12 12h.01" />
-		</svg>
-	</button>
-
-	<div class="mx-0.5 h-4 w-px bg-[var(--color-border)]"></div>
-
-	<!-- Undo -->
-	<button
-		type="button"
-		onclick={() => onUndo?.()}
-		disabled={!$canUndo}
-		class="flex h-7 w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-30"
-		title="Undo (Ctrl+Z)"
-		aria-label="Undo"
-	>
-		<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-			<path stroke-linecap="round" stroke-linejoin="round" d="M9 15L3 9m0 0l6-6M3 9h12a6 6 0 010 12h-3" />
-		</svg>
-	</button>
-
-	<!-- Redo -->
-	<button
-		type="button"
-		onclick={() => onRedo?.()}
-		disabled={!$canRedo}
-		class="flex h-7 w-7 items-center justify-center rounded text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-text)] disabled:cursor-not-allowed disabled:opacity-30"
-		title="Redo (Ctrl+Shift+Z)"
-		aria-label="Redo"
-	>
-		<svg class="h-4 w-4" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-			<path stroke-linecap="round" stroke-linejoin="round" d="M15 15l6-6m0 0l-6-6m6 6H9a6 6 0 000 12h3" />
-		</svg>
+		<span>Shortcuts</span>
 	</button>
 </div>
+
+{#if showShortcuts}
+	<!-- svelte-ignore a11y_no_static_element_interactions -->
+	<div
+		class="fixed inset-0 z-50 flex items-center justify-center bg-black/40"
+		onclick={handleBackdropClick}
+		onkeydown={handleKeydown}
+	>
+		<div class="w-80 rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)] shadow-xl" role="dialog" aria-modal="true" aria-label="Keyboard shortcuts">
+			<div class="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-2.5">
+				<h2 class="text-sm font-semibold text-[var(--color-text)]">Keyboard Shortcuts</h2>
+				<button
+					type="button"
+					onclick={() => (showShortcuts = false)}
+					class="flex h-5 w-5 items-center justify-center rounded text-[var(--color-text-subtle)] hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-text)]"
+					aria-label="Close"
+				>
+					<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+						<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+					</svg>
+				</button>
+			</div>
+			<div class="max-h-72 overflow-y-auto px-4 py-2">
+				{#each shortcuts as shortcut}
+					<div class="flex items-center justify-between py-1.5">
+						<span class="text-xs text-[var(--color-text-muted)]">{shortcut.action}</span>
+						<kbd class="rounded border border-[var(--color-border)] bg-[var(--color-surface-elevated)] px-1.5 py-0.5 text-[0.625rem] font-mono text-[var(--color-text-subtle)]">{shortcut.keys}</kbd>
+					</div>
+				{/each}
+			</div>
+		</div>
+	</div>
+{/if}

--- a/apps/web/src/lib/components/workspace/SidebarTabs.svelte
+++ b/apps/web/src/lib/components/workspace/SidebarTabs.svelte
@@ -9,11 +9,9 @@
 	interface Props {
 		onOpenCommandPalette?: () => void;
 		onSolve?: () => void;
-		onUndo?: () => void;
-		onRedo?: () => void;
 	}
 
-	let { onOpenCommandPalette, onSolve, onUndo, onRedo }: Props = $props();
+	let { onOpenCommandPalette, onSolve }: Props = $props();
 
 	const tabs: { id: SidebarTab; label: string }[] = [
 		{ id: 'tree', label: 'Tree' },
@@ -93,6 +91,6 @@
 				<SystemResultsPanel {onSolve} />
 			{/if}
 		</div>
-		<SidebarFooter {onOpenCommandPalette} {onSolve} {onUndo} {onRedo} />
+		<SidebarFooter />
 	</div>
 </div>

--- a/apps/web/src/routes/p/[encoded]/+page.svelte
+++ b/apps/web/src/routes/p/[encoded]/+page.svelte
@@ -264,8 +264,6 @@
 		<SidebarTabs
 			onOpenCommandPalette={() => (showCommandPalette = true)}
 			onSolve={handleSolve}
-			onUndo={() => projectStore.undo()}
-			onRedo={() => projectStore.redo()}
 		/>
 	</div>
 


### PR DESCRIPTION
## Summary
- Replaces the sidebar footer action buttons (Add Component, Solve, Undo, Redo) with a single "Shortcuts" button
- Clicking the button opens a modal popup listing all keyboard shortcuts with their key bindings
- Modal includes backdrop click and Escape key to dismiss
- Removes unused `onUndo`/`onRedo` prop threading through SidebarTabs

Closes #205

## Test plan
- [x] All 17 E2E tests pass
- [x] Svelte type-check passes (0 errors)
- [x] Production build succeeds
- [ ] Manual: click Shortcuts button in sidebar footer, verify popup appears with all shortcuts
- [ ] Manual: click backdrop or press Escape to dismiss popup
- [ ] Manual: verify all listed shortcuts still work (Ctrl+K, Ctrl+Enter, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)