### PR TITLE
feat: inspector pane shows selected entity details from results views

### DIFF
--- a/apps/web/src/lib/components/results/ComponentTable.svelte
+++ b/apps/web/src/lib/components/results/ComponentTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { components } from '$lib/stores';
+	import { components, navigationStore, workspaceStore, currentElementId } from '$lib/stores';
 	import {
 		COMPONENT_TYPE_LABELS,
 		type SolvedState,
@@ -7,6 +7,11 @@
 		type ComponentType,
 		type ComponentResult
 	} from '$lib/models';
+
+	function handleRowClick(componentId: string) {
+		navigationStore.navigateTo(componentId);
+		workspaceStore.setInspectorOpen(true);
+	}
 
 	interface Props {
 		/** The solved state containing results. */
@@ -128,7 +133,10 @@
 		</thead>
 		<tbody class="divide-y divide-[var(--color-border)] bg-[var(--color-surface)]">
 			{#each portData as row}
-				<tr class="hover:bg-[var(--color-surface-elevated)]">
+				<tr
+					class="cursor-pointer hover:bg-[var(--color-surface-elevated)] {$currentElementId === row.componentId ? 'bg-[var(--color-accent)]/10' : ''}"
+					onclick={() => handleRowClick(row.componentId)}
+				>
 					{#if row.isFirstPort}
 						<td
 							class="whitespace-nowrap px-4 py-3 text-sm font-medium text-[var(--color-text)]"

--- a/apps/web/src/lib/components/results/ElevationProfile.svelte
+++ b/apps/web/src/lib/components/results/ElevationProfile.svelte
@@ -7,6 +7,7 @@
 	 * Translated from the React reference in docs/features/viz_elevation_profile/.
 	 */
 	import type { ElevationElement } from '$lib/utils/elevationProfile';
+	import { navigationStore, workspaceStore } from '$lib/stores';
 
 	interface Props {
 		/** Elevation profile data elements (ordered upstream → downstream). */
@@ -386,6 +387,13 @@
 	function handleLeave(): void {
 		hoveredItem = null;
 	}
+
+	function handleElementClick(el: ElevationElement): void {
+		if (el.type === 'comp') {
+			navigationStore.navigateTo(el.id);
+			workspaceStore.setInspectorOpen(true);
+		}
+	}
 </script>
 
 <div bind:this={containerElement} class="flex flex-col gap-4">
@@ -736,11 +744,15 @@
 				{@const color = getComponentColor(comp.name)}
 				{@const isHovered = hoveredItem?.type === 'comp' && hoveredItem?.data.id === comp.id}
 
-				<!-- svelte-ignore a11y_no_static_element_interactions -->
+				<!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
 				<g
 					class="cursor-pointer"
 					onmouseenter={() => handleHover('comp', data.indexOf(comp), comp, cx, yScale(comp.p1_el))}
 					onmouseleave={handleLeave}
+					onclick={() => handleElementClick(comp)}
+					onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') handleElementClick(comp); }}
+					role="button"
+					tabindex="0"
 				>
 					<!-- P1 marker -->
 					<circle
@@ -867,7 +879,7 @@
 						{@const isHovered = hoveredItem?.data.id === item.id}
 						<!-- svelte-ignore a11y_no_static_element_interactions -->
 						<tr
-							class="border-b border-[var(--color-border)] transition-colors {isHovered ? 'bg-[var(--color-accent)]/10' : 'hover:bg-[var(--color-surface-elevated)]'}"
+							class="cursor-pointer border-b border-[var(--color-border)] transition-colors {isHovered ? 'bg-[var(--color-accent)]/10' : 'hover:bg-[var(--color-surface-elevated)]'}"
 							onmouseenter={() => {
 								const cx = item.type === 'comp'
 									? xScale(components.indexOf(item))
@@ -875,6 +887,7 @@
 								handleHover(item.type, i, item, cx, yScale(item.p1_el));
 							}}
 							onmouseleave={handleLeave}
+							onclick={() => handleElementClick(item)}
 						>
 							<td class="px-3 py-1.5 text-[var(--color-text-muted)]">{item.type}</td>
 							<td class="px-3 py-1.5 font-medium" style="color: {item.type === 'comp' ? getComponentColor(item.name) : 'var(--color-text)'}">

--- a/apps/web/src/lib/components/results/PipingTable.svelte
+++ b/apps/web/src/lib/components/results/PipingTable.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { components, connections } from '$lib/stores';
+	import { components, connections, navigationStore, workspaceStore, currentElementId } from '$lib/stores';
 	import type { SolvedState } from '$lib/models';
 
 	interface Props {
@@ -11,9 +11,15 @@
 
 	interface PipingData {
 		id: string;
+		fromComponentId: string;
 		name: string;
 		type: string;
 		result: typeof results.piping_results[string] | undefined;
+	}
+
+	function handleRowClick(componentId: string) {
+		navigationStore.navigateTo(componentId);
+		workspaceStore.setInspectorOpen(true);
 	}
 
 	// Build a map of component IDs to names for display
@@ -36,6 +42,7 @@
 				const toName = componentNames[conn.to_component_id] || conn.to_component_id;
 				data.push({
 					id: conn.id,
+					fromComponentId: conn.from_component_id,
 					name: `${fromName} → ${toName}`,
 					type: 'pipe',
 					result: results.piping_results[conn.id]
@@ -72,7 +79,10 @@
 		</thead>
 		<tbody class="divide-y divide-[var(--color-border)] bg-[var(--color-surface)]">
 			{#each pipingData as piping}
-				<tr class="hover:bg-[var(--color-surface-elevated)]">
+				<tr
+					class="cursor-pointer hover:bg-[var(--color-surface-elevated)] {$currentElementId === piping.fromComponentId ? 'bg-[var(--color-accent)]/10' : ''}"
+					onclick={() => handleRowClick(piping.fromComponentId)}
+				>
 					<td class="whitespace-nowrap px-4 py-3 text-sm font-medium text-[var(--color-text)]">
 						{piping.name}
 					</td>

--- a/apps/web/src/lib/components/results/PumpResultsCard.svelte
+++ b/apps/web/src/lib/components/results/PumpResultsCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { PumpComponent, PumpCurve, PumpResult } from '$lib/models';
 	import { PUMP_STATUS_LABELS, PUMP_OPERATING_MODE_LABELS } from '$lib/models';
+	import { navigationStore, workspaceStore, currentElementId } from '$lib/stores';
 	import PumpCurveChart from './PumpCurveChart.svelte';
 
 	interface Props {
@@ -45,7 +46,13 @@
 	}
 </script>
 
-<div class="rounded-lg border border-[var(--color-border)] bg-[var(--color-surface)]">
+<div
+	class="cursor-pointer rounded-lg border bg-[var(--color-surface)] {$currentElementId === pump.id ? 'border-[var(--color-accent)]' : 'border-[var(--color-border)]'}"
+	onclick={() => { navigationStore.navigateTo(pump.id); workspaceStore.setInspectorOpen(true); }}
+	role="button"
+	tabindex="0"
+	onkeydown={(e) => { if (e.key === 'Enter' || e.key === ' ') { navigationStore.navigateTo(pump.id); workspaceStore.setInspectorOpen(true); } }}
+>
 	<!-- Header -->
 	<div class="flex items-center justify-between border-b border-[var(--color-border)] px-4 py-3">
 		<div>

--- a/docs/plans/issue-226-plan.md
+++ b/docs/plans/issue-226-plan.md
@@ -1,0 +1,38 @@
+# Issue #226: Inspector Pane Shows Selected Entity Details from Results Views
+
+## Summary
+
+When clicking items in Results views, navigate the inspector panel to that entity's configuration.
+
+## Implementation
+
+### Pattern
+
+Replicate the existing schematic click handler pattern:
+
+```typescript
+navigationStore.navigateTo(componentId);
+workspaceStore.setInspectorOpen(true);
+```
+
+### Components Modified
+
+1. **ComponentTable.svelte** - Click row navigates to component, highlights selected
+2. **PipingTable.svelte** - Click row navigates to source component, highlights selected
+3. **PumpResultsCard.svelte** - Click card navigates to pump, highlights with accent border
+4. **ElevationProfile.svelte** - Click SVG markers or data table rows navigates to component
+
+### Design Decisions
+
+- Navigate to source component for piping rows (the component whose downstream piping is shown)
+- Only component-type elements are clickable in elevation profile (connections don't map to a single component)
+- Selected row/card highlighted with accent color
+- Inspector auto-opens if closed when a results item is clicked
+- Both results viewer (left overlay) and inspector (right sidebar) visible simultaneously
+
+## Files Changed
+
+- `apps/web/src/lib/components/results/ComponentTable.svelte`
+- `apps/web/src/lib/components/results/PipingTable.svelte`
+- `apps/web/src/lib/components/results/PumpResultsCard.svelte`
+- `apps/web/src/lib/components/results/ElevationProfile.svelte`


### PR DESCRIPTION
## Summary

Closes #226

When clicking items in Results views, the inspector panel navigates to that entity's configuration:

- **ComponentTable** - Click row navigates to component, highlights selected row
- **PipingTable** - Click row navigates to source component, highlights selected row
- **PumpResultsCard** - Click card navigates to pump, highlights with accent border
- **ElevationProfile** - Click SVG markers or data table rows navigates to component

### Design decisions
- Navigate to source component for piping rows (the component whose downstream piping is shown)
- Only component-type elements are clickable in elevation profile (connections don't map to a single component)
- Selected row/card highlighted with accent color
- Inspector auto-opens if closed when a results item is clicked
- Both results viewer (left overlay) and inspector (right sidebar) visible simultaneously

## Test plan
- [ ] Click a row in Components table — inspector shows that component
- [ ] Click a row in Piping table — inspector shows the source component
- [ ] Click a Pump card — inspector shows that pump's config
- [ ] Click a marker in Elevation Profile SVG — inspector shows that component
- [ ] Click a row in Elevation Profile data table — inspector shows that component
- [ ] Verify selected items are highlighted with accent color
- [ ] Verify inspector auto-opens if it was closed

🤖 Generated with [Claude Code](https://claude.com/claude-code)