### PR TITLE
feat: add arrow key navigation in component tree

### DIFF
--- a/apps/web/src/lib/components/workspace/ComponentTree.svelte
+++ b/apps/web/src/lib/components/workspace/ComponentTree.svelte
@@ -199,7 +199,6 @@
 	</div>
 
 	<!-- Component List -->
-	<!-- svelte-ignore a11y_no_static_element_interactions -->
 	<div bind:this={listEl} class="flex-1 overflow-y-auto py-1" tabindex="-1" onkeydown={handleListKeydown} role="listbox" aria-label="Component list">
 		{#if $components.length === 0}
 			<div class="flex flex-col items-center gap-2 px-3 py-6 text-center">


### PR DESCRIPTION
## Summary
- Adds Up/Down arrow key navigation to cycle through components in the tree panel
- Home/End keys jump to first/last component
- Clicking a component focuses the list so arrow keys work immediately
- Uses listbox/option ARIA pattern for accessibility
- Existing auto-scroll `$effect` keeps selected component visible

Closes #204

## Test plan
- [x] All 17 E2E tests pass
- [x] Svelte type-check passes (0 errors)
- [x] Production build succeeds
- [ ] Manual: add several components, click one, use Up/Down arrows to navigate
- [ ] Manual: Home key selects first, End key selects last
- [ ] Manual: inspector panel updates on each arrow key navigation
- [ ] Manual: long list auto-scrolls to keep selection visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)