### PR TITLE
feat: add full-width pump curve editor panel

### DIFF
--- a/apps/api/src/opensolve_pipe/models/pump.py
+++ b/apps/api/src/opensolve_pipe/models/pump.py
@@ -28,6 +28,13 @@ class NPSHRPoint(OpenSolvePipeBaseModel):
     npsh_required: PositiveFloat = Field(description="NPSH required in project units")
 
 
+class FlowPowerPoint(OpenSolvePipeBaseModel):
+    """A single point on a power curve (flow vs brake horsepower)."""
+
+    flow: NonNegativeFloat = Field(description="Flow rate in project units")
+    power: NonNegativeFloat = Field(description="Power (BHP) in project units")
+
+
 class PumpCurve(OpenSolvePipeBaseModel):
     """Pump performance curve definition."""
 
@@ -41,6 +48,11 @@ class PumpCurve(OpenSolvePipeBaseModel):
     impeller_diameter: PositiveFloat | None = Field(
         default=None, description="Impeller diameter in project units"
     )
+    stages: int | None = Field(default=None, ge=1, description="Number of pump stages")
+    inlet_outlet: str | None = Field(
+        default=None, description="Inlet/outlet size description"
+    )
+    notes: str | None = Field(default=None, description="Free-form notes")
 
     points: list[FlowHeadPoint] = Field(
         min_length=2, description="Pump curve points (minimum 2)"
@@ -50,6 +62,9 @@ class PumpCurve(OpenSolvePipeBaseModel):
     )
     npshr_curve: list[NPSHRPoint] | None = Field(
         default=None, description="Optional NPSH required curve"
+    )
+    power_curve: list[FlowPowerPoint] | None = Field(
+        default=None, description="Optional power curve"
     )
 
     @field_validator("points")

