### PR TITLE
feat: add Left/Right arrow key navigation in workspace

### DIFF
--- a/apps/web/src/routes/p/[encoded]/+page.svelte
+++ b/apps/web/src/routes/p/[encoded]/+page.svelte
@@ -204,6 +204,33 @@
 				return;
 			}
 		}
+
+		// Left/Right arrow keys to navigate components in schematic
+		// Only when not typing in an input field and no modifiers
+		if ((event.key === 'ArrowLeft' || event.key === 'ArrowRight') && !event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey) {
+			const tag = (event.target as HTMLElement)?.tagName;
+			if (tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+
+			const comps = $components;
+			if (comps.length === 0) return;
+
+			const currentIndex = comps.findIndex((c) => c.id === $currentElementId);
+			let newIndex: number | null = null;
+
+			if (event.key === 'ArrowRight') {
+				newIndex = currentIndex < 0 ? 0 : Math.min(currentIndex + 1, comps.length - 1);
+			} else {
+				newIndex = currentIndex < 0 ? comps.length - 1 : Math.max(currentIndex - 1, 0);
+			}
+
+			if (newIndex !== null) {
+				event.preventDefault();
+				navigationStore.navigateTo(comps[newIndex].id);
+				if (!isInspectorOpen) {
+					workspaceStore.setInspectorOpen(true);
+				}
+			}
+		}
 	}
 
 	// Mobile tab switching


### PR DESCRIPTION
## Summary
- Adds Left/Right arrow key navigation at the workspace level to cycle through components
- Left arrow selects previous component, Right arrow selects next
- Automatically opens the inspector panel if it's closed
- Skips navigation when focus is on input/textarea/select elements
- No modifiers required (plain arrow keys only, no conflict with Ctrl shortcuts)

Closes #209

## Test plan
- [x] All 17 E2E tests pass
- [x] Svelte type-check passes (0 errors)
- [x] Production build succeeds
- [ ] Manual: add components, select one, use Left/Right to navigate
- [ ] Manual: verify inspector updates with each navigation
- [ ] Manual: verify no navigation when typing in input fields
- [ ] Manual: verify no conflict with Ctrl+Z, Ctrl+K, etc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)