--- a/apps/web/src/lib/components/workspace/PumpCurveEditorPanel.svelte
+++ b/apps/web/src/lib/components/workspace/PumpCurveEditorPanel.svelte
@@ -1,0 +1,645 @@
+<script lang="ts">
+	import { pumpLibrary, projectStore, workspaceStore } from '$lib/stores';
+	import type { PumpCurve, FlowHeadPoint, FlowEfficiencyPoint, NPSHRPoint, FlowPowerPoint } from '$lib/models';
+	import { generatePumpBestFitCurve, generateEfficiencyBestFitCurve } from '$lib/models';
+
+	interface Props {
+		curveId: string;
+	}
+
+	let { curveId }: Props = $props();
+
+	// Find the curve from the library
+	let sourceCurve = $derived($pumpLibrary.find((c) => c.id === curveId));
+
+	// Local editable state — reset when curveId changes
+	let name = $state('');
+	let manufacturer = $state('');
+	let model = $state('');
+	let ratedSpeed = $state<number | null>(null);
+	let impellerDiameter = $state<number | null>(null);
+	let stages = $state<number | null>(null);
+	let inletOutlet = $state('');
+	let notes = $state('');
+	let headPoints = $state<FlowHeadPoint[]>([]);
+	let efficiencyPoints = $state<FlowEfficiencyPoint[]>([]);
+	let npshPoints = $state<NPSHRPoint[]>([]);
+	let powerPoints = $state<FlowPowerPoint[]>([]);
+
+	let isDirty = $state(false);
+	let activeTab = $state<'info' | 'data' | 'preview'>('info');
+	let activeDataTab = $state<'head' | 'efficiency' | 'npsh' | 'power'>('head');
+	let pendingDelete = $state(false);
+
+	// Load curve data when curveId or sourceCurve changes
+	$effect(() => {
+		if (sourceCurve) {
+			loadFromCurve(sourceCurve);
+		}
+	});
+
+	function loadFromCurve(c: PumpCurve) {
+		name = c.name;
+		manufacturer = c.manufacturer ?? '';
+		model = c.model ?? '';
+		ratedSpeed = c.rated_speed ?? null;
+		impellerDiameter = c.impeller_diameter ?? null;
+		stages = c.stages ?? null;
+		inletOutlet = c.inlet_outlet ?? '';
+		notes = c.notes ?? '';
+		headPoints = c.points.map((p) => ({ ...p }));
+		efficiencyPoints = (c.efficiency_curve ?? []).map((p) => ({ ...p }));
+		npshPoints = (c.npshr_curve ?? []).map((p) => ({ ...p }));
+		powerPoints = (c.power_curve ?? []).map((p) => ({ ...p }));
+		isDirty = false;
+		pendingDelete = false;
+	}
+
+	function markDirty() {
+		isDirty = true;
+	}
+
+	// === Actions ===
+
+	function handleSave() {
+		const sorted = [...headPoints].sort((a, b) => a.flow - b.flow);
+		const sortedEff = [...efficiencyPoints].sort((a, b) => a.flow - b.flow);
+		const sortedNpsh = [...npshPoints].sort((a, b) => a.flow - b.flow);
+		const sortedPower = [...powerPoints].sort((a, b) => a.flow - b.flow);
+
+		projectStore.updatePumpCurve(curveId, {
+			name: name.trim() || 'Untitled',
+			manufacturer: manufacturer.trim() || undefined,
+			model: model.trim() || undefined,
+			rated_speed: ratedSpeed ?? undefined,
+			impeller_diameter: impellerDiameter ?? undefined,
+			stages: stages ?? undefined,
+			inlet_outlet: inletOutlet.trim() || undefined,
+			notes: notes.trim() || undefined,
+			points: sorted.length >= 2 ? sorted : headPoints,
+			efficiency_curve: sortedEff.length > 0 ? sortedEff : undefined,
+			npshr_curve: sortedNpsh.length > 0 ? sortedNpsh : undefined,
+			power_curve: sortedPower.length > 0 ? sortedPower : undefined
+		});
+		isDirty = false;
+	}
+
+	function handleDuplicate() {
+		if (!sourceCurve) return;
+		const newId = `curve_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`;
+		const copy: PumpCurve = {
+			...sourceCurve,
+			id: newId,
+			name: `${sourceCurve.name} (Copy)`
+		};
+		projectStore.addPumpCurve(copy);
+		workspaceStore.setEditingPumpCurve(newId);
+	}
+
+	function handleDelete() {
+		if (!pendingDelete) {
+			pendingDelete = true;
+			return;
+		}
+		projectStore.removePumpCurve(curveId);
+		// Select next curve or close editor
+		const remaining = $pumpLibrary.filter((c) => c.id !== curveId);
+		if (remaining.length > 0) {
+			workspaceStore.setEditingPumpCurve(remaining[0].id);
+		} else {
+			workspaceStore.setEditingPumpCurve(null);
+		}
+	}
+
+	function handleClose() {
+		workspaceStore.setEditingPumpCurve(null);
+	}
+
+	// === Data table helpers ===
+
+	function addHeadPoint() {
+		const last = headPoints[headPoints.length - 1];
+		headPoints = [...headPoints, { flow: last ? last.flow + 50 : 0, head: last ? Math.max(0, last.head - 10) : 100 }];
+		markDirty();
+	}
+
+	function removeHeadPoint(i: number) {
+		headPoints = headPoints.filter((_, idx) => idx !== i);
+		markDirty();
+	}
+
+	function addEfficiencyPoint() {
+		const last = efficiencyPoints[efficiencyPoints.length - 1];
+		efficiencyPoints = [...efficiencyPoints, { flow: last ? last.flow + 50 : 0, efficiency: last ? last.efficiency : 0.7 }];
+		markDirty();
+	}
+
+	function removeEfficiencyPoint(i: number) {
+		efficiencyPoints = efficiencyPoints.filter((_, idx) => idx !== i);
+		markDirty();
+	}
+
+	function addNpshPoint() {
+		const last = npshPoints[npshPoints.length - 1];
+		npshPoints = [...npshPoints, { flow: last ? last.flow + 50 : 0, npsh_required: last ? last.npsh_required : 5 }];
+		markDirty();
+	}
+
+	function removeNpshPoint(i: number) {
+		npshPoints = npshPoints.filter((_, idx) => idx !== i);
+		markDirty();
+	}
+
+	function addPowerPoint() {
+		const last = powerPoints[powerPoints.length - 1];
+		powerPoints = [...powerPoints, { flow: last ? last.flow + 50 : 0, power: last ? last.power : 10 }];
+		markDirty();
+	}
+
+	function removePowerPoint(i: number) {
+		powerPoints = powerPoints.filter((_, idx) => idx !== i);
+		markDirty();
+	}
+
+	// === Chart data for preview ===
+	let showHeadCurve = $state(true);
+	let showEffCurve = $state(true);
+	let showNpshCurve = $state(true);
+	let showPowerCurve = $state(true);
+
+	// Build a temporary PumpCurve for chart utilities
+	let previewCurve = $derived<PumpCurve>({
+		id: curveId,
+		name,
+		points: headPoints,
+		efficiency_curve: efficiencyPoints.length > 0 ? efficiencyPoints : undefined,
+		npshr_curve: npshPoints.length > 0 ? npshPoints : undefined,
+		power_curve: powerPoints.length > 0 ? powerPoints : undefined
+	});
+
+	let headBestFit = $derived(showHeadCurve ? generatePumpBestFitCurve(previewCurve) : null);
+	let effBestFit = $derived(showEffCurve ? generateEfficiencyBestFitCurve(previewCurve) : null);
+
+	// Primary tabs
+	const primaryTabs = [
+		{ id: 'info' as const, label: 'Pump Information', icon: 'info' },
+		{ id: 'data' as const, label: 'Curve Data', icon: 'data' },
+		{ id: 'preview' as const, label: 'Curve Preview', icon: 'chart' }
+	];
+
+	// Data sub-tab counts
+	let headCount = $derived(headPoints.length);
+	let effCount = $derived(efficiencyPoints.length);
+	let npshCount = $derived(npshPoints.length);
+	let powerCount = $derived(powerPoints.length);
+
+	const dataTabDefs = [
+		{ id: 'head' as const, label: 'Head' },
+		{ id: 'efficiency' as const, label: 'Efficiency' },
+		{ id: 'npsh' as const, label: 'NPSH' },
+		{ id: 'power' as const, label: 'Power' }
+	] as const;
+
+	function getDataTabCount(id: 'head' | 'efficiency' | 'npsh' | 'power'): number {
+		if (id === 'head') return headCount;
+		if (id === 'efficiency') return effCount;
+		if (id === 'npsh') return npshCount;
+		return powerCount;
+	}
+</script>
+
+{#if !sourceCurve}
+	<div class="flex h-full items-center justify-center">
+		<p class="text-sm text-[var(--color-text-subtle)]">Pump curve not found</p>
+	</div>
+{:else}
+	<div class="flex h-full flex-col bg-[var(--color-surface)]">
+		<!-- Top Bar: Breadcrumb + Actions -->
+		<div class="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-2">
+			<!-- Breadcrumb -->
+			<div class="flex items-center gap-1 text-xs">
+				<button
+					type="button"
+					onclick={handleClose}
+					class="text-[var(--color-accent)] hover:underline"
+				>Library</button>
+				<span class="text-[var(--color-text-subtle)]">/</span>
+				<button
+					type="button"
+					onclick={handleClose}
+					class="text-[var(--color-accent)] hover:underline"
+				>Pump Curves</button>
+				<span class="text-[var(--color-text-subtle)]">/</span>
+				<span class="font-medium text-[var(--color-text)]">{name || 'Untitled'}</span>
+			</div>
+
+			<!-- Actions -->
+			<div class="flex items-center gap-2">
+				{#if pendingDelete}
+					<span class="text-xs text-[var(--color-error)]">Confirm delete?</span>
+					<button
+						type="button"
+						onclick={handleDelete}
+						class="rounded bg-[var(--color-error)] px-2.5 py-1 text-xs font-medium text-white"
+					>Delete</button>
+					<button
+						type="button"
+						onclick={() => pendingDelete = false}
+						class="rounded border border-[var(--color-border)] px-2.5 py-1 text-xs text-[var(--color-text-muted)]"
+					>Cancel</button>
+				{:else}
+					<button
+						type="button"
+						onclick={handleDelete}
+						class="rounded border border-[var(--color-border)] px-2.5 py-1 text-xs text-[var(--color-error)] transition-colors hover:bg-[var(--color-error)] hover:text-white"
+					>Delete</button>
+					<button
+						type="button"
+						onclick={handleDuplicate}
+						class="rounded border border-[var(--color-border)] px-2.5 py-1 text-xs text-[var(--color-text-muted)] transition-colors hover:bg-[var(--color-surface-elevated)]"
+					>Duplicate</button>
+					<button
+						type="button"
+						onclick={handleSave}
+						class="relative rounded bg-[var(--color-accent)] px-3 py-1 text-xs font-medium text-[var(--color-accent-text)] transition-colors hover:opacity-90"
+					>
+						Save
+						{#if isDirty}
+							<span class="absolute -right-0.5 -top-0.5 h-2 w-2 rounded-full bg-[var(--color-warning)]"></span>
+						{/if}
+					</button>
+				{/if}
+			</div>
+		</div>
+
+		<!-- Primary Tabs -->
+		<div class="flex border-b border-[var(--color-border)]">
+			{#each primaryTabs as tab}
+				<button
+					type="button"
+					onclick={() => activeTab = tab.id}
+					class="flex items-center gap-1.5 border-b-2 px-4 py-2 text-xs font-medium transition-colors
+						{activeTab === tab.id
+						? 'border-[var(--color-accent)] text-[var(--color-accent)]'
+						: 'border-transparent text-[var(--color-text-muted)] hover:text-[var(--color-text)]'}"
+				>
+					{#if tab.icon === 'info'}
+						<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M11.25 11.25l.041-.02a.75.75 0 011.063.852l-.708 2.836a.75.75 0 001.063.853l.041-.021M21 12a9 9 0 11-18 0 9 9 0 0118 0zm-9-3.75h.008v.008H12V8.25z" />
+						</svg>
+					{:else if tab.icon === 'data'}
+						<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M3.375 19.5h17.25m-17.25 0a1.125 1.125 0 01-1.125-1.125M3.375 19.5h7.5c.621 0 1.125-.504 1.125-1.125m-9.75 0V5.625m0 12.75v-1.5c0-.621.504-1.125 1.125-1.125m18.375 2.625V5.625m0 12.75c0 .621-.504 1.125-1.125 1.125m1.125-1.125v-1.5c0-.621-.504-1.125-1.125-1.125m0 3.75h-7.5A1.125 1.125 0 0112 18.375m9.75-12.75c0-.621-.504-1.125-1.125-1.125H3.375c-.621 0-1.125.504-1.125 1.125m19.5 0v1.5c0 .621-.504 1.125-1.125 1.125M2.25 5.625v1.5c0 .621.504 1.125 1.125 1.125m0 0h17.25m-17.25 0h7.5c.621 0 1.125.504 1.125 1.125M3.375 8.25c-.621 0-1.125.504-1.125 1.125v1.5c0 .621.504 1.125 1.125 1.125m17.25-3.75h-7.5c-.621 0-1.125.504-1.125 1.125m8.625-1.125c.621 0 1.125.504 1.125 1.125v1.5c0 .621-.504 1.125-1.125 1.125" />
+						</svg>
+					{:else}
+						<svg class="h-3.5 w-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941" />
+						</svg>
+					{/if}
+					{tab.label}
+				</button>
+			{/each}
+		</div>
+
+		<!-- Tab Content -->
+		<div class="min-h-0 flex-1 overflow-y-auto">
+			{#if activeTab === 'info'}
+				<!-- Pump Information Tab -->
+				<div class="mx-auto max-w-2xl space-y-4 p-6">
+					<div>
+						<label for="curve-name" class="mb-1 block section-heading text-[var(--color-text-subtle)]">Curve Name *</label>
+						<input id="curve-name" type="text" bind:value={name} oninput={markDirty} class="form-input" placeholder="e.g. Grundfos CR 32-2" />
+					</div>
+
+					<div class="grid grid-cols-3 gap-4">
+						<div>
+							<label for="curve-mfr" class="mb-1 block section-heading text-[var(--color-text-subtle)]">Manufacturer</label>
+							<input id="curve-mfr" type="text" bind:value={manufacturer} oninput={markDirty} class="form-input" placeholder="Optional" />
+						</div>
+						<div>
+							<label for="curve-model" class="mb-1 block section-heading text-[var(--color-text-subtle)]">Model</label>
+							<input id="curve-model" type="text" bind:value={model} oninput={markDirty} class="form-input" placeholder="Optional" />
+						</div>
+						<div>
+							<label for="curve-speed" class="mb-1 block section-heading text-[var(--color-text-subtle)]">Speed (RPM)</label>
+							<input id="curve-speed" type="number" value={ratedSpeed ?? ''} oninput={(e) => { ratedSpeed = parseFloat(e.currentTarget.value) || null; markDirty(); }} class="form-input mono-value" placeholder="Optional" />
+						</div>
+					</div>
+
+					<div class="grid grid-cols-3 gap-4">
+						<div>
+							<label for="curve-impeller" class="mb-1 block section-heading text-[var(--color-text-subtle)]">Impeller Diameter</label>
+							<input id="curve-impeller" type="number" value={impellerDiameter ?? ''} oninput={(e) => { impellerDiameter = parseFloat(e.currentTarget.value) || null; markDirty(); }} class="form-input mono-value" placeholder="Optional" />
+						</div>
+						<div>
+							<label for="curve-stages" class="mb-1 block section-heading text-[var(--color-text-subtle)]">Stages</label>
+							<input id="curve-stages" type="number" min="1" value={stages ?? ''} oninput={(e) => { stages = parseInt(e.currentTarget.value) || null; markDirty(); }} class="form-input mono-value" placeholder="Optional" />
+						</div>
+						<div>
+							<label for="curve-io" class="mb-1 block section-heading text-[var(--color-text-subtle)]">Inlet / Outlet</label>
+							<input id="curve-io" type="text" bind:value={inletOutlet} oninput={markDirty} class="form-input" placeholder='e.g. 2" / 2"' />
+						</div>
+					</div>
+
+					<div>
+						<label for="curve-notes" class="mb-1 block section-heading text-[var(--color-text-subtle)]">Notes</label>
+						<textarea id="curve-notes" bind:value={notes} oninput={markDirty} rows="3" class="form-input resize-y" placeholder="Free-form notes..."></textarea>
+					</div>
+				</div>
+
+			{:else if activeTab === 'data'}
+				<!-- Curve Data Tab -->
+				<div class="flex h-full flex-col">
+					<!-- Data Sub-Tabs -->
+					<div class="flex gap-1 border-b border-[var(--color-border)] px-4 py-1.5">
+						{#each dataTabDefs as dt}
+						{@const count = getDataTabCount(dt.id)}
+							<button
+								type="button"
+								onclick={() => activeDataTab = dt.id}
+								class="flex items-center gap-1.5 rounded px-3 py-1.5 text-xs font-medium transition-colors
+									{activeDataTab === dt.id
+									? 'bg-[var(--color-accent)] text-[var(--color-accent-text)]'
+									: 'text-[var(--color-text-muted)] hover:bg-[var(--color-surface-elevated)] hover:text-[var(--color-text)]'}"
+							>
+								{dt.label}
+								<span class="rounded-full bg-black/10 px-1.5 py-0.5 text-[0.5625rem] {count === 0 ? 'opacity-40' : ''}">
+									{count}
+								</span>
+							</button>
+						{/each}
+					</div>
+
+					<!-- Data Table -->
+					<div class="min-h-0 flex-1 overflow-y-auto p-4">
+						{#if activeDataTab === 'head'}
+							{#if headPoints.length === 0}
+								<div class="flex flex-col items-center gap-3 py-12 text-center">
+									<p class="text-sm text-[var(--color-text-subtle)]">No head data yet.</p>
+									<button type="button" onclick={addHeadPoint} class="rounded bg-[var(--color-accent)] px-3 py-1.5 text-xs font-medium text-[var(--color-accent-text)]">Add Data</button>
+								</div>
+							{:else}
+								<div class="mx-auto max-w-lg">
+									<div class="sticky top-0 z-10 grid grid-cols-[2rem_1fr_1fr_2rem] gap-2 bg-[var(--color-surface)] pb-1 text-[0.625rem] font-semibold uppercase tracking-wider text-[var(--color-text-subtle)]">
+										<span>#</span><span>Flow (GPM)</span><span>Head (ft)</span><span></span>
+									</div>
+									{#each headPoints as point, i}
+										<div class="group grid grid-cols-[2rem_1fr_1fr_2rem] items-center gap-2 py-0.5">
+											<span class="text-[0.625rem] text-[var(--color-text-subtle)]">{i + 1}</span>
+											<input type="number" value={point.flow} oninput={(e) => { headPoints[i] = { ...headPoints[i], flow: parseFloat(e.currentTarget.value) || 0 }; headPoints = headPoints; markDirty(); }} class="form-input mono-value text-xs" min="0" step="any" />
+											<input type="number" value={point.head} oninput={(e) => { headPoints[i] = { ...headPoints[i], head: parseFloat(e.currentTarget.value) || 0 }; headPoints = headPoints; markDirty(); }} class="form-input mono-value text-xs" min="0" step="any" />
+											<button type="button" onclick={() => removeHeadPoint(i)} class="flex h-full items-center justify-center rounded text-[var(--color-text-subtle)] opacity-0 transition-opacity group-hover:opacity-100 hover:text-[var(--color-error)]" title="Remove">
+												<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+											</button>
+										</div>
+									{/each}
+									<button type="button" onclick={addHeadPoint} class="mt-2 flex items-center gap-1 rounded px-2 py-1 text-xs text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent-muted)]">
+										<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" /></svg>
+										Add Row
+									</button>
+								</div>
+							{/if}
+
+						{:else if activeDataTab === 'efficiency'}
+							{#if efficiencyPoints.length === 0}
+								<div class="flex flex-col items-center gap-3 py-12 text-center">
+									<p class="text-sm text-[var(--color-text-subtle)]">No efficiency data yet.</p>
+									<button type="button" onclick={addEfficiencyPoint} class="rounded bg-[var(--color-accent)] px-3 py-1.5 text-xs font-medium text-[var(--color-accent-text)]">Add Data</button>
+								</div>
+							{:else}
+								<div class="mx-auto max-w-lg">
+									<div class="sticky top-0 z-10 grid grid-cols-[2rem_1fr_1fr_2rem] gap-2 bg-[var(--color-surface)] pb-1 text-[0.625rem] font-semibold uppercase tracking-wider text-[var(--color-text-subtle)]">
+										<span>#</span><span>Flow (GPM)</span><span>Efficiency (%)</span><span></span>
+									</div>
+									{#each efficiencyPoints as point, i}
+										<div class="group grid grid-cols-[2rem_1fr_1fr_2rem] items-center gap-2 py-0.5">
+											<span class="text-[0.625rem] text-[var(--color-text-subtle)]">{i + 1}</span>
+											<input type="number" value={point.flow} oninput={(e) => { efficiencyPoints[i] = { ...efficiencyPoints[i], flow: parseFloat(e.currentTarget.value) || 0 }; efficiencyPoints = efficiencyPoints; markDirty(); }} class="form-input mono-value text-xs" min="0" step="any" />
+											<input type="number" value={point.efficiency * 100} oninput={(e) => { efficiencyPoints[i] = { ...efficiencyPoints[i], efficiency: (parseFloat(e.currentTarget.value) || 0) / 100 }; efficiencyPoints = efficiencyPoints; markDirty(); }} class="form-input mono-value text-xs" min="0" max="100" step="any" />
+											<button type="button" onclick={() => removeEfficiencyPoint(i)} class="flex h-full items-center justify-center rounded text-[var(--color-text-subtle)] opacity-0 transition-opacity group-hover:opacity-100 hover:text-[var(--color-error)]" title="Remove">
+												<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+											</button>
+										</div>
+									{/each}
+									<button type="button" onclick={addEfficiencyPoint} class="mt-2 flex items-center gap-1 rounded px-2 py-1 text-xs text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent-muted)]">
+										<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" /></svg>
+										Add Row
+									</button>
+								</div>
+							{/if}
+
+						{:else if activeDataTab === 'npsh'}
+							{#if npshPoints.length === 0}
+								<div class="flex flex-col items-center gap-3 py-12 text-center">
+									<p class="text-sm text-[var(--color-text-subtle)]">No NPSH data yet.</p>
+									<button type="button" onclick={addNpshPoint} class="rounded bg-[var(--color-accent)] px-3 py-1.5 text-xs font-medium text-[var(--color-accent-text)]">Add Data</button>
+								</div>
+							{:else}
+								<div class="mx-auto max-w-lg">
+									<div class="sticky top-0 z-10 grid grid-cols-[2rem_1fr_1fr_2rem] gap-2 bg-[var(--color-surface)] pb-1 text-[0.625rem] font-semibold uppercase tracking-wider text-[var(--color-text-subtle)]">
+										<span>#</span><span>Flow (GPM)</span><span>NPSH (ft)</span><span></span>
+									</div>
+									{#each npshPoints as point, i}
+										<div class="group grid grid-cols-[2rem_1fr_1fr_2rem] items-center gap-2 py-0.5">
+											<span class="text-[0.625rem] text-[var(--color-text-subtle)]">{i + 1}</span>
+											<input type="number" value={point.flow} oninput={(e) => { npshPoints[i] = { ...npshPoints[i], flow: parseFloat(e.currentTarget.value) || 0 }; npshPoints = npshPoints; markDirty(); }} class="form-input mono-value text-xs" min="0" step="any" />
+											<input type="number" value={point.npsh_required} oninput={(e) => { npshPoints[i] = { ...npshPoints[i], npsh_required: parseFloat(e.currentTarget.value) || 0 }; npshPoints = npshPoints; markDirty(); }} class="form-input mono-value text-xs" min="0" step="any" />
+											<button type="button" onclick={() => removeNpshPoint(i)} class="flex h-full items-center justify-center rounded text-[var(--color-text-subtle)] opacity-0 transition-opacity group-hover:opacity-100 hover:text-[var(--color-error)]" title="Remove">
+												<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+											</button>
+										</div>
+									{/each}
+									<button type="button" onclick={addNpshPoint} class="mt-2 flex items-center gap-1 rounded px-2 py-1 text-xs text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent-muted)]">
+										<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" /></svg>
+										Add Row
+									</button>
+								</div>
+							{/if}
+
+						{:else if activeDataTab === 'power'}
+							{#if powerPoints.length === 0}
+								<div class="flex flex-col items-center gap-3 py-12 text-center">
+									<p class="text-sm text-[var(--color-text-subtle)]">No power data yet.</p>
+									<button type="button" onclick={addPowerPoint} class="rounded bg-[var(--color-accent)] px-3 py-1.5 text-xs font-medium text-[var(--color-accent-text)]">Add Data</button>
+								</div>
+							{:else}
+								<div class="mx-auto max-w-lg">
+									<div class="sticky top-0 z-10 grid grid-cols-[2rem_1fr_1fr_2rem] gap-2 bg-[var(--color-surface)] pb-1 text-[0.625rem] font-semibold uppercase tracking-wider text-[var(--color-text-subtle)]">
+										<span>#</span><span>Flow (GPM)</span><span>Power (HP)</span><span></span>
+									</div>
+									{#each powerPoints as point, i}
+										<div class="group grid grid-cols-[2rem_1fr_1fr_2rem] items-center gap-2 py-0.5">
+											<span class="text-[0.625rem] text-[var(--color-text-subtle)]">{i + 1}</span>
+											<input type="number" value={point.flow} oninput={(e) => { powerPoints[i] = { ...powerPoints[i], flow: parseFloat(e.currentTarget.value) || 0 }; powerPoints = powerPoints; markDirty(); }} class="form-input mono-value text-xs" min="0" step="any" />
+											<input type="number" value={point.power} oninput={(e) => { powerPoints[i] = { ...powerPoints[i], power: parseFloat(e.currentTarget.value) || 0 }; powerPoints = powerPoints; markDirty(); }} class="form-input mono-value text-xs" min="0" step="any" />
+											<button type="button" onclick={() => removePowerPoint(i)} class="flex h-full items-center justify-center rounded text-[var(--color-text-subtle)] opacity-0 transition-opacity group-hover:opacity-100 hover:text-[var(--color-error)]" title="Remove">
+												<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" /></svg>
+											</button>
+										</div>
+									{/each}
+									<button type="button" onclick={addPowerPoint} class="mt-2 flex items-center gap-1 rounded px-2 py-1 text-xs text-[var(--color-accent)] transition-colors hover:bg-[var(--color-accent-muted)]">
+										<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2"><path stroke-linecap="round" stroke-linejoin="round" d="M12 4v16m8-8H4" /></svg>
+										Add Row
+									</button>
+								</div>
+							{/if}
+						{/if}
+					</div>
+				</div>
+
+			{:else if activeTab === 'preview'}
+				<!-- Curve Preview Tab -->
+				<div class="flex h-full flex-col p-4">
+					<!-- Toggle Buttons -->
+					<div class="mb-4 flex flex-wrap gap-2">
+						<button
+							type="button"
+							onclick={() => showHeadCurve = !showHeadCurve}
+							class="rounded px-3 py-1.5 text-xs font-medium transition-colors
+								{showHeadCurve ? 'bg-blue-500 text-white' : 'bg-[var(--color-surface-elevated)] text-[var(--color-text-muted)]'}
+								{headPoints.length === 0 ? 'opacity-40 cursor-not-allowed' : ''}"
+							disabled={headPoints.length === 0}
+						>Head</button>
+						<button
+							type="button"
+							onclick={() => showEffCurve = !showEffCurve}
+							class="rounded px-3 py-1.5 text-xs font-medium transition-colors
+								{showEffCurve ? 'bg-green-500 text-white' : 'bg-[var(--color-surface-elevated)] text-[var(--color-text-muted)]'}
+								{efficiencyPoints.length === 0 ? 'opacity-40 cursor-not-allowed' : ''}"
+							disabled={efficiencyPoints.length === 0}
+						>Efficiency</button>
+						<button
+							type="button"
+							onclick={() => showNpshCurve = !showNpshCurve}
+							class="rounded px-3 py-1.5 text-xs font-medium transition-colors
+								{showNpshCurve ? 'bg-orange-500 text-white' : 'bg-[var(--color-surface-elevated)] text-[var(--color-text-muted)]'}
+								{npshPoints.length === 0 ? 'opacity-40 cursor-not-allowed' : ''}"
+							disabled={npshPoints.length === 0}
+						>NPSH</button>
+						<button
+							type="button"
+							onclick={() => showPowerCurve = !showPowerCurve}
+							class="rounded px-3 py-1.5 text-xs font-medium transition-colors
+								{showPowerCurve ? 'bg-purple-500 text-white' : 'bg-[var(--color-surface-elevated)] text-[var(--color-text-muted)]'}
+								{powerPoints.length === 0 ? 'opacity-40 cursor-not-allowed' : ''}"
+							disabled={powerPoints.length === 0}
+						>Power</button>
+					</div>
+
+					<!-- Chart Area -->
+					<div class="flex flex-1 items-center justify-center rounded border border-[var(--color-border)] bg-[var(--color-surface-elevated)] p-4">
+						{#if headPoints.length === 0 && efficiencyPoints.length === 0 && npshPoints.length === 0 && powerPoints.length === 0}
+							<p class="text-sm text-[var(--color-text-subtle)]">Add curve data to see a preview.</p>
+						{:else}
+							<!-- SVG chart -->
+							<svg viewBox="0 0 500 300" class="h-full w-full max-h-[400px]" preserveAspectRatio="xMidYMid meet">
+								<!-- Grid -->
+								{#each [0, 1, 2, 3, 4] as i}
+									<line x1="50" y1={50 + i * 50} x2="470" y2={50 + i * 50} stroke="var(--color-border)" stroke-width="0.5" />
+								{/each}
+								<!-- Axes -->
+								<line x1="50" y1="50" x2="50" y2="260" stroke="var(--color-text-subtle)" stroke-width="1" />
+								<line x1="50" y1="260" x2="470" y2="260" stroke="var(--color-text-subtle)" stroke-width="1" />
+								<text x="260" y="290" text-anchor="middle" fill="var(--color-text-muted)" font-size="10">Flow (GPM)</text>
+								<text x="15" y="155" text-anchor="middle" fill="var(--color-text-muted)" font-size="10" transform="rotate(-90, 15, 155)">Value</text>
+
+								<!-- Head curve (blue) -->
+								{#if showHeadCurve && headBestFit && headBestFit.length > 0}
+									{@const maxFlow = Math.max(...headPoints.map(p => p.flow), 1)}
+									{@const maxHead = Math.max(...headPoints.map(p => p.head), 1)}
+									<polyline
+										points={headBestFit.map(p => `${50 + (p.flow / maxFlow) * 420},${260 - (p.head / maxHead) * 200}`).join(' ')}
+										fill="none"
+										stroke="#3b82f6"
+										stroke-width="2"
+									/>
+									{#each headPoints as p}
+										<circle cx={50 + (p.flow / maxFlow) * 420} cy={260 - (p.head / maxHead) * 200} r="3" fill="#3b82f6" />
+									{/each}
+								{:else if showHeadCurve && headPoints.length >= 2}
+									{@const maxFlow = Math.max(...headPoints.map(p => p.flow), 1)}
+									{@const maxHead = Math.max(...headPoints.map(p => p.head), 1)}
+									{@const sorted = [...headPoints].sort((a, b) => a.flow - b.flow)}
+									<polyline
+										points={sorted.map(p => `${50 + (p.flow / maxFlow) * 420},${260 - (p.head / maxHead) * 200}`).join(' ')}
+										fill="none"
+										stroke="#3b82f6"
+										stroke-width="2"
+									/>
+									{#each sorted as p}
+										<circle cx={50 + (p.flow / maxFlow) * 420} cy={260 - (p.head / maxHead) * 200} r="3" fill="#3b82f6" />
+									{/each}
+								{/if}
+
+								<!-- Efficiency curve (green) -->
+								{#if showEffCurve && effBestFit && effBestFit.length > 0}
+									{@const maxFlow = Math.max(...efficiencyPoints.map(p => p.flow), 1)}
+									<polyline
+										points={effBestFit.map(p => `${50 + (p.flow / maxFlow) * 420},${260 - p.efficiency * 200}`).join(' ')}
+										fill="none"
+										stroke="#22c55e"
+										stroke-width="2"
+										stroke-dasharray="6 3"
+									/>
+									{#each efficiencyPoints as p}
+										<circle cx={50 + (p.flow / maxFlow) * 420} cy={260 - p.efficiency * 200} r="3" fill="#22c55e" />
+									{/each}
+								{/if}
+
+								<!-- NPSH curve (orange) -->
+								{#if showNpshCurve && npshPoints.length >= 2}
+									{@const maxFlow = Math.max(...npshPoints.map(p => p.flow), 1)}
+									{@const maxNpsh = Math.max(...npshPoints.map(p => p.npsh_required), 1)}
+									{@const sorted = [...npshPoints].sort((a, b) => a.flow - b.flow)}
+									<polyline
+										points={sorted.map(p => `${50 + (p.flow / maxFlow) * 420},${260 - (p.npsh_required / maxNpsh) * 200}`).join(' ')}
+										fill="none"
+										stroke="#f97316"
+										stroke-width="2"
+										stroke-dasharray="3 3"
+									/>
+									{#each sorted as p}
+										<circle cx={50 + (p.flow / maxFlow) * 420} cy={260 - (p.npsh_required / maxNpsh) * 200} r="3" fill="#f97316" />
+									{/each}
+								{/if}
+
+								<!-- Power curve (purple) -->
+								{#if showPowerCurve && powerPoints.length >= 2}
+									{@const maxFlow = Math.max(...powerPoints.map(p => p.flow), 1)}
+									{@const maxPower = Math.max(...powerPoints.map(p => p.power), 1)}
+									{@const sorted = [...powerPoints].sort((a, b) => a.flow - b.flow)}
+									<polyline
+										points={sorted.map(p => `${50 + (p.flow / maxFlow) * 420},${260 - (p.power / maxPower) * 200}`).join(' ')}
+										fill="none"
+										stroke="#a855f7"
+										stroke-width="2"
+										stroke-dasharray="8 4"
+									/>
+									{#each sorted as p}
+										<circle cx={50 + (p.flow / maxFlow) * 420} cy={260 - (p.power / maxPower) * 200} r="3" fill="#a855f7" />
+									{/each}
+								{/if}
+							</svg>
+						{/if}
+					</div>
+
+					<!-- Legend -->
+					<div class="mt-3 flex flex-wrap gap-4 text-xs text-[var(--color-text-muted)]">
+						{#if headPoints.length > 0}
+							<span class="flex items-center gap-1.5"><span class="h-0.5 w-4 bg-blue-500"></span> Head (ft)</span>
+						{/if}
+						{#if efficiencyPoints.length > 0}
+							<span class="flex items-center gap-1.5"><span class="h-0.5 w-4 border-t-2 border-dashed border-green-500"></span> Efficiency (%)</span>
+						{/if}
+						{#if npshPoints.length > 0}
+							<span class="flex items-center gap-1.5"><span class="h-0.5 w-4 border-t-2 border-dotted border-orange-500"></span> NPSH (ft)</span>
+						{/if}
+						{#if powerPoints.length > 0}
+							<span class="flex items-center gap-1.5"><span class="h-0.5 w-4 border-t-2 border-dashed border-purple-500"></span> Power (HP)</span>
+						{/if}
+					</div>
+				</div>
+			{/if}
+		</div>
+	</div>
+{/if}

--- a/apps/web/src/lib/components/workspace/PumpCurveList.svelte
+++ b/apps/web/src/lib/components/workspace/PumpCurveList.svelte
@@ -1,31 +1,21 @@
 <script lang="ts">
-	import { pumpLibrary, projectStore } from '$lib/stores';
+	import { pumpLibrary, projectStore, workspaceStore, editingPumpCurveId } from '$lib/stores';
 	import { createDefaultPumpCurve } from '$lib/models';
-	import type { PumpCurve } from '$lib/models';
-	import PumpCurveEditor from './PumpCurveEditor.svelte';
 
-	let editingCurveId = $state<string | null>(null);
 	let pendingDeleteId = $state<string | null>(null);
 
 	function handleAdd() {
 		const id = `curve_${Date.now()}_${Math.random().toString(36).substring(2, 7)}`;
 		const curve = createDefaultPumpCurve(id);
 		projectStore.addPumpCurve(curve);
-		editingCurveId = id;
+		workspaceStore.setEditingPumpCurve(id);
 	}
 
-	function handleEdit(curveId: string) {
-		editingCurveId = editingCurveId === curveId ? null : curveId;
+	function handleSelect(curveId: string) {
+		workspaceStore.setEditingPumpCurve(
+			$editingPumpCurveId === curveId ? null : curveId
+		);
 		pendingDeleteId = null;
-	}
-
-	function handleSave(updated: PumpCurve) {
-		projectStore.updatePumpCurve(updated.id, updated);
-		editingCurveId = null;
-	}
-
-	function handleCancelEdit() {
-		editingCurveId = null;
 	}
 
 	function handleDelete(e: Event, curveId: string) {
@@ -37,8 +27,8 @@
 		e.stopPropagation();
 		if (pendingDeleteId) {
 			projectStore.removePumpCurve(pendingDeleteId);
-			if (editingCurveId === pendingDeleteId) {
-				editingCurveId = null;
+			if ($editingPumpCurveId === pendingDeleteId) {
+				workspaceStore.setEditingPumpCurve(null);
 			}
 			pendingDeleteId = null;
 		}
@@ -57,70 +47,61 @@
 		</p>
 	{:else}
 		{#each $pumpLibrary as curve}
-			<div class="flex flex-col">
-				<!-- Curve Row -->
-				<div
-					onclick={() => handleEdit(curve.id)}
-					onkeydown={(e) => e.key === 'Enter' && handleEdit(curve.id)}
-					role="button"
-					tabindex="0"
-					class="group flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-left text-xs transition-colors
-						{editingCurveId === curve.id
-						? 'bg-[var(--color-tree-selected)] text-[var(--color-text)]'
-						: 'text-[var(--color-text-muted)] hover:bg-[var(--color-tree-hover)] hover:text-[var(--color-text)]'}"
-				>
-					<!-- Icon -->
-					<svg class="h-3.5 w-3.5 flex-shrink-0 text-[var(--color-text-subtle)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
-						<path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941" />
-					</svg>
+			<!-- Curve Row -->
+			<div
+				onclick={() => handleSelect(curve.id)}
+				onkeydown={(e) => e.key === 'Enter' && handleSelect(curve.id)}
+				role="button"
+				tabindex="0"
+				class="group flex w-full cursor-pointer items-center gap-2 rounded px-2 py-1.5 text-left text-xs transition-colors
+					{$editingPumpCurveId === curve.id
+					? 'bg-[var(--color-tree-selected)] text-[var(--color-text)]'
+					: 'text-[var(--color-text-muted)] hover:bg-[var(--color-tree-hover)] hover:text-[var(--color-text)]'}"
+			>
+				<!-- Icon -->
+				<svg class="h-3.5 w-3.5 flex-shrink-0 text-[var(--color-text-subtle)]" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="1.5">
+					<path stroke-linecap="round" stroke-linejoin="round" d="M2.25 18L9 11.25l4.306 4.307a11.95 11.95 0 015.814-5.519l2.74-1.22m0 0l-5.94-2.28m5.94 2.28l-2.28 5.941" />
+				</svg>
 
-					<!-- Name + Details -->
-					<div class="min-w-0 flex-1">
-						<span class="block truncate">{curve.name}</span>
-						<span class="block text-[0.625rem] text-[var(--color-text-subtle)]">
-							{curve.points.length} pts{curve.manufacturer ? ` - ${curve.manufacturer}` : ''}
-						</span>
-					</div>
+				<!-- Name + Details -->
+				<div class="min-w-0 flex-1">
+					<span class="block truncate">{curve.name}</span>
+					<span class="block text-[0.625rem] text-[var(--color-text-subtle)]">
+						{curve.points.length} pts{curve.manufacturer ? ` - ${curve.manufacturer}` : ''}
+					</span>
+				</div>
 
-					<!-- Delete -->
-					{#if pendingDeleteId === curve.id}
-						<div class="flex flex-shrink-0 items-center gap-1">
-							<button
-								type="button"
-								onclick={confirmDelete}
-								class="flex h-4 items-center rounded bg-[var(--color-error)] px-1.5 text-[0.5625rem] font-semibold text-white"
-								title="Confirm delete"
-							>Del</button>
-							<button
-								type="button"
-								onclick={cancelDelete}
-								class="flex h-4 items-center rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-1 text-[0.5625rem] text-[var(--color-text-muted)]"
-								title="Cancel"
-							>
-								<svg class="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
-									<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
-								</svg>
-							</button>
-						</div>
-					{:else}
+				<!-- Delete -->
+				{#if pendingDeleteId === curve.id}
+					<div class="flex flex-shrink-0 items-center gap-1">
 						<button
 							type="button"
-							onclick={(e) => handleDelete(e, curve.id)}
-							class="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded opacity-0 transition-opacity group-hover:opacity-100 hover:text-[var(--color-error)]"
-							title="Delete pump curve"
+							onclick={confirmDelete}
+							class="flex h-4 items-center rounded bg-[var(--color-error)] px-1.5 text-[0.5625rem] font-semibold text-white"
+							title="Confirm delete"
+						>Del</button>
+						<button
+							type="button"
+							onclick={cancelDelete}
+							class="flex h-4 items-center rounded border border-[var(--color-border)] bg-[var(--color-surface)] px-1 text-[0.5625rem] text-[var(--color-text-muted)]"
+							title="Cancel"
 						>
-							<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+							<svg class="h-2.5 w-2.5" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
 								<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
 							</svg>
 						</button>
-					{/if}
-				</div>
-
-				<!-- Inline Editor -->
-				{#if editingCurveId === curve.id}
-					<div class="mt-1 px-1">
-						<PumpCurveEditor {curve} onSave={handleSave} onCancel={handleCancelEdit} />
 					</div>
+				{:else}
+					<button
+						type="button"
+						onclick={(e) => handleDelete(e, curve.id)}
+						class="flex h-4 w-4 flex-shrink-0 items-center justify-center rounded opacity-0 transition-opacity group-hover:opacity-100 hover:text-[var(--color-error)]"
+						title="Delete pump curve"
+					>
+						<svg class="h-3 w-3" fill="none" stroke="currentColor" viewBox="0 0 24 24" stroke-width="2">
+							<path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
+						</svg>
+					</button>
 				{/if}
 			</div>
 		{/each}

--- a/apps/web/src/lib/components/workspace/index.ts
+++ b/apps/web/src/lib/components/workspace/index.ts
@@ -12,3 +12,4 @@ export { default as MetricsStrip } from './MetricsStrip.svelte';
 export { default as ProjectSummary } from './ProjectSummary.svelte';
 export { default as BottomSheet } from './BottomSheet.svelte';
 export { default as MobileNavBar } from './MobileNavBar.svelte';
+export { default as PumpCurveEditorPanel } from './PumpCurveEditorPanel.svelte';

--- a/apps/web/src/lib/models/index.ts
+++ b/apps/web/src/lib/models/index.ts
@@ -50,6 +50,7 @@ export type {
 	FlowHeadPoint,
 	FlowEfficiencyPoint,
 	NPSHRPoint,
+	FlowPowerPoint,
 	PumpCurve,
 	BestEfficiencyPoint,
 	QuadraticCoefficients

--- a/apps/web/src/lib/models/pump.ts
+++ b/apps/web/src/lib/models/pump.ts
@@ -27,6 +27,14 @@ export interface NPSHRPoint {
 	npsh_required: number;
 }
 
+/** A single point on a power curve (flow vs brake horsepower). */
+export interface FlowPowerPoint {
+	/** Flow rate in project units. */
+	flow: number;
+	/** Power (BHP) in project units. */
+	power: number;
+}
+
 /** Pump performance curve definition. */
 export interface PumpCurve {
 	/** Unique identifier for this pump curve. */
@@ -41,12 +49,20 @@ export interface PumpCurve {
 	rated_speed?: number;
 	/** Impeller diameter in project units. */
 	impeller_diameter?: number;
+	/** Number of pump stages. */
+	stages?: number;
+	/** Inlet/outlet size description (e.g. "2\" / 2\""). */
+	inlet_outlet?: string;
+	/** Free-form notes. */
+	notes?: string;
 	/** Pump curve points (minimum 2). */
 	points: FlowHeadPoint[];
 	/** Optional efficiency curve. */
 	efficiency_curve?: FlowEfficiencyPoint[];
 	/** Optional NPSH required curve. */
 	npshr_curve?: NPSHRPoint[];
+	/** Optional power curve. */
+	power_curve?: FlowPowerPoint[];
 }
 
 /** Validate pump curve. Returns error message or null if valid. */

--- a/apps/web/src/lib/stores/index.ts
+++ b/apps/web/src/lib/stores/index.ts
@@ -43,6 +43,7 @@ export {
 	activeInspectorTab,
 	isFocusMode,
 	canvasZoom,
+	editingPumpCurveId,
 	type SidebarTab,
 	type InspectorTab,
 	type WorkspaceState

--- a/apps/web/src/lib/stores/workspace.ts
+++ b/apps/web/src/lib/stores/workspace.ts
@@ -23,6 +23,7 @@ export interface WorkspaceState {
 	focusMode: boolean;
 	canvasZoom: number;
 	lastSelectedComponentId: string | null;
+	editingPumpCurveId: string | null;
 }
 
 /** Default workspace state. */
@@ -33,7 +34,8 @@ const DEFAULT_STATE: WorkspaceState = {
 	inspectorTab: 'properties',
 	focusMode: false,
 	canvasZoom: 1,
-	lastSelectedComponentId: null
+	lastSelectedComponentId: null,
+	editingPumpCurveId: null
 };
 
 /** Storage key for workspace preferences. */
@@ -139,6 +141,11 @@ function createWorkspaceStore() {
 			update((s) => ({ ...s, lastSelectedComponentId: id }));
 		},
 
+		/** Set the pump curve being edited (opens editor in canvas area). */
+		setEditingPumpCurve(id: string | null) {
+			update((s) => ({ ...s, editingPumpCurveId: id }));
+		},
+
 		/** Reset all layout state to defaults. */
 		reset() {
 			store.set({ ...DEFAULT_STATE });
@@ -166,3 +173,6 @@ export const isFocusMode = derived(workspaceStore, ($ws) => $ws.focusMode);
 
 /** The current canvas zoom level. */
 export const canvasZoom = derived(workspaceStore, ($ws) => $ws.canvasZoom);
+
+/** The pump curve ID currently being edited (null = show schematic). */
+export const editingPumpCurveId = derived(workspaceStore, ($ws) => $ws.editingPumpCurveId);

--- a/apps/web/src/routes/p/[encoded]/+page.svelte
+++ b/apps/web/src/routes/p/[encoded]/+page.svelte
@@ -6,7 +6,8 @@
 		CommandPalette,
 		StatusBar,
 		BottomSheet,
-		MobileNavBar
+		MobileNavBar,
+		PumpCurveEditorPanel
 	} from '$lib/components/workspace';
 	import SchematicViewer from '$lib/components/schematic/SchematicViewer.svelte';
 	import PanelNavigator from '$lib/components/panel/PanelNavigator.svelte';
@@ -16,7 +17,7 @@
 	import { page } from '$app/stores';
 	import { goto } from '$app/navigation';
 	import { get } from 'svelte/store';
-	import { projectStore, components, metadata, navigationStore, workspaceStore, currentElementId } from '$lib/stores';
+	import { projectStore, components, metadata, navigationStore, workspaceStore, currentElementId, editingPumpCurveId, activeSidebarTab } from '$lib/stores';
 	import { solveNetwork, ApiError, NetworkError, TimeoutError } from '$lib/api';
 	import { encodeProject, tryDecodeProject } from '$lib/utils';
 
@@ -155,6 +156,9 @@
 
 	// Focus mode state
 	let focusModeActive = $derived($workspaceStore.focusMode);
+
+	// Show pump curve editor in canvas when a curve is selected and Library tab is active
+	let showPumpCurveEditor = $derived($editingPumpCurveId !== null && $activeSidebarTab === 'library');
 
 	// Keyboard shortcuts
 	function handleKeydown(event: KeyboardEvent) {
@@ -298,9 +302,11 @@
 		/>
 	</div>
 
-	<!-- Canvas: Schematic Viewer -->
-	<div class="workspace-canvas canvas-grid">
-		{#if isLoading}
+	<!-- Canvas: Schematic Viewer or Pump Curve Editor -->
+	<div class="workspace-canvas {showPumpCurveEditor ? '' : 'canvas-grid'}">
+		{#if showPumpCurveEditor && $editingPumpCurveId}
+			<PumpCurveEditorPanel curveId={$editingPumpCurveId} />
+		{:else if isLoading}
 			<!-- Loading state for URL-encoded projects -->
 			<div class="absolute inset-0 flex items-center justify-center">
 				<div class="flex flex-col items-center gap-3">


### PR DESCRIPTION
## Summary
- Add **PumpCurveEditorPanel** component with 3 tabs: Pump Information (form), Curve Data (4 sub-tabs: head/efficiency/NPSH/power with editable tables), and Curve Preview (SVG chart with toggle buttons)
- Update PumpCurve models (TypeScript + Python) with `stages`, `inlet_outlet`, `notes`, and `power_curve` fields
- Add `editingPumpCurveId` to workspace store; clicking a curve in the Library sidebar opens the full-width editor in the canvas area
- Replace inline sidebar editing in PumpCurveList with selection-based workflow

Closes #217

## Test plan
- [x] `svelte-check` passes with zero errors
- [x] ESLint passes with zero warnings
- [x] Build succeeds
- [x] All 17 E2E tests pass (16 pass + 1 flaky unrelated)
- [ ] Manual: Switch to Library tab, add a pump curve → editor opens in canvas
- [ ] Manual: Edit pump info, curve data, save → data persists
- [ ] Manual: Switch tabs (Info → Data → Preview) and sub-tabs (Head/Eff/NPSH/Power)
- [ ] Manual: Duplicate and delete pump curves
- [ ] Manual: Switch to Tree/Config/Results sidebar tab → schematic shown in canvas
- [ ] Manual: Switch back to Library → editor restored for selected curve

🤖 Generated with [Claude Code](https://claude.com/claude-code)